### PR TITLE
Allow batch scoring of dataset from AI Catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ in the `context["params"]` variable, e.g. getting a training data you would use 
     Prerequisites:
     - [S3 credentials added to DataRobot via Python API client](https://datarobot-public-api-client.readthedocs-hosted.com/en/v2.27.1/reference/admin/credentials.html#s3-credentials).
       You need the `creds.credential_id` for the `credential_id` parameter in the config.
+    - OR the ID of a Dataset in the AI Catalog
 
     Parameters:
   
@@ -147,6 +148,18 @@ in the `context["params"]` variable, e.g. getting a training data you would use 
             }
         }
 
+    Config params for scoring a Dataset in the AI Catalog:
+
+        "score_settings": {
+            "intake_settings": {
+                "type": "dataset",
+                "datasetId": "<datasetid>",
+            },
+            "output_settings": {
+            ...
+            }
+        }
+    
     For more [batch prediction settings](https://datarobot-public-api-client.readthedocs-hosted.com/en/v2.27.1/autodoc/api_reference.html#batch-predictions) see the DataRobot docs.
 
 ### [Sensors](https://github.com/datarobot/airflow-provider-datarobot/blob/main/datarobot_provider/sensors/datarobot.py)

--- a/datarobot_provider/operators/datarobot.py
+++ b/datarobot_provider/operators/datarobot.py
@@ -265,13 +265,7 @@ class ScorePredictionsOperator(BaseOperator):
         if intake_type == "dataset":
             dataset_id = intake_settings.get("datasetId")
             if not dataset_id:
-                raise ValueError(
-                    """
-                    If intake data type is `dataset`, then a `datasetId` must be supplied.
-
-                    No `datasetId` found in intake_settings.
-                    """
-                )
+                raise ValueError("Invalid or missing `datasetId` value for the `dataset` intake type.")
             dataset = dr.Dataset.get(dataset_id)
             intake_settings["dataset"] = dataset
 

--- a/datarobot_provider/operators/datarobot.py
+++ b/datarobot_provider/operators/datarobot.py
@@ -259,8 +259,9 @@ class ScorePredictionsOperator(BaseOperator):
             f"with settings: {score_settings}"
         )
 
-        # The BatchPredictionJob API expects an instance of a dataset, not just
-        # a datasetId. We must fetch the dataset corresponding to the given ID
+        # The BatchPredictionJob method of the Python SDK expects an instance of
+        # a dataset, not just a datasetId. We must fetch the dataset
+        # corresponding to the given ID
         if intake_type == "dataset":
             dataset_id = intake_settings.get("datasetId")
             if not dataset_id:

--- a/datarobot_provider/operators/datarobot.py
+++ b/datarobot_provider/operators/datarobot.py
@@ -250,8 +250,8 @@ class ScorePredictionsOperator(BaseOperator):
         DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
 
         score_settings = context["params"]["score_settings"]
-        intake_settings = score_settings["intake_settings"]
-        intake_type = intake_settings["type"]
+        intake_settings = score_settings.get("intake_settings", dict())
+        intake_type = intake_settings.get("type")
 
         # Score data
         self.log.info(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -25,6 +25,7 @@ def mock_datarobot_client(mocker, dr_conn_details):
 @pytest.fixture(scope="function", autouse=True)
 def mock_airflow_connection(mocker, dr_conn_details):
     conn = Connection(
+        conn_type="DataRobot",
         extra=json.dumps(
             {
                 "extra__http__endpoint": dr_conn_details["endpoint"],


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Modifies ScorePredictionsOperator to allow passing in a `datasetId`. The dataset can then be fetched via the Python API and passed to dr.BatchPredictionJob to run the scoring.


## Rationale
The `batchPredictions` REST endpoint accepts a `datasetId` when the type is `dataset`: https://docs.datarobot.com/en/docs/api/reference/batch-prediction-api/job-definitions.html
```javascript
{
...,
"intakeSettings": {
        "type": "dataset",
        "datasetId": "<dataset_ud>"
    },
...
}
```

However, the Python API (which the `ScorePredictionsOperator` uses) requires the actual dataset, and not just the ID: https://docs.datarobot.com/en/docs/api/reference/batch-prediction-api/pred-examples.html#ai-catalog-to-csv-file-scoring
```python
dataset = dr.Dataset.get(dataset_id)

job = dr.BatchPredictionJob.score(
    ...,
    intake_settings={
        'type': 'dataset',
        'dataset_id': dataset,
    },
    ...
)
```

Currently, datasets from the AI Catalog can't be scored, because we can't just provide a `datasetId`. This PR brings the Operator more in line with the REST API parameters and allows the user to score data from the AI Catalog by providing that `datasetId` in the `intake_settings`.