### PR TITLE
fix for pypi upload url

### DIFF
--- a/jenkins/build_and_publish.groovy
+++ b/jenkins/build_and_publish.groovy
@@ -1,8 +1,8 @@
 stage('Build and Publish'){
     node('ubuntu:focal && 2xCPU~4xRAM') {
-      env.PUBLISH_REPO_URL = env.PUBLISH_REPO_URL ?: 'https://pypi.org/legacy/'
+      env.PUBLISH_REPO_URL = env.PUBLISH_REPO_URL ?: 'https://upload.pypi.org/legacy/'
 
-      String repo_jenkins_creds_key = env.PUBLISH_REPO_URL.startsWith('https://pypi.org/') ? 'pypi' : 'test-pypi'
+      String repo_jenkins_creds_key = env.PUBLISH_REPO_URL.startsWith('https://upload.pypi.org/') ? 'pypi' : 'test-pypi'
 
       checkout scm
       withCredentials([


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
fix for pypi upload url

## Rationale
Default pypi upload url should be "https://upload.pypi.org/legacy/" instead of "https://pypi.org/legacy/"
