### PR TITLE
Allow batch scoring of dataset from AI Catalog.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ in the `context["params"]` variable, e.g. getting a training data you would use 
     Prerequisites:
     - [S3 credentials added to DataRobot via Python API client](https://datarobot-public-api-client.readthedocs-hosted.com/en/v2.27.1/reference/admin/credentials.html#s3-credentials).
       You need the `creds.credential_id` for the `credential_id` parameter in the config.
+    - OR a Dataset ID in the AI Catalog
 
     Parameters:
   
@@ -147,6 +148,18 @@ in the `context["params"]` variable, e.g. getting a training data you would use 
             }
         }
 
+    Config params for scoring a Dataset in the AI Catalog:
+
+        "score_settings": {
+            "intake_settings": {
+                "type": "dataset",
+                "dataset_id": "<datasetId>",
+            },
+            "output_settings": {
+                ...
+            }
+        }
+    
     For more [batch prediction settings](https://datarobot-public-api-client.readthedocs-hosted.com/en/v2.27.1/autodoc/api_reference.html#batch-predictions) see the DataRobot docs.
 
 ### [Sensors](https://github.com/datarobot/airflow-provider-datarobot/blob/main/datarobot_provider/sensors/datarobot.py)

--- a/datarobot_provider/example_dags/datarobot_score_dag.py
+++ b/datarobot_provider/example_dags/datarobot_score_dag.py
@@ -1,0 +1,55 @@
+# Copyright 2022 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+"""
+Config example for this dag:
+{
+    "deployment_id": "62cc0a6383d7a13d34f83344",
+    "score_settings": {
+        "intake_settings": {
+            "type": "dataset",
+            "dataset_id": "623d8ae79b186124a926c3cd"
+        },
+        "output_settings": {
+            "type": "localFile",
+            "path": "include/Diabetes_predictions.csv"
+        }
+    }
+}
+"""
+from datetime import datetime
+
+from airflow.decorators import dag
+
+from datarobot_provider.operators.datarobot import ScorePredictionsOperator
+from datarobot_provider.sensors.datarobot import ScoringCompleteSensor
+
+
+@dag(
+    schedule_interval=None,
+    start_date=datetime(2022, 1, 1),
+    tags=['example'],
+)
+def datarobot_score(deployment_id=None):
+
+    if not deployment_id:
+        raise ValueError("Invalid or missing `deployment_id` value")
+
+    score_predictions_op = ScorePredictionsOperator(
+        task_id="score_predictions",
+        deployment_id=deployment_id,
+    )
+
+    scoring_complete_sensor = ScoringCompleteSensor(
+        task_id="check_scoring_complete",
+        job_id=score_predictions_op.output,
+    )
+
+    score_predictions_op >> scoring_complete_sensor
+
+
+datarobot_pipeline_dag = datarobot_score()

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -25,6 +25,7 @@ def mock_datarobot_client(mocker, dr_conn_details):
 @pytest.fixture(scope="function", autouse=True)
 def mock_airflow_connection(mocker, dr_conn_details):
     conn = Connection(
+        conn_type="DataRobot",
         extra=json.dumps(
             {
                 "extra__http__endpoint": dr_conn_details["endpoint"],

--- a/tests/unit/dags/test_datarobot_score_dag.py
+++ b/tests/unit/dags/test_datarobot_score_dag.py
@@ -1,0 +1,42 @@
+# Copyright 2022 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+import pytest
+from airflow.models import DagBag
+
+from datarobot_provider.example_dags.datarobot_score_dag import datarobot_score
+
+
+@pytest.fixture()
+def dagbag(provider_dir):
+    return DagBag(dag_folder=f"{str(provider_dir)}/example_dags", include_examples=False)
+
+
+def test_dag_loaded(dagbag):
+    dag = dagbag.get_dag(dag_id="datarobot_score")
+    assert dagbag.import_errors == {}
+    assert dag is not None
+    assert len(dag.tasks) == 2
+
+
+def assert_dag_dict_equal(source, dag):
+    assert dag.task_dict.keys() == source.keys()
+    for task_id, downstream_list in source.items():
+        assert dag.has_task(task_id)
+        task = dag.get_task(task_id)
+        assert task.downstream_task_ids == set(downstream_list)
+
+
+def test_dag_structure():
+    dag = datarobot_score()
+    assert_dag_dict_equal(
+        {
+            "score_predictions": ["check_scoring_complete"],
+            "check_scoring_complete": [],
+        },
+        dag,
+    )


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Adding support for AI catalog dataset to be used in batch scoring. Also, added a new example dag `datarobot_score` which scores the dataset against an existing deployment.

## Rationale
