### PR TITLE
[AGENT-4240] Add AWS credentials support

### DIFF
--- a/datarobot_provider/__init__.py
+++ b/datarobot_provider/__init__.py
@@ -28,6 +28,10 @@ def get_provider_info():
                 "hook-class-name": "datarobot_provider.hooks.credentials.GoogleCloudCredentialsHook",
                 "connection-type": "datarobot.credentials.gcp",
             },
+            {
+                "hook-class-name": "datarobot_provider.hooks.credentials.AwsCredentialsHook",
+                "connection-type": "datarobot.credentials.aws",
+            },
         ],
         "extra-links": [],
     }

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -50,27 +50,8 @@ def dr_jdbc_conn_details():
     }
 
 
-# For Basic Credentials test
-@pytest.fixture
-def dr_basic_credentials_conn_details():
-    return {
-        "login": "test_login",
-        "password": "test_password",
-        "datarobot_connection": "datarobot_default",
-    }
-
-
-# For GCP Credentials test
-@pytest.fixture
-def dr_gcp_credentials_conn_details():
-    return {
-        "gcp_key": '{"gcp_credentials":"test"}',
-        "datarobot_connection": "datarobot_default",
-    }
-
-
 @pytest.fixture()
-def mock_datarobot_driver(mocker, dr_jdbc_conn_details):
+def mock_datarobot_driver(mocker):
     driver_list_mock = [
         mocker.Mock(
             id='test-jdbc-driver-id',
@@ -116,6 +97,16 @@ def mock_airflow_connection_datarobot_jdbc(mocker, dr_jdbc_conn_details, mock_da
     mocker.patch.dict("os.environ", AIRFLOW_CONN_DATAROBOT_JDBC_DEFAULT=conn.get_uri())
 
 
+# For Basic Credentials test
+@pytest.fixture
+def dr_basic_credentials_conn_details():
+    return {
+        "login": "test_login",
+        "password": "test_password",
+        "datarobot_connection": "datarobot_default",
+    }
+
+
 @pytest.fixture()
 def mock_datarobot_basic_credentials(mocker):
     credentials_create_mock = mocker.Mock(
@@ -149,8 +140,17 @@ def mock_airflow_connection_datarobot_basic_credentials(
     mocker.patch.dict("os.environ", AIRFLOW_CONN_DATAROBOT_BASIC_CREDENTIALS_TEST=conn.get_uri())
 
 
+# For GCP Credentials test
+@pytest.fixture
+def dr_gcp_credentials_conn_details():
+    return {
+        "gcp_key": '{"gcp_credentials":"test"}',
+        "datarobot_connection": "datarobot_default",
+    }
+
+
 @pytest.fixture()
-def mock_datarobot_gcp_credentials(mocker, dr_gcp_credentials_conn_details):
+def mock_datarobot_gcp_credentials(mocker):
     gcp_credentials_create_mock = mocker.Mock(
         credential_id='test-gcp-credentials-id',
         name='datarobot_gcp_credentials_test',
@@ -193,7 +193,7 @@ def dr_aws_credentials_conn_details():
 
 
 @pytest.fixture()
-def mock_datarobot_aws_credentials(mocker, dr_aws_credentials_conn_details):
+def mock_datarobot_aws_credentials(mocker):
     aws_credentials_create_mock = mocker.Mock(
         credential_id='test-aws-credentials-id',
         name='datarobot_aws_credentials_test',
@@ -214,6 +214,13 @@ def mock_airflow_connection_datarobot_aws_credentials(
 ):
     conn = Connection(
         conn_type="datarobot.credentials.aws",
-        extra=json.dumps(dr_aws_credentials_conn_details),
+        login=dr_aws_credentials_conn_details["aws_access_key_id"],
+        password=dr_aws_credentials_conn_details["aws_secret_access_key"],
+        extra=json.dumps(
+            {
+                "aws_session_token": dr_aws_credentials_conn_details["aws_session_token"],
+                "datarobot_connection": dr_aws_credentials_conn_details["datarobot_connection"],
+            }
+        ),
     )
     mocker.patch.dict("os.environ", AIRFLOW_CONN_DATAROBOT_AWS_CREDENTIALS_TEST=conn.get_uri())

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -84,7 +84,7 @@ def mock_datarobot_driver(mocker, dr_jdbc_conn_details):
 
 
 @pytest.fixture()
-def mock_datarobot_datastore(mocker, dr_jdbc_conn_details):
+def mock_datarobot_datastore(mocker, dr_jdbc_conn_details, mock_datarobot_driver):
     datastore_create_mock = mocker.Mock(
         id='test-datastore-id',
         canonical_name='datarobot_jdbc_default',
@@ -133,7 +133,9 @@ def mock_datarobot_basic_credentials(mocker, dr_basic_credentials_conn_details):
 
 
 @pytest.fixture()
-def mock_airflow_connection_datarobot_basic_credentials(mocker, dr_basic_credentials_conn_details):
+def mock_airflow_connection_datarobot_basic_credentials(
+    mocker, dr_basic_credentials_conn_details, mock_datarobot_basic_credentials
+):
     conn = Connection(
         conn_type="datarobot.credentials.basic",
         login=dr_basic_credentials_conn_details["login"],

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -117,7 +117,7 @@ def mock_airflow_connection_datarobot_jdbc(mocker, dr_jdbc_conn_details, mock_da
 
 
 @pytest.fixture()
-def mock_datarobot_basic_credentials(mocker, dr_basic_credentials_conn_details):
+def mock_datarobot_basic_credentials(mocker):
     credentials_create_mock = mocker.Mock(
         credential_id='test-credentials-id',
         name='datarobot_basic_credentials_test',

--- a/tests/unit/hooks/credentials/__init__.py
+++ b/tests/unit/hooks/credentials/__init__.py
@@ -1,0 +1,7 @@
+# Copyright 2023 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.

--- a/tests/unit/hooks/credentials/test_aws_credentials.py
+++ b/tests/unit/hooks/credentials/test_aws_credentials.py
@@ -1,0 +1,24 @@
+# Copyright 2023 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+from datarobot_provider.hooks.credentials import AwsCredentialsHook
+
+
+def test_datarobot_aws_credentials_conn(
+    dr_aws_credentials_conn_details, mock_airflow_connection_datarobot_aws_credentials
+):
+    hook = AwsCredentialsHook(datarobot_credentials_conn_id="datarobot_aws_credentials_test")
+    credentials, credential_data = hook.get_conn()
+
+    assert credential_data["awsAccessKeyId"] == dr_aws_credentials_conn_details["aws_access_key_id"]
+    assert (
+        credential_data["awsSecretAccessKey"]
+        == dr_aws_credentials_conn_details["aws_secret_access_key"]
+    )
+    assert (
+        credential_data["awsSessionToken"] == dr_aws_credentials_conn_details["aws_session_token"]
+    )

--- a/tests/unit/hooks/credentials/test_basic_credentials.py
+++ b/tests/unit/hooks/credentials/test_basic_credentials.py
@@ -8,7 +8,9 @@
 from datarobot_provider.hooks.credentials import BasicCredentialsHook
 
 
-def test_datarobot_basic_credentials_conn(dr_basic_credentials_conn_details):
+def test_datarobot_basic_credentials_conn(
+    dr_basic_credentials_conn_details, mock_airflow_connection_datarobot_basic_credentials
+):
     hook = BasicCredentialsHook(datarobot_credentials_conn_id="datarobot_basic_credentials_test")
     credentials, credential_data = hook.get_conn()
 

--- a/tests/unit/hooks/credentials/test_gcp_credentials.py
+++ b/tests/unit/hooks/credentials/test_gcp_credentials.py
@@ -8,7 +8,9 @@
 from datarobot_provider.hooks.credentials import GoogleCloudCredentialsHook
 
 
-def test_datarobot_gcp_credentials_conn(dr_gcp_credentials_conn_details):
+def test_datarobot_gcp_credentials_conn(
+    dr_gcp_credentials_conn_details, mock_airflow_connection_datarobot_gcp_credentials
+):
     hook = GoogleCloudCredentialsHook(
         datarobot_credentials_conn_id="datarobot_gcp_credentials_test"
     )

--- a/tests/unit/hooks/test_connections.py
+++ b/tests/unit/hooks/test_connections.py
@@ -8,7 +8,7 @@
 from datarobot_provider.hooks.connections import JDBCDataSourceHook
 
 
-def test_datarobot_jdbc_get_conn(dr_jdbc_conn_details):
+def test_datarobot_jdbc_get_conn(dr_jdbc_conn_details, mock_airflow_connection_datarobot_jdbc):
     hook = JDBCDataSourceHook(datarobot_jdbc_conn_id="datarobot_jdbc_default")
     dr_credentials, dr_datastore = hook.get_conn()
 

--- a/tests/unit/operators/test_ai_catalog.py
+++ b/tests/unit/operators/test_ai_catalog.py
@@ -57,7 +57,7 @@ def test_operator_update_dataset_from_file(mocker):
     )
 
 
-def test_operator_create_dataset_from_jdbc(mocker):
+def test_operator_create_dataset_from_jdbc(mocker, mock_airflow_connection_datarobot_jdbc):
     credential_data = {"credentialType": "basic", "user": "test_login", "password": "test_password"}
     test_params = {
         "datarobot_jdbc_connection": "datarobot_jdbc_default",

--- a/tests/unit/operators/test_credentials.py
+++ b/tests/unit/operators/test_credentials.py
@@ -32,7 +32,9 @@ def test_operator_get_credential_not_found(mocker):
         )
 
 
-def test_operator_get_basic_credential_id(mocker):
+def test_operator_get_basic_credential_id(
+    mocker, mock_airflow_connection_datarobot_basic_credentials
+):
     credential_mock = mocker.Mock()
     credential_mock.credential_id = "credential-id"
     credential_mock.credential_type = 'datarobot.credentials.basic'
@@ -52,7 +54,7 @@ def test_operator_get_basic_credential_id(mocker):
     assert credential_id == "credential-id"
 
 
-def test_operator_get_gcp_credential_id(mocker):
+def test_operator_get_gcp_credential_id(mocker, mock_airflow_connection_datarobot_gcp_credentials):
     credential_mock = mocker.Mock()
     credential_mock.credential_id = "test-gcp-credentials-id"
     credential_mock.credential_type = 'datarobot.credentials.gcp'

--- a/tests/unit/operators/test_credentials.py
+++ b/tests/unit/operators/test_credentials.py
@@ -90,3 +90,41 @@ def test_operator_get_gcp_credential_not_found(mocker):
                 },
             }
         )
+
+
+def test_operator_get_aws_credential_id(mocker, mock_airflow_connection_datarobot_aws_credentials):
+    credential_mock = mocker.Mock()
+    credential_mock.credential_id = "test-aws-credentials-id"
+    credential_mock.credential_type = 'datarobot.credentials.aws'
+    credential_mock.name = "datarobot_aws_credentials_test"
+    credential_mock.description = "Credentials managed by Airflow provider for Datarobot"
+    mocker.patch.object(dr.Credential, "list", return_value=[credential_mock])
+
+    operator = GetCredentialIdOperator(task_id='get_credentials')
+    credential_id = operator.execute(
+        context={
+            "params": {
+                "datarobot_credentials_name": "datarobot_aws_credentials_test",
+            },
+        }
+    )
+
+    assert credential_id == "test-aws-credentials-id"
+
+
+def test_operator_get_aws_credential_not_found(mocker):
+    credential_mock = mocker.Mock()
+    credential_mock.credential_type = 'datarobot.credentials.aws'
+    credential_mock.credential_id = "test-aws-credentials-id"
+    credential_mock.name = "datarobot_aws_credentials_test"
+    mocker.patch.object(dr.Credential, "list", return_value=[credential_mock])
+    # should raise ValueError if credentials with provided name is not found
+    with pytest.raises(AirflowNotFoundException):
+        operator = GetCredentialIdOperator(task_id='get_credentials')
+        operator.execute(
+            context={
+                "params": {
+                    "datarobot_credentials_name": "datarobot_aws_credentials_not_exist",
+                },
+            }
+        )


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Added support for storing and using AWS credentials on Airflow side

## Rationale
Users should be able to create DataRobot credentials for AWS using  Airflow UI