### PR TITLE
oleksandr-saienko/AGENT-4243-Implement-JDBC-DataConnectionHook

### DIFF
--- a/datarobot_provider/__init__.py
+++ b/datarobot_provider/__init__.py
@@ -12,13 +12,18 @@ def get_provider_info():
         "description": "DataRobot Airflow provider.",
         "versions": ["0.0.5"],
         "hook-class-names": [
-            "datarobot_provider.hooks.datarobot.DataRobotHook"
+            "datarobot_provider.hooks.datarobot.DataRobotHook",
+            "datarobot_provider.hooks.connections.JDBCDataSourceHook",
         ],  # Deprecated in >=2.2.0
         "connection-types": [
             {
                 "hook-class-name": "datarobot_provider.hooks.datarobot.DataRobotHook",
                 "connection-type": "http",
-            }
+            },
+            {
+                "hook-class-name": "datarobot_provider.hooks.connections.JDBCDataSourceHook",
+                "connection-type": "datarobot_jdbc_datasource",
+            },
         ],
         "extra-links": [],
     }

--- a/datarobot_provider/example_dags/datarobot_jdbc_dataset_dag.py
+++ b/datarobot_provider/example_dags/datarobot_jdbc_dataset_dag.py
@@ -1,0 +1,43 @@
+# Copyright 2023 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+"""
+Config example for this dag:
+{
+    "dataset_file_path": "/tests/integration/datasets/titanic.csv",
+}
+"""
+from datetime import datetime
+
+from airflow.decorators import dag
+
+from datarobot_provider.operators.ai_catalog import CreateDatasetFromJDBCOperator
+
+
+@dag(
+    schedule_interval=None,
+    start_date=datetime(2023, 1, 1),
+    tags=['example'],
+    params={"datarobot_jdbc_connection": "datarobot_jdbc_default",
+            "dataset_name": "test_dataset_name",
+            "table_schema": "SCORING_CODE_UDF_SCHEMA",
+            "table_name": "10k_diabetes.csv",
+            "query": "SELECT * FROM airlines10mb ;"
+            },
+)
+def datarobot_dataset_connect():
+    dataset_connect_op = CreateDatasetFromJDBCOperator(
+        task_id="create_dataset_jdbc",
+    )
+
+    dataset_connect_op
+
+
+datarobot_jdbc_connection_dag = datarobot_dataset_connect()
+
+if __name__ == "__main__":
+    print(datarobot_jdbc_connection_dag.test())

--- a/datarobot_provider/example_dags/datarobot_jdbc_dataset_dag.py
+++ b/datarobot_provider/example_dags/datarobot_jdbc_dataset_dag.py
@@ -22,12 +22,12 @@ from datarobot_provider.operators.ai_catalog import CreateDatasetFromJDBCOperato
     schedule_interval=None,
     start_date=datetime(2023, 1, 1),
     tags=['example'],
-    params={"datarobot_jdbc_connection": "datarobot_jdbc_default",
-            "dataset_name": "test_dataset_name",
-            "table_schema": "SCORING_CODE_UDF_SCHEMA",
-            "table_name": "10k_diabetes.csv",
-            "query": "SELECT * FROM airlines10mb ;"
-            },
+    params={
+        "datarobot_jdbc_connection": "datarobot_jdbc_default",
+        "dataset_name": "test_dataset_name_sql",
+        "table_schema": "SCORING_CODE_UDF_SCHEMA",
+        "table_name": "10k_diabetes.csv",
+    },
 )
 def datarobot_dataset_connect():
     dataset_connect_op = CreateDatasetFromJDBCOperator(

--- a/datarobot_provider/hooks/connections.py
+++ b/datarobot_provider/hooks/connections.py
@@ -1,0 +1,172 @@
+# Copyright 2022 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+from typing import Any
+from typing import Dict
+
+import datarobot as dr
+from airflow import AirflowException
+from airflow.hooks.base import BaseHook
+
+from datarobot_provider.hooks.datarobot import DataRobotHook
+
+
+class JDBCDataSourceHook(BaseHook):
+    """
+    A hook that interacts with DataRobot via its public Python API library.
+
+    :param datarobot_jdbc_conn_id: Connection ID, defaults to `datarobot_jdbc_default`
+    :type datarobot_jdbc_conn_id: str, optional
+    """
+
+    conn_name_attr = 'datarobot_jdbc_conn_id'
+    default_datarobot_jdbc_conn_name = 'datarobot_jdbc_default'
+    conn_type = 'datarobot_jdbc_datasource'
+    hook_name = 'DataRobot JDBC DataSource'
+
+    @staticmethod
+    def get_connection_form_widgets() -> Dict[str, Any]:
+        """Returns connection widgets to add to connection form."""
+        from flask_appbuilder.fieldwidgets import BS3TextFieldWidget
+        from flask_babel import lazy_gettext
+        from wtforms import StringField
+
+        return {
+            "datarobot_connection": StringField(
+                lazy_gettext('DataRobot Connection'),
+                widget=BS3TextFieldWidget(),
+                default='datarobot_default',
+            ),
+            "jdbc_driver": StringField(
+                lazy_gettext('JDBC Driver'),
+                widget=BS3TextFieldWidget(),
+                default='',
+            ),
+            "jdbc_url": StringField(
+                lazy_gettext('JDBC URL'),
+                widget=BS3TextFieldWidget(),
+                default='jdbc:',
+            ),
+        }
+
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict:
+        """Returns custom field behaviour."""
+        return {
+            "hidden_fields": ['host', 'schema', 'port', 'extra'],
+            "relabeling": {},
+            "placeholders": {
+                'datarobot_connection': 'datarobot_default',
+                'jdbc_driver': '',
+                'jdbc_url': 'jdbc:',
+                'login': '',
+                'password': '',
+            },
+        }
+
+    def __init__(
+        self,
+        datarobot_jdbc_conn_id: str = default_datarobot_jdbc_conn_name,
+    ) -> None:
+        super().__init__()
+        self.datarobot_jdbc_conn_id = datarobot_jdbc_conn_id
+
+    def get_conn(self) -> (dict, dr.DataStore):
+        """Initializes a DataRobot DataStore instance with associated credentials."""
+
+        conn = self.get_connection(self.datarobot_jdbc_conn_id)
+
+        datarobot_connection_id = conn.extra_dejson.get('datarobot_connection', '')
+
+        if not datarobot_connection_id:
+            raise AirflowException("datarobot_connection is not defined")
+
+        # Initialize DataRobot client by DataRobotHook
+        DataRobotHook(datarobot_conn_id=datarobot_connection_id).run()
+
+        jdbc_driver_name = conn.extra_dejson.get('jdbc_driver_name', '')
+
+        if not jdbc_driver_name:
+            raise AirflowException("jdbc_driver is not defined")
+
+        jdbc_url = conn.extra_dejson.get('jdbc_url', '')
+
+        if not jdbc_url:
+            raise AirflowException("jdbc_url is not defined")
+
+        if not conn.login:
+            raise AirflowException("login is not defined")
+
+        if not conn.password:
+            raise AirflowException("password is not defined")
+
+        # For methods that accept credential data instead of credential ID
+        credential_data = {
+            "credentialType": "basic",
+            "user": conn.login,
+            "password": conn.password,
+        }
+
+        # Find the JDBC driver ID from name:
+        for jdbc_driver in dr.DataDriver.list():
+            if jdbc_driver.canonical_name in jdbc_driver_name:
+                self.log.info(
+                    f"Found JDBC Driver:{jdbc_driver.canonical_name} , id={jdbc_driver.id}"
+                )
+                jdbc_driver_id = jdbc_driver.id
+                break
+
+        if jdbc_driver_id is None:
+            raise AirflowException("JDBC Driver not found")
+
+        # Check if DataStore created already:
+        for data_store in dr.DataStore.list():
+            if data_store.canonical_name == self.datarobot_jdbc_conn_id:
+                f"Found DataStore:{data_store.canonical_name} , id={data_store.id}"
+                break
+
+        if data_store is None:
+            self.log.info(
+                f"DataStore:{self.datarobot_jdbc_conn_id} does not exist, trying to create it"
+            )
+            data_store = dr.DataStore.create(
+                data_store_type='jdbc',
+                canonical_name=self.datarobot_jdbc_conn_id,
+                driver_id=jdbc_driver_id,
+                jdbc_url=jdbc_url,
+            )
+            self.log.info(
+                f"DataStore:{self.datarobot_jdbc_conn_id} successfully created, id={data_store.id}"
+            )
+        else:
+            if (
+                jdbc_url != data_store.params.jdbc_url
+                or jdbc_driver_id != data_store.params.driver_id
+            ):
+                data_store.update(
+                    canonical_name=self.datarobot_jdbc_conn_id,
+                    driver_id=jdbc_driver_id,
+                    jdbc_url=jdbc_url,
+                )
+
+        return credential_data, data_store
+
+    def run(self) -> Any:
+        # Initialize DataRobot client
+        return self.get_conn()
+
+    def test_connection(self):
+        """Test DataRobot connection to JDBC DataSource"""
+        try:
+            credential_data, data_store = self.run()
+            test_result = data_store.test(
+                username=credential_data["user"], password=credential_data["password"]
+            )
+
+            return True, test_result['message']
+        except Exception as e:
+            return False, str(e)


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Added new connection "DataRobot JDBC DataSource" type that works as a proxy for DataRobot JDBC Connection.
Also Added CreateDatasetFromJDBCOperator to ingest data from JDBC Connection to AI Catalog, and example DAG
## Rationale
Users should be able to configure JDBC Connection using Airflow and use it as a data source with AI Catalog
