### PR TITLE
[AGENT-4349] Implement-UpdateDatasetFromFileOperator

### DIFF
--- a/datarobot_provider/example_dags/datarobot_create_project_from_dataset_version_dag.py
+++ b/datarobot_provider/example_dags/datarobot_create_project_from_dataset_version_dag.py
@@ -1,0 +1,53 @@
+# Copyright 2023 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+"""
+Example of DAG to upload local file to DataRobot AI Catalog as a dataset version,
+then using this dataset version as a training data to create a DataRobot Project.
+
+Config example for this dag:
+{
+    "training_dataset_id": "existing training dataset id"
+    "dataset_file_path": "/path/to/local/file",
+    "project_name": "test project",
+    "unsupervised_mode": False,
+    "use_feature_discovery": False
+}
+"""
+from datetime import datetime
+
+from airflow.decorators import dag
+
+from datarobot_provider.operators.ai_catalog import UpdateDatasetFromFileOperator
+from datarobot_provider.operators.datarobot import CreateProjectOperator
+
+
+@dag(
+    schedule_interval=None,
+    start_date=datetime(2022, 1, 1),
+    tags=['example'],
+    params={
+        "training_dataset_id": "644...590",
+        "dataset_file_path": "/path/to/local/file",
+        "project_name": "test project updated",
+        "unsupervised_mode": False,
+        "use_feature_discovery": False,
+    },
+)
+def create_project_from_dataset_version():
+    dataset_new_version_op = UpdateDatasetFromFileOperator(
+        task_id="dataset_new_version",
+    )
+
+    create_project_op = CreateProjectOperator(
+        task_id='create_project', dataset_version_id=dataset_new_version_op.output
+    )
+
+    dataset_new_version_op >> create_project_op
+
+
+create_project_from_dataset_version_dag = create_project_from_dataset_version()

--- a/datarobot_provider/operators/ai_catalog.py
+++ b/datarobot_provider/operators/ai_catalog.py
@@ -59,3 +59,61 @@ class UploadDatasetOperator(BaseOperator):
         ai_catalog_dataset = dr.Dataset.create_from_file(context["params"]["dataset_file_path"])
         self.log.info(f"Dataset created: dataset_id={ai_catalog_dataset.id}")
         return ai_catalog_dataset.id
+
+
+class UpdateDatasetFromFileOperator(BaseOperator):
+    """
+    Operator that creates a new Dataset version from a file.
+    Returns when the new dataset version has been successfully uploaded.
+
+    :param dataset_id: DataRobot AI Catalog dataset ID
+    :type dataset_id: str, optional
+    :param datarobot_conn_id: Connection ID, defaults to `datarobot_default`
+    :type datarobot_conn_id: str, optional
+    :return: DataRobot AI Catalog dataset version ID
+    :rtype: str
+    """
+
+    # Specify the arguments that are allowed to parse with jinja templating
+    template_fields: Iterable[str] = ["dataset_id"]
+    template_fields_renderers: Dict[str, str] = {}
+    template_ext: Iterable[str] = ()
+    ui_color = '#f4a460'
+
+    def __init__(
+        self,
+        *,
+        dataset_id: str = None,
+        datarobot_conn_id: str = "datarobot_default",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.dataset_id = dataset_id
+        self.datarobot_conn_id = datarobot_conn_id
+        if kwargs.get('xcom_push') is not None:
+            raise AirflowException(
+                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
+            )
+
+    def execute(self, context: Dict[str, Any]) -> str:
+        # Initialize DataRobot client
+        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
+
+        # If dataset_id not provided in constructor, then using training_dataset_id from json config
+        dataset_id = (
+            self.dataset_id
+            if self.dataset_id is not None
+            else context['params']['training_dataset_id']
+        )
+
+        # The path to the file.
+        file_path = context["params"]["dataset_file_path"]
+        self.log.info(f"Update Dataset {dataset_id} in AI Catalog from the local file: {file_path}")
+        ai_catalog_dataset = dr.Dataset.create_version_from_file(
+            dataset_id=dataset_id, file_path=file_path
+        )
+        self.log.info(
+            f"Dataset updated: dataset_id={ai_catalog_dataset.id}, dataset_version_id:{ai_catalog_dataset.version_id}"
+        )
+
+        return ai_catalog_dataset.version_id

--- a/datarobot_provider/operators/datarobot.py
+++ b/datarobot_provider/operators/datarobot.py
@@ -25,7 +25,10 @@ DATETIME_FORMAT = "%Y-%m-%d %H:%M:%s"
 class CreateProjectOperator(BaseOperator):
     """
     Creates DataRobot project.
