### PR TITLE
[AGENT-4337] Add Airflow DAG example Uploading Dataset to AICatalog and Creating Project

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ in the `context["params"]` variable, e.g. getting a training data you would use 
 
       Returns a project ID.
 
-   - Creating project from an existing dataset in Datarobot AICatalog, using dataset_id coming from previous operator. 
+   - Creating project from an existing dataset in DataRobot AI Catalog, using dataset_id coming from previous operator. 
      In this case your previous operator must return valid dataset_id (for example `UploadDatasetOperator`) and you 
      should use this output value as a 'dataset_id' argument in `CreateProjectOperator` object creation step. 
      Required config params:

--- a/README.md
+++ b/README.md
@@ -71,20 +71,52 @@ in the `context["params"]` variable, e.g. getting a training data you would use 
 
 ### [Operators](https://github.com/datarobot/airflow-provider-datarobot/blob/main/datarobot_provider/operators/datarobot.py)
 
+- `UploadDatasetOperator`
+
+    Uploading local file to DataRobot AI Catalog and return Dataset ID.
+ 
+    Required config params:
+
+        dataset_file_path: str - local path to training dataset
+
+    Returns a dataset ID.
+
 - `CreateProjectOperator`
 
     Creates a DataRobot project and returns its ID.
  
-    Required config params:
+    Several options of source dataset supported:
+  
+   - Creating project directly from local file or pre-signed S3 URL. Required config params:
 
-        training_data: str - pre-signed S3 URL or local path to training dataset
-        project_name: str - project name
+          training_data: str - pre-signed S3 URL or local path to training dataset
+          project_name: str - project name
 
-    In case of an S3 input, the `training_data` value must be a [pre-signed AWS S3 URL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-presigned-url.html).
+      In case of an S3 input, the `training_data` value must be a [pre-signed AWS S3 URL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-presigned-url.html).
 
