### PR TITLE
[AGENT-4242] add gcp credentials management from airflow

### DIFF
--- a/datarobot_provider/__init__.py
+++ b/datarobot_provider/__init__.py
@@ -22,11 +22,11 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "datarobot_provider.hooks.credentials.BasicCredentialsHook",
-                "connection-type": "datarobot-basic-credentials",
+                "connection-type": "datarobotcredentialsbasic",
             },
             {
                 "hook-class-name": "datarobot_provider.hooks.credentials.GoogleCloudCredentialsHook",
-                "connection-type": "datarobot_gcp_credentials",
+                "connection-type": "datarobotcredentialsgcp",
             },
         ],
         "extra-links": [],

--- a/datarobot_provider/__init__.py
+++ b/datarobot_provider/__init__.py
@@ -22,11 +22,11 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "datarobot_provider.hooks.credentials.BasicCredentialsHook",
-                "connection-type": "datarobotcredentialsbasic",
+                "connection-type": "datarobot.credentials.basic",
             },
             {
                 "hook-class-name": "datarobot_provider.hooks.credentials.GoogleCloudCredentialsHook",
-                "connection-type": "datarobotcredentialsgcp",
+                "connection-type": "datarobot.credentials.gcp",
             },
         ],
         "extra-links": [],

--- a/datarobot_provider/__init__.py
+++ b/datarobot_provider/__init__.py
@@ -22,7 +22,7 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "datarobot_provider.hooks.credentials.BasicCredentialsHook",
-                "connection-type": "datarobot_basic_credentials",
+                "connection-type": "datarobot-basic-credentials",
             },
             {
                 "hook-class-name": "datarobot_provider.hooks.credentials.GoogleCloudCredentialsHook",

--- a/datarobot_provider/__init__.py
+++ b/datarobot_provider/__init__.py
@@ -24,6 +24,10 @@ def get_provider_info():
                 "hook-class-name": "datarobot_provider.hooks.credentials.BasicCredentialsHook",
                 "connection-type": "datarobot_basic_credentials",
             },
+            {
+                "hook-class-name": "datarobot_provider.hooks.credentials.GoogleCloudCredentialsHook",
+                "connection-type": "datarobot_gcp_credentials",
+            },
         ],
         "extra-links": [],
     }

--- a/datarobot_provider/hooks/credentials.py
+++ b/datarobot_provider/hooks/credentials.py
@@ -6,9 +6,10 @@
 #
 # Released under the terms of DataRobot Tool and Utility Agreement.
 
+import json
 from typing import Any
 from typing import Dict
-import json
+
 from airflow import AirflowException
 from airflow.hooks.base import BaseHook
 from datarobot.models.credential import Credential
@@ -216,8 +217,8 @@ class GoogleCloudCredentialsHook(CredentialsBaseHook):
     @staticmethod
     def get_connection_form_widgets() -> Dict[str, Any]:
         """Returns connection widgets to add to connection form."""
-        from flask_appbuilder.fieldwidgets import BS3TextFieldWidget
         from flask_appbuilder.fieldwidgets import BS3TextAreaFieldWidget
+        from flask_appbuilder.fieldwidgets import BS3TextFieldWidget
         from flask_babel import lazy_gettext
         from wtforms import StringField
 

--- a/datarobot_provider/hooks/credentials.py
+++ b/datarobot_provider/hooks/credentials.py
@@ -109,7 +109,7 @@ class CredentialsBaseHook(BaseHook):
 
 class BasicCredentialsHook(CredentialsBaseHook):
     hook_name = 'DataRobot Basic Credentials'
-    conn_type = 'datarobot-basic-credentials'
+    conn_type = 'datarobotcredentialsbasic'
 
     def __init__(
         self,
@@ -176,7 +176,7 @@ class BasicCredentialsHook(CredentialsBaseHook):
 
 class GoogleCloudCredentialsHook(CredentialsBaseHook):
     hook_name = 'DataRobot GCP Credentials'
-    conn_type = 'datarobot_gcp_credentials'
+    conn_type = 'datarobotcredentialsgcp'
 
     def create_credentials(self, conn) -> Credential:
         """Returns Google Cloud credentials for params in connection object"""

--- a/datarobot_provider/hooks/credentials.py
+++ b/datarobot_provider/hooks/credentials.py
@@ -232,10 +232,6 @@ class GoogleCloudCredentialsHook(CredentialsBaseHook):
                 lazy_gettext('GCP Key (Service Account)'),
                 widget=BS3TextAreaFieldWidget(),
             ),
-            "created": StringField(
-                lazy_gettext('GCP Key (Service Account)'),
-                widget=BS3TextAreaFieldWidget(),
-            ),
         }
 
     @staticmethod