-
+    :param dataset_id: DataRobot AI Catalog dataset ID
+    :type dataset_id: str, optional
+    :param dataset_version_id: DataRobot AI Catalog dataset version ID
+    :type dataset_version_id: str, optional
     :param datarobot_conn_id: Connection ID, defaults to `datarobot_default`
     :type datarobot_conn_id: str, optional
     :return: DataRobot project ID
@@ -33,7 +36,7 @@ class CreateProjectOperator(BaseOperator):
     """
 
     # Specify the arguments that are allowed to parse with jinja templating
-    template_fields: Iterable[str] = ["dataset_id"]
+    template_fields: Iterable[str] = ["dataset_id", "dataset_version_id"]
     template_fields_renderers: Dict[str, str] = {}
     template_ext: Iterable[str] = ()
     ui_color = '#f4a460'
@@ -42,11 +45,13 @@ class CreateProjectOperator(BaseOperator):
         self,
         *,
         dataset_id: str = None,
+        dataset_version_id: str = None,
         datarobot_conn_id: str = "datarobot_default",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.dataset_id = dataset_id
+        self.dataset_version_id = dataset_version_id
         self.datarobot_conn_id = datarobot_conn_id
         if kwargs.get('xcom_push') is not None:
             raise AirflowException(
@@ -81,7 +86,9 @@ class CreateProjectOperator(BaseOperator):
             )
 
             project = dr.Project.create_from_dataset(
-                dataset_id=training_dataset_id, project_name=context['params']['project_name']
+                dataset_id=training_dataset_id,
+                dataset_version_id=self.dataset_version_id,
+                project_name=context['params']['project_name'],
             )
             self.log.info(
                 f"Project created: project_id={project.id} from dataset: dataset_id={training_dataset_id}"

--- a/tests/unit/dags/test_create_project_from_dataset_version_dag.py
+++ b/tests/unit/dags/test_create_project_from_dataset_version_dag.py
@@ -1,0 +1,41 @@
+# Copyright 2023 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+import pytest
+from airflow.models import DagBag
+
+from datarobot_provider.example_dags.datarobot_create_project_from_dataset_version_dag import (
+    create_project_from_dataset_version,
+)
+
+
+@pytest.fixture()
+def dagbag(provider_dir):
+    return DagBag(dag_folder=f"{str(provider_dir)}/example_dags", include_examples=False)
+
+
+def test_dag_loaded(dagbag):
+    dag = dagbag.get_dag(dag_id="create_project_from_dataset_version")
+    assert dagbag.import_errors == {}
+    assert dag is not None
+    assert len(dag.tasks) == 2
+
+
+def assert_dag_dict_equal(source, dag):
+    assert dag.task_dict.keys() == source.keys()
+    for task_id, downstream_list in source.items():
+        assert dag.has_task(task_id)
+        task = dag.get_task(task_id)
+        assert task.downstream_task_ids == set(downstream_list)
+
+
+def test_dag_structure():
+    dag = create_project_from_dataset_version()
+    assert_dag_dict_equal(
+        {"dataset_new_version": ["create_project"], "create_project": []},
+        dag,
+    )

--- a/tests/unit/operators/test_ai_catalog.py
+++ b/tests/unit/operators/test_ai_catalog.py
@@ -8,7 +8,10 @@
 
 import datarobot as dr
 
-from datarobot_provider.operators.ai_catalog import UploadDatasetOperator
+from datarobot_provider.operators.ai_catalog import (
+    UploadDatasetOperator,
+    UpdateDatasetFromFileOperator,
+)
 
 
 def test_operator_upload_dataset(mocker):
@@ -29,3 +32,27 @@ def test_operator_upload_dataset(mocker):
 
     assert dataset_id == "dataset-id"
     upload_dataset_mock.assert_called_with("/path/to/local/file")
+
+
+def test_operator_update_dataset_from_file(mocker):
+    dataset_mock = mocker.Mock()
+    dataset_mock.id = "dataset-id"
+    dataset_mock.version_id = "dataset-version-id"
+    create_version_from_file_mock = mocker.patch.object(
+        dr.Dataset, "create_version_from_file", return_value=dataset_mock
+    )
+
+    operator = UpdateDatasetFromFileOperator(task_id='create_version_dataset')
+    dataset_version_id = operator.execute(
+        context={
+            "params": {
+                "training_dataset_id": "dataset-id",
+                "dataset_file_path": "/path/to/local/file",
+            },
+        }
+    )
+
+    assert dataset_version_id == "dataset-version-id"
+    create_version_from_file_mock.assert_called_with(
+        dataset_id="dataset-id", file_path="/path/to/local/file"
+    )

--- a/tests/unit/operators/test_ai_catalog.py
+++ b/tests/unit/operators/test_ai_catalog.py
@@ -8,10 +8,8 @@
 
 import datarobot as dr
 
-from datarobot_provider.operators.ai_catalog import (
-    UploadDatasetOperator,
-    UpdateDatasetFromFileOperator,
-)
+from datarobot_provider.operators.ai_catalog import UpdateDatasetFromFileOperator
+from datarobot_provider.operators.ai_catalog import UploadDatasetOperator
 
 
 def test_operator_upload_dataset(mocker):

--- a/tests/unit/operators/test_datarobot.py
+++ b/tests/unit/operators/test_datarobot.py
@@ -65,7 +65,7 @@ def test_operator_create_project_from_dataset(mocker):
 
     assert project_id == "project-id"
     create_project_mock.assert_called_with(
-        dataset_id='some_dataset_id', project_name='test project'
+        dataset_id='some_dataset_id', dataset_version_id=None, project_name='test project'
     )
 
 
@@ -91,12 +91,42 @@ def test_operator_create_project_from_dataset_id(mocker):
 
     assert project_id == "project-id"
     create_project_mock.assert_called_with(
-        dataset_id='some_dataset_id', project_name='test project'
+        dataset_id='some_dataset_id', dataset_version_id=None, project_name='test project'
+    )
+
+
+def test_operator_create_project_from_dataset_id_and_version_id(mocker):
+    project_mock = mocker.Mock()
+    project_mock.id = "project-id"
+    create_project_mock = mocker.patch.object(
+        dr.Project, "create_from_dataset", return_value=project_mock
+    )
+
+    operator = CreateProjectOperator(
+        task_id='create_project_from_dataset_id_version_id',
+        dataset_id='some_dataset_id',
+        dataset_version_id='some_dataset_version_id',
+    )
+    project_id = operator.execute(
+        context={
+            "params": {
+                "project_name": "test project",
+                "unsupervised_mode": False,
+                "use_feature_discovery": False,
+            },
+        }
+    )
+
+    assert project_id == "project-id"
+    create_project_mock.assert_called_with(
+        dataset_id='some_dataset_id',
+        dataset_version_id='some_dataset_version_id',
+        project_name='test project',
     )
 
 
 def test_operator_create_project_fails_when_no_datasetid_or_training_data():
-    operator = CreateProjectOperator(task_id='create_project_no_datasetid')
+    operator = CreateProjectOperator(task_id='create_project_no_dataset_id')
 
     # should raise AirflowFailException if no "training_data" or "training_dataset_id"
     # or dataset_id provided


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Added Airflow operator "UpdateDatasetFromFileOperator" that allows to create a new version of existing dataset by uploading a local file.
Also CreateProjectOperator extended to support specific dataset_version_id

## Rationale
We need to allow users to update their existing datasets in AI Catalog with new versions of data
