### PR TITLE
[AGENT-4334] Extended CreateProjectOperator to support creating project from dataset_id

### DIFF
--- a/datarobot_provider/example_dags/datarobot_score_dag.py
+++ b/datarobot_provider/example_dags/datarobot_score_dag.py
@@ -35,7 +35,6 @@ from datarobot_provider.sensors.datarobot import ScoringCompleteSensor
     tags=['example'],
 )
 def datarobot_score(deployment_id=None):
-
     if not deployment_id:
         raise ValueError("Invalid or missing `deployment_id` value")
 

--- a/tests/unit/operators/test_datarobot.py
+++ b/tests/unit/operators/test_datarobot.py
@@ -43,6 +43,31 @@ def test_operator_create_project(mocker):
     create_project_mock.assert_called_with("/path/to/s3/or/local/file", "test project")
 
 
+def test_operator_create_project_from_dataset(mocker):
+    project_mock = mocker.Mock()
+    project_mock.id = "project-id"
+    create_project_mock = mocker.patch.object(
+        dr.Project, "create_from_dataset", return_value=project_mock
+    )
+
+    operator = CreateProjectOperator(task_id='create_project_from_dataset')
+    project_id = operator.execute(
+        context={
+            "params": {
+                "training_dataset_id": "some_dataset_id",
+                "project_name": "test project",
+                "unsupervised_mode": False,
+                "use_feature_discovery": False,
+            },
+        }
+    )
+
+    assert project_id == "project-id"
+    create_project_mock.assert_called_with(
+        dataset_id='some_dataset_id', project_name='test project'
+    )
+
+
 def test_operator_train_models(mocker):
     project_mock = mocker.Mock(target=None)
     mocker.patch.object(dr.Project, "get", return_value=project_mock)

--- a/tests/unit/operators/test_datarobot.py
+++ b/tests/unit/operators/test_datarobot.py
@@ -9,6 +9,7 @@ from datetime import datetime
 
 import datarobot as dr
 import pytest
+from airflow.exceptions import AirflowFailException
 from datarobot.models.data_drift import FeatureDrift
 from datarobot.models.data_drift import TargetDrift
 
@@ -66,6 +67,49 @@ def test_operator_create_project_from_dataset(mocker):
     create_project_mock.assert_called_with(
         dataset_id='some_dataset_id', project_name='test project'
     )
+
+
+def test_operator_create_project_from_dataset_id(mocker):
+    project_mock = mocker.Mock()
+    project_mock.id = "project-id"
+    create_project_mock = mocker.patch.object(
+        dr.Project, "create_from_dataset", return_value=project_mock
+    )
+
+    operator = CreateProjectOperator(
+        task_id='create_project_from_dataset_id', dataset_id='some_dataset_id'
+    )
+    project_id = operator.execute(
+        context={
+            "params": {
+                "project_name": "test project",
+                "unsupervised_mode": False,
+                "use_feature_discovery": False,
+            },
+        }
+    )
+
+    assert project_id == "project-id"
+    create_project_mock.assert_called_with(
+        dataset_id='some_dataset_id', project_name='test project'
+    )
+
+
+def test_operator_create_project_fails_when_no_datasetid_or_training_data():
+    operator = CreateProjectOperator(task_id='create_project_no_datasetid')
+
+    # should raise AirflowFailException if no "training_data" or "training_dataset_id"
+    # or dataset_id provided
+    with pytest.raises(AirflowFailException):
+        operator.execute(
+            context={
+                "params": {
+                    "project_name": "test project",
+                    "unsupervised_mode": False,
+                    "use_feature_discovery": False,
+                },
+            }
+        )
 
 
 def test_operator_train_models(mocker):


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Extended CreateProjectOperator to support creating projects from dataset_id

## Rationale
In most of the cases customers uploading their datasets to AICatalog to reuse it many times.
So its must-have ability to create DR projects from datasets previously uploaded to AICatalog using dataset_id