--- a/datarobot_provider/hooks/credentials.py
+++ b/datarobot_provider/hooks/credentials.py
@@ -209,7 +209,7 @@ class GoogleCloudCredentialsHook(CredentialsBaseHook):
     def get_credential_data(self, conn) -> dict:
         # For methods that accept credential data instead of credential ID
         credential_data = {
-            "credentialType": "basic",
+            "credentialType": "gcp",
             "gcpKey": conn.extra_dejson.get('gcp_key', ''),
         }
         return credential_data

--- a/datarobot_provider/hooks/credentials.py
+++ b/datarobot_provider/hooks/credentials.py
@@ -109,7 +109,7 @@ class CredentialsBaseHook(BaseHook):
 
 class BasicCredentialsHook(CredentialsBaseHook):
     hook_name = 'DataRobot Basic Credentials'
-    conn_type = 'datarobotcredentialsbasic'
+    conn_type = 'datarobot.credentials.basic'
 
     def __init__(
         self,
@@ -176,7 +176,7 @@ class BasicCredentialsHook(CredentialsBaseHook):
 
 class GoogleCloudCredentialsHook(CredentialsBaseHook):
     hook_name = 'DataRobot GCP Credentials'
-    conn_type = 'datarobotcredentialsgcp'
+    conn_type = 'datarobot.credentials.gcp'
 
     def create_credentials(self, conn) -> Credential:
         """Returns Google Cloud credentials for params in connection object"""

--- a/datarobot_provider/hooks/credentials.py
+++ b/datarobot_provider/hooks/credentials.py
@@ -109,7 +109,7 @@ class CredentialsBaseHook(BaseHook):
 
 class BasicCredentialsHook(CredentialsBaseHook):
     hook_name = 'DataRobot Basic Credentials'
-    conn_type = 'datarobot_basic_credentials'
+    conn_type = 'datarobot-basic-credentials'
 
     def __init__(
         self,

--- a/datarobot_provider/operators/credentials.py
+++ b/datarobot_provider/operators/credentials.py
@@ -58,17 +58,15 @@ class GetCredentialIdOperator(BaseOperator):
         credential_name = context["params"][self.credentials_param_name]
         # Trying to find a credential associated with provided credential name:
         for credential in Credential.list():
-            if (
-                credential.name == credential_name
-                and CredentialsBaseHook.default_credential_description not in credential.description
-            ):
+            if credential.name == credential_name:
                 self.log.info(
                     f'Found Credentials :{credential.name} , id={credential.credential_id} '
                     f'for param {self.credentials_param_name}'
                 )
                 return credential.credential_id
         else:
-            # Trying to find an Airflow preconfigured credentials for provided credential name:
+            # Trying to find an Airflow preconfigured credentials for provided credential name
+            # to replicate credentials on DataRobot side:
             credentials, credentials_data = CredentialsBaseHook.get_hook(
                 conn_id=credential_name
             ).run()

--- a/datarobot_provider/operators/credentials.py
+++ b/datarobot_provider/operators/credentials.py
@@ -13,6 +13,7 @@ from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from datarobot import Credential
 
+from datarobot_provider.hooks.credentials import CredentialsBaseHook
 from datarobot_provider.hooks.datarobot import DataRobotHook
 
 DATAROBOT_MAX_WAIT = 3600
@@ -39,11 +40,13 @@ class GetCredentialIdOperator(BaseOperator):
     def __init__(
         self,
         *,
+        credentials_param_name: str = "datarobot_credentials_name",
         datarobot_conn_id: str = "datarobot_default",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.datarobot_conn_id = datarobot_conn_id
+        self.credentials_param_name = credentials_param_name
         if kwargs.get('xcom_push') is not None:
             raise AirflowException(
                 "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
@@ -52,13 +55,21 @@ class GetCredentialIdOperator(BaseOperator):
     def execute(self, context: Dict[str, Any]) -> str:
         # Initialize DataRobot client
         DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
-
+        credential_name = context["params"][self.credentials_param_name]
         # Trying to find a credential associated with provided credential name:
         for credential in Credential.list():
-            if credential.name == context["params"]["datarobot_credentials_name"]:
+            if (
+                credential.name == credential_name
+                and CredentialsBaseHook.default_credential_description not in credential.description
+            ):
                 self.log.info(
-                    f'Found Credentials :{credential.name} , id={credential.credential_id}'
+                    f'Found Credentials :{credential.name} , id={credential.credential_id} '
+                    f'for param {self.credentials_param_name}'
                 )
                 return credential.credential_id
         else:
-            raise ValueError('Credentials does not exist')
+            # Trying to find an Airflow preconfigured credentials for provided credential name:
+            credentials, credentials_data = CredentialsBaseHook.get_hook(
+                conn_id=credential_name
+            ).run()
+            return credentials.credential_id

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -16,7 +16,7 @@ def dr_conn_details():
     return {"endpoint": "https://app.datarobot.com/api/v2", "api_key": "my-api-key"}
 
 
-@pytest.fixture(scope="function", autouse=True)
+@pytest.fixture(autouse=True)
 def mock_datarobot_client(mocker, dr_conn_details):
     client_mock = mocker.Mock(
         endpoint=dr_conn_details["endpoint"], token=dr_conn_details["api_key"]
@@ -24,7 +24,7 @@ def mock_datarobot_client(mocker, dr_conn_details):
     mocker.patch("datarobot_provider.hooks.datarobot.Client", return_value=client_mock)
 
 
-@pytest.fixture(scope="function", autouse=True)
+@pytest.fixture(autouse=True)
 def mock_airflow_connection(mocker, dr_conn_details):
     conn = Connection(
         conn_type="DataRobot",
@@ -83,7 +83,7 @@ def mock_datarobot_driver(mocker, dr_jdbc_conn_details):
     )
 
 
-@pytest.fixture(scope="function", autouse=True)
+@pytest.fixture(autouse=True)
 def mock_datarobot_datastore(mocker, dr_jdbc_conn_details):
     datastore_create_mock = mocker.Mock(
         id='test-datastore-id',
@@ -99,7 +99,7 @@ def mock_datarobot_datastore(mocker, dr_jdbc_conn_details):
     )
 
 
-@pytest.fixture(scope="function", autouse=True)
+@pytest.fixture(autouse=True)
 def mock_airflow_connection_datarobot_jdbc(mocker, dr_jdbc_conn_details):
     conn = Connection(
         conn_type="datarobot_jdbc_datasource",
@@ -116,7 +116,7 @@ def mock_airflow_connection_datarobot_jdbc(mocker, dr_jdbc_conn_details):
     mocker.patch.dict("os.environ", AIRFLOW_CONN_DATAROBOT_JDBC_DEFAULT=conn.get_uri())
 
 
-@pytest.fixture(scope="function", autouse=True)
+@pytest.fixture(autouse=True)
 def mock_datarobot_basic_credentials(mocker, dr_basic_credentials_conn_details):
     credentials_create_mock = mocker.Mock(
         credential_id='test-credentials-id',
@@ -134,7 +134,7 @@ def mock_datarobot_basic_credentials(mocker, dr_basic_credentials_conn_details):
     )
 
 
-@pytest.fixture(scope="function", autouse=True)
+@pytest.fixture(autouse=True)
 def mock_airflow_connection_datarobot_basic_credentials(mocker, dr_basic_credentials_conn_details):
     conn = Connection(
         conn_type="datarobot_basic_credentials",
@@ -149,7 +149,7 @@ def mock_airflow_connection_datarobot_basic_credentials(mocker, dr_basic_credent
     mocker.patch.dict("os.environ", AIRFLOW_CONN_DATAROBOT_BASIC_CREDENTIALS_DEFAULT=conn.get_uri())
 
 
-@pytest.fixture(scope="function", autouse=True)
+@pytest.fixture(autouse=True)
 def mock_datarobot_gcp_credentials(mocker, dr_gcp_credentials_conn_details):
     gcp_credentials_create_mock = mocker.Mock(
         credential_id='test-gcp-credentials-id',
@@ -166,7 +166,7 @@ def mock_datarobot_gcp_credentials(mocker, dr_gcp_credentials_conn_details):
     )
 
 
-@pytest.fixture(scope="function", autouse=True)
+@pytest.fixture(autouse=True)
 def mock_airflow_connection_datarobot_gcp_credentials(mocker, dr_gcp_credentials_conn_details):
     conn = Connection(
         conn_type="datarobot_gcp_credentials",

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -149,7 +149,7 @@ def mock_airflow_connection_datarobot_basic_credentials(mocker, dr_basic_credent
     mocker.patch.dict("os.environ", AIRFLOW_CONN_DATAROBOT_BASIC_CREDENTIALS_DEFAULT=conn.get_uri())
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(scope="function", autouse=True)
 def mock_datarobot_gcp_credentials(mocker, dr_gcp_credentials_conn_details):
     gcp_credentials_create_mock = mocker.Mock(
         credential_id='test-gcp-credentials-id',
@@ -166,7 +166,7 @@ def mock_datarobot_gcp_credentials(mocker, dr_gcp_credentials_conn_details):
     )
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(scope="function", autouse=True)
 def mock_airflow_connection_datarobot_gcp_credentials(mocker, dr_gcp_credentials_conn_details):
     conn = Connection(
         conn_type="datarobot_gcp_credentials",

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -149,7 +149,7 @@ def mock_airflow_connection_datarobot_basic_credentials(mocker, dr_basic_credent
     mocker.patch.dict("os.environ", AIRFLOW_CONN_DATAROBOT_BASIC_CREDENTIALS_DEFAULT=conn.get_uri())
 
 
-@pytest.fixture(scope="function", autouse=True)
+@pytest.fixture(autouse=True)
 def mock_datarobot_gcp_credentials(mocker, dr_gcp_credentials_conn_details):
     gcp_credentials_create_mock = mocker.Mock(
         credential_id='test-gcp-credentials-id',

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -166,7 +166,7 @@ def mock_datarobot_gcp_credentials(mocker, dr_gcp_credentials_conn_details):
     )
 
 
-@pytest.fixture(scope="function", autouse=True)
+@pytest.fixture(autouse=True)
 def mock_airflow_connection_datarobot_gcp_credentials(mocker, dr_gcp_credentials_conn_details):
     conn = Connection(
         conn_type="datarobot_gcp_credentials",

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -137,7 +137,7 @@ def mock_datarobot_basic_credentials(mocker, dr_basic_credentials_conn_details):
 @pytest.fixture(autouse=True)
 def mock_airflow_connection_datarobot_basic_credentials(mocker, dr_basic_credentials_conn_details):
     conn = Connection(
-        conn_type="datarobotcredentialsbasic",
+        conn_type="datarobot.credentials.basic",
         login=dr_basic_credentials_conn_details["login"],
         password=dr_basic_credentials_conn_details["password"],
         extra=json.dumps(
@@ -169,7 +169,7 @@ def mock_datarobot_gcp_credentials(mocker, dr_gcp_credentials_conn_details):
 @pytest.fixture(autouse=True)
 def mock_airflow_connection_datarobot_gcp_credentials(mocker, dr_gcp_credentials_conn_details):
     conn = Connection(
-        conn_type="datarobotcredentialsgcp",
+        conn_type="datarobot.credentials.gcp",
         extra=json.dumps(
             {
                 "gcp_key": dr_gcp_credentials_conn_details["gcp_key"],

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -137,7 +137,7 @@ def mock_datarobot_basic_credentials(mocker, dr_basic_credentials_conn_details):
 @pytest.fixture(autouse=True)
 def mock_airflow_connection_datarobot_basic_credentials(mocker, dr_basic_credentials_conn_details):
     conn = Connection(
-        conn_type="datarobot-basic-credentials",
+        conn_type="datarobotcredentialsbasic",
         login=dr_basic_credentials_conn_details["login"],
         password=dr_basic_credentials_conn_details["password"],
         extra=json.dumps(
@@ -169,7 +169,7 @@ def mock_datarobot_gcp_credentials(mocker, dr_gcp_credentials_conn_details):
 @pytest.fixture(autouse=True)
 def mock_airflow_connection_datarobot_gcp_credentials(mocker, dr_gcp_credentials_conn_details):
     conn = Connection(
-        conn_type="datarobot_gcp_credentials",
+        conn_type="datarobotcredentialsgcp",
         extra=json.dumps(
             {
                 "gcp_key": dr_gcp_credentials_conn_details["gcp_key"],

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -120,7 +120,7 @@ def mock_airflow_connection_datarobot_jdbc(mocker, dr_jdbc_conn_details):
 def mock_datarobot_basic_credentials(mocker, dr_basic_credentials_conn_details):
     credentials_create_mock = mocker.Mock(
         credential_id='test-credentials-id',
-        name='datarobot_basic_credentials_default',
+        name='datarobot_basic_credentials_test',
         credential_type='basic',
         user=dr_basic_credentials_conn_details["login"],
         password=dr_basic_credentials_conn_details["password"],
@@ -137,7 +137,7 @@ def mock_datarobot_basic_credentials(mocker, dr_basic_credentials_conn_details):
 @pytest.fixture(autouse=True)
 def mock_airflow_connection_datarobot_basic_credentials(mocker, dr_basic_credentials_conn_details):
     conn = Connection(
-        conn_type="datarobot_basic_credentials",
+        conn_type="datarobot-basic-credentials",
         login=dr_basic_credentials_conn_details["login"],
         password=dr_basic_credentials_conn_details["password"],
         extra=json.dumps(
@@ -146,7 +146,7 @@ def mock_airflow_connection_datarobot_basic_credentials(mocker, dr_basic_credent
             }
         ),
     )
-    mocker.patch.dict("os.environ", AIRFLOW_CONN_DATAROBOT_BASIC_CREDENTIALS_DEFAULT=conn.get_uri())
+    mocker.patch.dict("os.environ", AIRFLOW_CONN_DATAROBOT_BASIC_CREDENTIALS_TEST=conn.get_uri())
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/hooks/test_basic_credentials.py
+++ b/tests/unit/hooks/test_basic_credentials.py
@@ -9,7 +9,7 @@ from datarobot_provider.hooks.credentials import BasicCredentialsHook
 
 
 def test_datarobot_basic_credentials_conn(dr_basic_credentials_conn_details):
-    hook = BasicCredentialsHook(datarobot_credentials_conn_id="datarobot_basic_credentials_default")
+    hook = BasicCredentialsHook(datarobot_credentials_conn_id="datarobot_basic_credentials_test")
     credentials, credential_data = hook.get_conn()
 
     assert credential_data["user"] == dr_basic_credentials_conn_details["login"]

--- a/tests/unit/hooks/test_gcp_credentials.py
+++ b/tests/unit/hooks/test_gcp_credentials.py
@@ -1,0 +1,17 @@
+# Copyright 2023 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+from datarobot_provider.hooks.credentials import GoogleCloudCredentialsHook
+
+
+def test_datarobot_gcp_credentials_conn(dr_gcp_credentials_conn_details):
+    hook = GoogleCloudCredentialsHook(
+        datarobot_credentials_conn_id="datarobot_gcp_credentials_test"
+    )
+    credentials, credential_data = hook.get_conn()
+
+    assert credential_data["gcpKey"] == dr_gcp_credentials_conn_details["gcp_key"]

--- a/tests/unit/operators/test_credentials.py
+++ b/tests/unit/operators/test_credentials.py
@@ -13,9 +13,10 @@ from airflow.exceptions import AirflowNotFoundException
 from datarobot_provider.operators.credentials import GetCredentialIdOperator
 
 
-def test_operator_get_credential_id(mocker):
+def test_operator_get_basic_credential_id(mocker):
     credential_mock = mocker.Mock()
     credential_mock.credential_id = "credential-id"
+    credential_mock.credential_type = 'datarobot_basic_credentials'
     credential_mock.name = "datarobot_basic_credentials_default"
     credential_mock.description = "Credentials managed by Airflow provider for Datarobot"
     mocker.patch.object(dr.Credential, "list", return_value=[credential_mock])
@@ -36,6 +37,7 @@ def test_operator_get_credential_not_found(mocker):
     credential_mock = mocker.Mock()
     credential_mock.credential_id = "credential-id"
     credential_mock.name = "datarobot_basic_credentials_default"
+    credential_mock.credential_type = 'datarobot_basic_credentials'
     credential_mock.description = "Credentials managed by Airflow provider for Datarobot"
     mocker.patch.object(dr.Credential, "list", return_value=[credential_mock])
     # should raise ValueError if credentials with provided name is not found
@@ -53,6 +55,7 @@ def test_operator_get_credential_not_found(mocker):
 def test_operator_get_gcp_credential_id(mocker):
     credential_mock = mocker.Mock()
     credential_mock.credential_id = "test-gcp-credentials-id"
+    credential_mock.credential_type = 'datarobot_gcp_credentials'
     credential_mock.name = "datarobot_gcp_credentials_test"
     credential_mock.description = "Credentials managed by Airflow provider for Datarobot"
     mocker.patch.object(dr.Credential, "list", return_value=[credential_mock])
@@ -71,6 +74,7 @@ def test_operator_get_gcp_credential_id(mocker):
 
 def test_operator_get_gcp_credential_not_found(mocker):
     credential_mock = mocker.Mock()
+    credential_mock.credential_type = 'datarobot_gcp_credentials'
     credential_mock.credential_id = "test-gcp-credentials-id"
     credential_mock.name = "datarobot_gcp_credentials_test"
     mocker.patch.object(dr.Credential, "list", return_value=[credential_mock])

--- a/tests/unit/operators/test_credentials.py
+++ b/tests/unit/operators/test_credentials.py
@@ -52,39 +52,39 @@ def test_operator_get_credential_not_found(mocker):
         )
 
 
-def test_operator_get_gcp_credential_id(mocker):
-    credential_mock = mocker.Mock()
-    credential_mock.credential_id = "test-gcp-credentials-id"
-    credential_mock.credential_type = 'datarobot_gcp_credentials'
-    credential_mock.name = "datarobot_gcp_credentials_test"
-    credential_mock.description = "Credentials managed by Airflow provider for Datarobot"
-    mocker.patch.object(dr.Credential, "list", return_value=[credential_mock])
-
-    operator = GetCredentialIdOperator(task_id='get_credentials')
-    credential_id = operator.execute(
-        context={
-            "params": {
-                "datarobot_credentials_name": "datarobot_gcp_credentials_test",
-            },
-        }
-    )
-
-    assert credential_id == "test-gcp-credentials-id"
-
-
-def test_operator_get_gcp_credential_not_found(mocker):
-    credential_mock = mocker.Mock()
-    credential_mock.credential_type = 'datarobot_gcp_credentials'
-    credential_mock.credential_id = "test-gcp-credentials-id"
-    credential_mock.name = "datarobot_gcp_credentials_test"
-    mocker.patch.object(dr.Credential, "list", return_value=[credential_mock])
-    # should raise ValueError if credentials with provided name is not found
-    with pytest.raises(AirflowNotFoundException):
-        operator = GetCredentialIdOperator(task_id='get_credentials')
-        operator.execute(
-            context={
-                "params": {
-                    "datarobot_credentials_name": "datarobot_gcp_credentials_not_exist",
-                },
-            }
-        )
+# def test_operator_get_gcp_credential_id(mocker):
+#     credential_mock = mocker.Mock()
+#     credential_mock.credential_id = "test-gcp-credentials-id"
+#     credential_mock.credential_type = 'datarobot_gcp_credentials'
+#     credential_mock.name = "datarobot_gcp_credentials_test"
+#     credential_mock.description = "Credentials managed by Airflow provider for Datarobot"
+#     mocker.patch.object(dr.Credential, "list", return_value=[credential_mock])
+#
+#     operator = GetCredentialIdOperator(task_id='get_credentials')
+#     credential_id = operator.execute(
+#         context={
+#             "params": {
+#                 "datarobot_credentials_name": "datarobot_gcp_credentials_test",
+#             },
+#         }
+#     )
+#
+#     assert credential_id == "test-gcp-credentials-id"
+#
+#
+# def test_operator_get_gcp_credential_not_found(mocker):
+#     credential_mock = mocker.Mock()
+#     credential_mock.credential_type = 'datarobot_gcp_credentials'
+#     credential_mock.credential_id = "test-gcp-credentials-id"
+#     credential_mock.name = "datarobot_gcp_credentials_test"
+#     mocker.patch.object(dr.Credential, "list", return_value=[credential_mock])
+#     # should raise ValueError if credentials with provided name is not found
+#     with pytest.raises(AirflowNotFoundException):
+#         operator = GetCredentialIdOperator(task_id='get_credentials')
+#         operator.execute(
+#             context={
+#                 "params": {
+#                     "datarobot_credentials_name": "datarobot_gcp_credentials_not_exist",
+#                 },
+#             }
+#         )

--- a/tests/unit/operators/test_credentials.py
+++ b/tests/unit/operators/test_credentials.py
@@ -16,7 +16,7 @@ from datarobot_provider.operators.credentials import GetCredentialIdOperator
 def test_operator_get_basic_credential_id(mocker):
     credential_mock = mocker.Mock()
     credential_mock.credential_id = "credential-id"
-    credential_mock.credential_type = 'datarobot-basic-credentials'
+    credential_mock.credential_type = 'datarobot.credentials.basic'
     credential_mock.name = "datarobot_basic_credentials_test"
     credential_mock.description = "Credentials managed by Airflow provider for Datarobot"
     mocker.patch.object(dr.Credential, "list", return_value=[credential_mock])
@@ -37,7 +37,7 @@ def test_operator_get_credential_not_found(mocker):
     credential_mock = mocker.Mock()
     credential_mock.credential_id = "credential-id"
     credential_mock.name = "datarobot_basic_credentials_test"
-    credential_mock.credential_type = 'datarobot-basic-credentials'
+    credential_mock.credential_type = 'datarobot.credentials.basic'
     credential_mock.description = "Credentials managed by Airflow provider for Datarobot"
     mocker.patch.object(dr.Credential, "list", return_value=[credential_mock])
     # should raise ValueError if credentials with provided name is not found

--- a/tests/unit/operators/test_credentials.py
+++ b/tests/unit/operators/test_credentials.py
@@ -12,6 +12,7 @@ from airflow.exceptions import AirflowNotFoundException
 
 from datarobot_provider.operators.credentials import GetCredentialIdOperator
 
+
 def test_operator_get_credential_not_found(mocker):
     credential_mock = mocker.Mock()
     credential_mock.credential_id = "credential-id"
@@ -30,12 +31,13 @@ def test_operator_get_credential_not_found(mocker):
             }
         )
 
+
 def test_operator_get_basic_credential_id(mocker):
     credential_mock = mocker.Mock()
     credential_mock.credential_id = "credential-id"
     credential_mock.credential_type = 'datarobot.credentials.basic'
     credential_mock.name = "datarobot_basic_credentials_test"
-    credential_mock.description = "Test Credentials"
+    credential_mock.description = "Credentials managed by Airflow provider for Datarobot"
     mocker.patch.object(dr.Credential, "list", return_value=[credential_mock])
 
     operator = GetCredentialIdOperator(task_id='get_credentials')
@@ -50,39 +52,39 @@ def test_operator_get_basic_credential_id(mocker):
     assert credential_id == "credential-id"
 
 
-# def test_operator_get_gcp_credential_id(mocker):
-#     credential_mock = mocker.Mock()
-#     credential_mock.credential_id = "test-gcp-credentials-id"
-#     credential_mock.credential_type = 'datarobot_gcp_credentials'
-#     credential_mock.name = "datarobot_gcp_credentials_test"
-#     credential_mock.description = "Credentials managed by Airflow provider for Datarobot"
-#     mocker.patch.object(dr.Credential, "list", return_value=[credential_mock])
-#
-#     operator = GetCredentialIdOperator(task_id='get_credentials')
-#     credential_id = operator.execute(
-#         context={
-#             "params": {
-#                 "datarobot_credentials_name": "datarobot_gcp_credentials_test",
-#             },
-#         }
-#     )
-#
-#     assert credential_id == "test-gcp-credentials-id"
-#
-#
-# def test_operator_get_gcp_credential_not_found(mocker):
-#     credential_mock = mocker.Mock()
-#     credential_mock.credential_type = 'datarobot_gcp_credentials'
-#     credential_mock.credential_id = "test-gcp-credentials-id"
-#     credential_mock.name = "datarobot_gcp_credentials_test"
-#     mocker.patch.object(dr.Credential, "list", return_value=[credential_mock])
-#     # should raise ValueError if credentials with provided name is not found
-#     with pytest.raises(AirflowNotFoundException):
-#         operator = GetCredentialIdOperator(task_id='get_credentials')
-#         operator.execute(
-#             context={
-#                 "params": {
-#                     "datarobot_credentials_name": "datarobot_gcp_credentials_not_exist",
-#                 },
-#             }
-#         )
+def test_operator_get_gcp_credential_id(mocker):
+    credential_mock = mocker.Mock()
+    credential_mock.credential_id = "test-gcp-credentials-id"
+    credential_mock.credential_type = 'datarobot.credentials.gcp'
+    credential_mock.name = "datarobot_gcp_credentials_test"
+    credential_mock.description = "Credentials managed by Airflow provider for Datarobot"
+    mocker.patch.object(dr.Credential, "list", return_value=[credential_mock])
+
+    operator = GetCredentialIdOperator(task_id='get_credentials')
+    credential_id = operator.execute(
+        context={
+            "params": {
+                "datarobot_credentials_name": "datarobot_gcp_credentials_test",
+            },
+        }
+    )
+
+    assert credential_id == "test-gcp-credentials-id"
+
+
+def test_operator_get_gcp_credential_not_found(mocker):
+    credential_mock = mocker.Mock()
+    credential_mock.credential_type = 'datarobot.credentials.gcp'
+    credential_mock.credential_id = "test-gcp-credentials-id"
+    credential_mock.name = "datarobot_gcp_credentials_test"
+    mocker.patch.object(dr.Credential, "list", return_value=[credential_mock])
+    # should raise ValueError if credentials with provided name is not found
+    with pytest.raises(AirflowNotFoundException):
+        operator = GetCredentialIdOperator(task_id='get_credentials')
+        operator.execute(
+            context={
+                "params": {
+                    "datarobot_credentials_name": "datarobot_gcp_credentials_not_exist",
+                },
+            }
+        )

--- a/tests/unit/operators/test_credentials.py
+++ b/tests/unit/operators/test_credentials.py
@@ -16,8 +16,8 @@ from datarobot_provider.operators.credentials import GetCredentialIdOperator
 def test_operator_get_basic_credential_id(mocker):
     credential_mock = mocker.Mock()
     credential_mock.credential_id = "credential-id"
-    credential_mock.credential_type = 'datarobot_basic_credentials'
-    credential_mock.name = "datarobot_basic_credentials_default"
+    credential_mock.credential_type = 'datarobot-basic-credentials'
+    credential_mock.name = "datarobot_basic_credentials_test"
     credential_mock.description = "Credentials managed by Airflow provider for Datarobot"
     mocker.patch.object(dr.Credential, "list", return_value=[credential_mock])
 
@@ -25,7 +25,7 @@ def test_operator_get_basic_credential_id(mocker):
     credential_id = operator.execute(
         context={
             "params": {
-                "datarobot_credentials_name": "datarobot_basic_credentials_default",
+                "datarobot_credentials_name": "datarobot_basic_credentials_test",
             },
         }
     )
@@ -36,8 +36,8 @@ def test_operator_get_basic_credential_id(mocker):
 def test_operator_get_credential_not_found(mocker):
     credential_mock = mocker.Mock()
     credential_mock.credential_id = "credential-id"
-    credential_mock.name = "datarobot_basic_credentials_default"
-    credential_mock.credential_type = 'datarobot_basic_credentials'
+    credential_mock.name = "datarobot_basic_credentials_test"
+    credential_mock.credential_type = 'datarobot-basic-credentials'
     credential_mock.description = "Credentials managed by Airflow provider for Datarobot"
     mocker.patch.object(dr.Credential, "list", return_value=[credential_mock])
     # should raise ValueError if credentials with provided name is not found
@@ -46,7 +46,7 @@ def test_operator_get_credential_not_found(mocker):
         operator.execute(
             context={
                 "params": {
-                    "datarobot_credentials_name": "datarobot_basic_credentials_not_exist",
+                    "datarobot_credentials_name": "datarobot_basic_credentials_not_exist2",
                 },
             }
         )

--- a/tests/unit/operators/test_credentials.py
+++ b/tests/unit/operators/test_credentials.py
@@ -8,6 +8,7 @@
 
 import datarobot as dr
 import pytest
+from airflow.exceptions import AirflowNotFoundException
 
 from datarobot_provider.operators.credentials import GetCredentialIdOperator
 
@@ -16,6 +17,7 @@ def test_operator_get_credential_id(mocker):
     credential_mock = mocker.Mock()
     credential_mock.credential_id = "credential-id"
     credential_mock.name = "datarobot_basic_credentials_default"
+    credential_mock.description = "Credentials managed by Airflow provider for Datarobot"
     mocker.patch.object(dr.Credential, "list", return_value=[credential_mock])
 
     operator = GetCredentialIdOperator(task_id='get_credentials')
@@ -33,15 +35,52 @@ def test_operator_get_credential_id(mocker):
 def test_operator_get_credential_not_found(mocker):
     credential_mock = mocker.Mock()
     credential_mock.credential_id = "credential-id"
-    credential_mock.name = "datarobot_basic_credentials_not_found"
+    credential_mock.name = "datarobot_basic_credentials_default"
+    credential_mock.description = "Credentials managed by Airflow provider for Datarobot"
     mocker.patch.object(dr.Credential, "list", return_value=[credential_mock])
     # should raise ValueError if credentials with provided name is not found
-    with pytest.raises(ValueError):
+    with pytest.raises(AirflowNotFoundException):
         operator = GetCredentialIdOperator(task_id='get_credentials')
         operator.execute(
             context={
                 "params": {
-                    "datarobot_credentials_name": "datarobot_basic_credentials_default",
+                    "datarobot_credentials_name": "datarobot_basic_credentials_not_exist",
+                },
+            }
+        )
+
+
+def test_operator_get_gcp_credential_id(mocker):
+    credential_mock = mocker.Mock()
+    credential_mock.credential_id = "test-gcp-credentials-id"
+    credential_mock.name = "datarobot_gcp_credentials_test"
+    credential_mock.description = "Credentials managed by Airflow provider for Datarobot"
+    mocker.patch.object(dr.Credential, "list", return_value=[credential_mock])
+
+    operator = GetCredentialIdOperator(task_id='get_credentials')
+    credential_id = operator.execute(
+        context={
+            "params": {
+                "datarobot_credentials_name": "datarobot_gcp_credentials_test",
+            },
+        }
+    )
+
+    assert credential_id == "test-gcp-credentials-id"
+
+
+def test_operator_get_gcp_credential_not_found(mocker):
+    credential_mock = mocker.Mock()
+    credential_mock.credential_id = "test-gcp-credentials-id"
+    credential_mock.name = "datarobot_gcp_credentials_test"
+    mocker.patch.object(dr.Credential, "list", return_value=[credential_mock])
+    # should raise ValueError if credentials with provided name is not found
+    with pytest.raises(AirflowNotFoundException):
+        operator = GetCredentialIdOperator(task_id='get_credentials')
+        operator.execute(
+            context={
+                "params": {
+                    "datarobot_credentials_name": "datarobot_gcp_credentials_not_exist",
                 },
             }
         )

--- a/tests/unit/operators/test_credentials.py
+++ b/tests/unit/operators/test_credentials.py
@@ -12,27 +12,6 @@ from airflow.exceptions import AirflowNotFoundException
 
 from datarobot_provider.operators.credentials import GetCredentialIdOperator
 
-
-def test_operator_get_basic_credential_id(mocker):
-    credential_mock = mocker.Mock()
-    credential_mock.credential_id = "credential-id"
-    credential_mock.credential_type = 'datarobot.credentials.basic'
-    credential_mock.name = "datarobot_basic_credentials_test"
-    credential_mock.description = "Credentials managed by Airflow provider for Datarobot"
-    mocker.patch.object(dr.Credential, "list", return_value=[credential_mock])
-
-    operator = GetCredentialIdOperator(task_id='get_credentials')
-    credential_id = operator.execute(
-        context={
-            "params": {
-                "datarobot_credentials_name": "datarobot_basic_credentials_test",
-            },
-        }
-    )
-
-    assert credential_id == "credential-id"
-
-
 def test_operator_get_credential_not_found(mocker):
     credential_mock = mocker.Mock()
     credential_mock.credential_id = "credential-id"
@@ -46,10 +25,29 @@ def test_operator_get_credential_not_found(mocker):
         operator.execute(
             context={
                 "params": {
-                    "datarobot_credentials_name": "datarobot_basic_credentials_not_exist2",
+                    "datarobot_credentials_name": "datarobot_basic_credentials_not_exist",
                 },
             }
         )
+
+def test_operator_get_basic_credential_id(mocker):
+    credential_mock = mocker.Mock()
+    credential_mock.credential_id = "credential-id"
+    credential_mock.credential_type = 'datarobot.credentials.basic'
+    credential_mock.name = "datarobot_basic_credentials_test"
+    credential_mock.description = "Test Credentials"
+    mocker.patch.object(dr.Credential, "list", return_value=[credential_mock])
+
+    operator = GetCredentialIdOperator(task_id='get_credentials')
+    credential_id = operator.execute(
+        context={
+            "params": {
+                "datarobot_credentials_name": "datarobot_basic_credentials_test",
+            },
+        }
+    )
+
+    assert credential_id == "credential-id"
 
 
 # def test_operator_get_gcp_credential_id(mocker):


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Added support for GCP Credentials, extended GetCredentialIdOperator to support fetching existing Credentials or replicating Credentials based on stored Airflow connection 
added unit-tests

## Rationale
Users should be able to create GCP credentials form Airflow, and use it for scoring and project creation