### PR TITLE
Add operators to get target drift and feature drift.

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,35 @@ in the `context["params"]` variable, e.g. getting a training data you would use 
     
     For more [batch prediction settings](https://datarobot-public-api-client.readthedocs-hosted.com/en/v2.27.1/autodoc/api_reference.html#batch-predictions) see the DataRobot docs.
 
+- `GetTargetDriftOperator` - Gets the target drift from a deployment. Returns a JSON blob of the target drift data.
+
+    Parameters:
+
+        deployment_id: str - DataRobot deployment ID
+
+    No config params are required. [Optional params](https://datarobot-public-api-client.readthedocs-hosted.com/en/latest-release/autodoc/api_reference.html#datarobot.models.Deployment.get_target_drift) may be passed in the config as follows:
+
+        "target_drift": {
+            ...
+        }
+
+- `GetFeatureDriftOperator` - Gets the feature drift from a deployment. Returns a JSON blob of the feature drift data.
+
+    Parameters:
+
+        deployment_id: str - DataRobot deployment ID
+
+    Required config params:
+
+        None
+
+    No config params are required. [Optional params](https://datarobot-public-api-client.readthedocs-hosted.com/en/latest-release/autodoc/api_reference.html#datarobot.models.Deployment.get_feature_drift) may be passed in the config as follows:
+
+        "feature_drift": {
+            ...
+        }
+
+
 ### [Sensors](https://github.com/datarobot/airflow-provider-datarobot/blob/main/datarobot_provider/sensors/datarobot.py)
 
 - `AutopilotCompleteSensor` - checks whether the Autopilot has completed

--- a/tests/unit/dags/test_datarobot_pipeline_dag.py
+++ b/tests/unit/dags/test_datarobot_pipeline_dag.py
@@ -20,7 +20,7 @@ def test_dag_loaded(dagbag):
     dag = dagbag.get_dag(dag_id="datarobot_pipeline")
     assert dagbag.import_errors == {}
     assert dag is not None
-    assert len(dag.tasks) == 6
+    assert len(dag.tasks) == 8
 
 
 def assert_dag_dict_equal(source, dag):
@@ -35,12 +35,22 @@ def test_dag_structure():
     dag = datarobot_pipeline()
     assert_dag_dict_equal(
         {
-            "create_project": ["train_models", "check_autopilot_complete", "deploy_recommended_model"],
+            "create_project": [
+                "train_models",
+                "check_autopilot_complete",
+                "deploy_recommended_model",
+            ],
             "train_models": ["check_autopilot_complete"],
             "check_autopilot_complete": ["deploy_recommended_model"],
-            "deploy_recommended_model": ["score_predictions"],
+            "deploy_recommended_model": [
+                "feature_drift",
+                "score_predictions",
+                "target_drift",
+            ],
             "score_predictions": ["check_scoring_complete"],
-            "check_scoring_complete": [],
+            "check_scoring_complete": ["target_drift", "feature_drift"],
+            "target_drift": [],
+            "feature_drift": [],
         },
         dag,
     )


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Adding two operators `GetFeatureDriftOperator` and `GetTargetDriftOperator` so that users can check for drift after running batch scoring in their pipelines.

Most changes were implemented by @zingbretsen in https://github.com/datarobot/airflow-provider-datarobot/pull/5 and moved to this PR.

## Rationale
It can be useful to check for drift after running predictions. This allows users to do it from Airflow if they want to automate the process, and then trigger other events if drift was detected.