### PR TITLE
[AGENT-4348] Add Airflow provider specific header suffix to DataRobot API invocations

### DIFF
--- a/datarobot_provider/hooks/datarobot.py
+++ b/datarobot_provider/hooks/datarobot.py
@@ -11,7 +11,9 @@ from typing import Dict
 import datarobot as dr
 from airflow import AirflowException
 from airflow.hooks.base import BaseHook
+from airflow import __version__ as AIRFLOW_VERSION
 from datarobot.client import Client
+from datarobot_provider import get_provider_info
 
 
 class DataRobotHook(BaseHook):
@@ -75,7 +77,13 @@ class DataRobotHook(BaseHook):
         api_key = conn.extra_dejson.get('extra__http__api_key', '')
         if not api_key:
             raise AirflowException("API key is not defined")
-        return Client(api_key, endpoint)
+
+        # Creating version-specific user agent suffix to collect usage statistics and troubleshooting proposes:
+        provider_package_name = get_provider_info().get('package-name')
+        provider_versions = ''.join(get_provider_info().get('versions'))
+        user_agent_suffix = "{}-{}-airflow-{}".format(provider_package_name, provider_versions, AIRFLOW_VERSION)
+        self.log.info("Initialize DataRobot Client, user_agent_suffix:{}".format(user_agent_suffix))
+        return Client(token=api_key, endpoint=endpoint, user_agent_suffix=user_agent_suffix)
 
     def run(self) -> Any:
         # Initialize DataRobot client

--- a/datarobot_provider/hooks/datarobot.py
+++ b/datarobot_provider/hooks/datarobot.py
@@ -10,9 +10,10 @@ from typing import Dict
 
 import datarobot as dr
 from airflow import AirflowException
-from airflow.hooks.base import BaseHook
 from airflow import __version__ as AIRFLOW_VERSION
+from airflow.hooks.base import BaseHook
 from datarobot.client import Client
+
 from datarobot_provider import get_provider_info
 
 
@@ -81,7 +82,9 @@ class DataRobotHook(BaseHook):
         # Creating version-specific user agent suffix to collect usage statistics and troubleshooting proposes:
         provider_package_name = get_provider_info().get('package-name')
         provider_versions = ''.join(get_provider_info().get('versions'))
-        user_agent_suffix = "{}-{}-airflow-{}".format(provider_package_name, provider_versions, AIRFLOW_VERSION)
+        user_agent_suffix = "{}-{}-airflow-{}".format(
+            provider_package_name, provider_versions, AIRFLOW_VERSION
+        )
         self.log.info("Initialize DataRobot Client, user_agent_suffix:{}".format(user_agent_suffix))
         return Client(token=api_key, endpoint=endpoint, user_agent_suffix=user_agent_suffix)
 

--- a/datarobot_provider/hooks/datarobot.py
+++ b/datarobot_provider/hooks/datarobot.py
@@ -79,7 +79,7 @@ class DataRobotHook(BaseHook):
         if not api_key:
             raise AirflowException("API key is not defined")
 
-        # Creating version-specific user agent suffix to collect usage statistics and troubleshooting proposes:
+        # Creating version-specific user agent suffix for collecting usage statistics and troubleshoot purposes:
         provider_package_name = get_provider_info().get('package-name')
         provider_versions = ''.join(get_provider_info().get('versions'))
         user_agent_suffix = "{}-{}-airflow-{}".format(


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Added Airflow-provider version specific header suffix to DataRobot API invocations 
## Rationale
To collect Airflow Provider usage statistics and troubleshooting proposes 