### PR TITLE
[AGENT-4239] added oauth credentials support

### DIFF
--- a/datarobot_provider/__init__.py
+++ b/datarobot_provider/__init__.py
@@ -36,6 +36,10 @@ def get_provider_info():
                 "hook-class-name": "datarobot_provider.hooks.credentials.AzureStorageCredentialsHook",
                 "connection-type": "datarobot.credentials.azure",
             },
+            {
+                "hook-class-name": "datarobot_provider.hooks.credentials.OAuthCredentialsHook",
+                "connection-type": "datarobot.credentials.oauth",
+            },
         ],
         "extra-links": [],
     }

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -269,3 +269,48 @@ def mock_airflow_connection_datarobot_azure_credentials(
         ),
     )
     mocker.patch.dict("os.environ", AIRFLOW_CONN_DATAROBOT_AZURE_CREDENTIALS_TEST=conn.get_uri())
+
+
+# For OAuth Credentials test
+@pytest.fixture
+def dr_oauth_credentials_conn_details():
+    return {
+        "oauth_client_id": "test_oauth_client_id",
+        "token": "test_oauth_token",
+        "refresh_token": "test_oauth_refresh_token",
+        "datarobot_connection": "datarobot_default",
+    }
+
+
+@pytest.fixture()
+def mock_datarobot_oauth_credentials(mocker):
+    oauth_credentials_create_mock = mocker.Mock(
+        credential_id='test-oauth-credentials-id',
+        name='datarobot_oauth_credentials_test',
+        credential_type='oauth',
+        description="Credentials managed by Airflow provider for Datarobot",
+    )
+
+    mocker.patch("datarobot_provider.hooks.credentials.Credential.list", return_value=[])
+    mocker.patch(
+        "datarobot_provider.hooks.credentials.Credential.create_oauth",
+        return_value=oauth_credentials_create_mock,
+    )
+
+
+@pytest.fixture()
+def mock_airflow_connection_datarobot_oauth_credentials(
+    mocker, dr_oauth_credentials_conn_details, mock_datarobot_oauth_credentials
+):
+    conn = Connection(
+        conn_type="datarobot.credentials.oauth",
+        login=dr_oauth_credentials_conn_details["oauth_client_id"],
+        password=dr_oauth_credentials_conn_details["token"],
+        extra=json.dumps(
+            {
+                "datarobot_connection": dr_oauth_credentials_conn_details["datarobot_connection"],
+                "refresh_token": dr_oauth_credentials_conn_details["refresh_token"],
+            }
+        ),
+    )
+    mocker.patch.dict("os.environ", AIRFLOW_CONN_DATAROBOT_OAUTH_CREDENTIALS_TEST=conn.get_uri())

--- a/tests/unit/hooks/credentials/test_oauth_credentials.py
+++ b/tests/unit/hooks/credentials/test_oauth_credentials.py
@@ -1,0 +1,21 @@
+# Copyright 2023 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+from datarobot_provider.hooks.credentials import OAuthCredentialsHook
+
+
+def test_datarobot_oauth_credentials_conn(
+    dr_oauth_credentials_conn_details, mock_airflow_connection_datarobot_oauth_credentials
+):
+    hook = OAuthCredentialsHook(datarobot_credentials_conn_id="datarobot_oauth_credentials_test")
+    credentials, credential_data = hook.get_conn()
+
+    assert credential_data["oauthClientId"] == dr_oauth_credentials_conn_details["oauth_client_id"]
+    assert credential_data["oauthClientSecret"] == dr_oauth_credentials_conn_details["token"]
+    assert (
+        credential_data["oauthRefreshToken"] == dr_oauth_credentials_conn_details["refresh_token"]
+    )


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Added OAuth credentials type hook to configure and store it as an Airflow connection
## Rationale
Users should be able to store OAuth credentials using  Airflow secure storage