-    For more [project settings](https://datarobot-public-api-client.readthedocs-hosted.com/en/latest-release/autodoc/api_reference.html#project) see the DataRobot docs.
+      For more [project settings](https://datarobot-public-api-client.readthedocs-hosted.com/en/latest-release/autodoc/api_reference.html#project) see the DataRobot docs.
 
-    Returns a project ID.
+      Returns a project ID.
+  
+   - Creating project from existing dataset in AICatalog, using dataset_id from config file. Required config params:
+
+          training_dataset_id: str - dataset_id corresponding to existing dataset in DataRobot AICatalog
+          project_name: str - project name
+
+      For more [project settings](https://datarobot-public-api-client.readthedocs-hosted.com/en/latest-release/autodoc/api_reference.html#project) see the DataRobot docs.
+
+      Returns a project ID.
+
+   - Creating project from an existing dataset in Datarobot AICatalog, using dataset_id coming from previous operator. 
+     In this case your previous operator must return valid dataset_id (for example `UploadDatasetOperator`) and you 
+     should use this output value as a 'dataset_id' argument in `CreateProjectOperator` object creation step. 
+     Required config params:
+
+          project_name: str - project name
+  
+      For more [project settings](https://datarobot-public-api-client.readthedocs-hosted.com/en/latest-release/autodoc/api_reference.html#project) see the DataRobot docs.
+
+      Returns a project ID.
 
 - `TrainModelsOperator`
 
@@ -214,16 +246,6 @@ in the `context["params"]` variable, e.g. getting a training data you would use 
 
     Returns a dict with the feature drift data.
 
-- `UploadDatasetOperator`
-
-    Uploading local file to DataRobot AI Catalog and return Dataset ID.
- 
-    Required config params:
-
-        dataset_file_path: str - local path to training dataset
-
-    Returns a dataset ID.
-
 ### [Sensors](https://github.com/datarobot/airflow-provider-datarobot/blob/main/datarobot_provider/sensors/datarobot.py)
 
 - `AutopilotCompleteSensor`
@@ -271,7 +293,7 @@ We are happy to hear from you. Please email any feedback to the authors at [supp
 
 # Copyright Notice
 
-Copyright 2022 DataRobot, Inc. and its affiliates.
+Copyright 2023 DataRobot, Inc. and its affiliates.
 
 All rights reserved.
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ in the `context["params"]` variable, e.g. getting a training data you would use 
 
       Returns a project ID.
   
-   - Creating project from existing dataset in AICatalog, using dataset_id from config file. Required config params:
+   - Creating project from existing dataset in AI Catalog, using dataset_id from config file. Required config params:
 
           training_dataset_id: str - dataset_id corresponding to existing dataset in DataRobot AICatalog
           project_name: str - project name

--- a/datarobot_provider/example_dags/datarobot_create_project_from_ai_catalog_dag.py
+++ b/datarobot_provider/example_dags/datarobot_create_project_from_ai_catalog_dag.py
@@ -6,9 +6,15 @@
 #
 # Released under the terms of DataRobot Tool and Utility Agreement.
 """
+Example of DAG to upload local file to DataRobot AICatalog as a static dataset,
+then using this stored dataset as a training data to create a DataRobot Project.
+
 Config example for this dag:
 {
-    "dataset_file_path": "/tests/integration/datasets/titanic.csv",
+    "dataset_file_path": "/path/to/local/file",
+    "project_name": "test project",
+    "unsupervised_mode": False,
+    "use_feature_discovery": False
 }
 """
 from datetime import datetime
@@ -17,19 +23,28 @@ from airflow.decorators import dag
 
 from datarobot_provider.operators.ai_catalog import UploadDatasetOperator
 from datarobot_provider.operators.datarobot import CreateProjectOperator
-
+"""
+Example of parameters for this dag:
+{
+    "dataset_file_path": "/path/to/local/file",
+    "project_name": "test project",
+    "unsupervised_mode": False,
+    "use_feature_discovery": False
+}
+"""
 @dag(
     schedule_interval=None,
     start_date=datetime(2022, 1, 1),
     tags=['example'],
     params={
-        "dataset_file_path": "./titanic.csv",
+        "dataset_file_path": "/path/to/local/file",
         "project_name": "test project",
         "unsupervised_mode": False,
         "use_feature_discovery": False
     },
 )
-def datarobot_dataset_uploading_create_project():
+def create_project_from_aicatalog():
+
     dataset_uploading_op = UploadDatasetOperator(
         task_id="dataset_uploading",
     )
@@ -42,7 +57,7 @@ def datarobot_dataset_uploading_create_project():
     dataset_uploading_op >> create_project_op
 
 
-datarobot_pipeline_dag = datarobot_dataset_uploading_create_project()
+create_project_from_aicatalog_dag = create_project_from_aicatalog()
 
 if __name__ == "__main__":
-    print(datarobot_pipeline_dag.test())
+    create_project_from_aicatalog_dag.test()

--- a/datarobot_provider/example_dags/datarobot_create_project_from_ai_catalog_dag.py
+++ b/datarobot_provider/example_dags/datarobot_create_project_from_ai_catalog_dag.py
@@ -23,15 +23,8 @@ from airflow.decorators import dag
 
 from datarobot_provider.operators.ai_catalog import UploadDatasetOperator
 from datarobot_provider.operators.datarobot import CreateProjectOperator
-"""
-Example of parameters for this dag:
-{
-    "dataset_file_path": "/path/to/local/file",
-    "project_name": "test project",
-    "unsupervised_mode": False,
-    "use_feature_discovery": False
-}
-"""
+
+
 @dag(
     schedule_interval=None,
     start_date=datetime(2022, 1, 1),
@@ -40,11 +33,10 @@ Example of parameters for this dag:
         "dataset_file_path": "/path/to/local/file",
         "project_name": "test project",
         "unsupervised_mode": False,
-        "use_feature_discovery": False
+        "use_feature_discovery": False,
     },
 )
 def create_project_from_aicatalog():
-
     dataset_uploading_op = UploadDatasetOperator(
         task_id="dataset_uploading",
     )
@@ -58,6 +50,3 @@ def create_project_from_aicatalog():
 
 
 create_project_from_aicatalog_dag = create_project_from_aicatalog()
-
-if __name__ == "__main__":
-    create_project_from_aicatalog_dag.test()

--- a/datarobot_provider/example_dags/datarobot_dataset_upload_create_project_dag.py
+++ b/datarobot_provider/example_dags/datarobot_dataset_upload_create_project_dag.py
@@ -1,0 +1,48 @@
+# Copyright 2023 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+"""
+Config example for this dag:
+{
+    "dataset_file_path": "/tests/integration/datasets/titanic.csv",
+}
+"""
+from datetime import datetime
+
+from airflow.decorators import dag
+
+from datarobot_provider.operators.ai_catalog import UploadDatasetOperator
+from datarobot_provider.operators.datarobot import CreateProjectOperator
+
+@dag(
+    schedule_interval=None,
+    start_date=datetime(2022, 1, 1),
+    tags=['example'],
+    params={
+        "dataset_file_path": "./titanic.csv",
+        "project_name": "test project",
+        "unsupervised_mode": False,
+        "use_feature_discovery": False
+    },
+)
+def datarobot_dataset_uploading_create_project():
+    dataset_uploading_op = UploadDatasetOperator(
+        task_id="dataset_uploading",
+    )
+
+    create_project_op = CreateProjectOperator(
+        task_id='create_project',
+        dataset_id=dataset_uploading_op.output,
+    )
+
+    dataset_uploading_op >> create_project_op
+
+
+datarobot_pipeline_dag = datarobot_dataset_uploading_create_project()
+
+if __name__ == "__main__":
+    print(datarobot_pipeline_dag.test())

--- a/tests/unit/dags/test_create_project_from_ai_catalog_dag.py
+++ b/tests/unit/dags/test_create_project_from_ai_catalog_dag.py
@@ -1,0 +1,41 @@
+# Copyright 2023 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+import pytest
+from airflow.models import DagBag
+
+from datarobot_provider.example_dags.datarobot_create_project_from_ai_catalog_dag import create_project_from_aicatalog
+
+@pytest.fixture()
+def dagbag(provider_dir):
+    return DagBag(dag_folder=f"{str(provider_dir)}/example_dags", include_examples=False)
+
+
+def test_dag_loaded(dagbag):
+    dag = dagbag.get_dag(dag_id="create_project_from_aicatalog")
+    assert dagbag.import_errors == {}
+    assert dag is not None
+    assert len(dag.tasks) == 2
+
+
+def assert_dag_dict_equal(source, dag):
+    assert dag.task_dict.keys() == source.keys()
+    for task_id, downstream_list in source.items():
+        assert dag.has_task(task_id)
+        task = dag.get_task(task_id)
+        assert task.downstream_task_ids == set(downstream_list)
+
+
+def test_dag_structure():
+    dag = create_project_from_aicatalog()
+    assert_dag_dict_equal(
+        {
+            "dataset_uploading": ["create_project"],
+            "create_project": []
+        },
+        dag,
+    )

--- a/tests/unit/dags/test_create_project_from_ai_catalog_dag.py
+++ b/tests/unit/dags/test_create_project_from_ai_catalog_dag.py
@@ -8,7 +8,10 @@
 import pytest
 from airflow.models import DagBag
 
-from datarobot_provider.example_dags.datarobot_create_project_from_ai_catalog_dag import create_project_from_aicatalog
+from datarobot_provider.example_dags.datarobot_create_project_from_ai_catalog_dag import (
+    create_project_from_aicatalog,
+)
+
 
 @pytest.fixture()
 def dagbag(provider_dir):
@@ -33,9 +36,6 @@ def assert_dag_dict_equal(source, dag):
 def test_dag_structure():
     dag = create_project_from_aicatalog()
     assert_dag_dict_equal(
-        {
-            "dataset_uploading": ["create_project"],
-            "create_project": []
-        },
+        {"dataset_uploading": ["create_project"], "create_project": []},
         dag,
     )


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Added Example of Airflow DAG using recently added new operators (UploadDatasetOperator and extended CreateProject Operator). This DAG uploading local file to DataRobot AICatalog as a static dataset, then using this stored dataset as a training data to create a DataRobot Project.

## Rationale
When we adding new Airflow Operators or extending existing, it's very crucial to provide number of usage examples to make learning curve as easy as possible
