### PR TITLE
[AGENT-4245] Implement CreateDataStoreOperator

### DIFF
--- a/datarobot_provider/__init__.py
+++ b/datarobot_provider/__init__.py
@@ -18,27 +18,27 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "datarobot_provider.hooks.connections.JDBCDataSourceHook",
-                "connection-type": "datarobot_jdbc_datasource",
+                "connection-type": "datarobot:datasource:jdbc",
             },
             {
                 "hook-class-name": "datarobot_provider.hooks.credentials.BasicCredentialsHook",
-                "connection-type": "datarobot.credentials.basic",
+                "connection-type": "datarobot:credentials:basic",
             },
             {
                 "hook-class-name": "datarobot_provider.hooks.credentials.GoogleCloudCredentialsHook",
-                "connection-type": "datarobot.credentials.gcp",
+                "connection-type": "datarobot:credentials:gcp",
             },
             {
                 "hook-class-name": "datarobot_provider.hooks.credentials.AwsCredentialsHook",
-                "connection-type": "datarobot.credentials.aws",
+                "connection-type": "datarobot:credentials:aws",
             },
             {
                 "hook-class-name": "datarobot_provider.hooks.credentials.AzureStorageCredentialsHook",
-                "connection-type": "datarobot.credentials.azure",
+                "connection-type": "datarobot:credentials:azure",
             },
             {
                 "hook-class-name": "datarobot_provider.hooks.credentials.OAuthCredentialsHook",
-                "connection-type": "datarobot.credentials.oauth",
+                "connection-type": "datarobot:credentials:oauth",
             },
         ],
         "extra-links": [],

--- a/datarobot_provider/example_dags/datarobot_get_datastore_dag.py
+++ b/datarobot_provider/example_dags/datarobot_get_datastore_dag.py
@@ -1,0 +1,42 @@
+# Copyright 2023 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+"""
+Config example for this dag:
+{
+    "datarobot_jdbc_connection": "datarobot_jdbc_test",
+}
+"""
+from datetime import datetime
+
+from airflow.decorators import dag
+
+from datarobot_provider.operators.connections import GetOrCreateDataStoreOperator
+
+
+@dag(
+    schedule_interval=None,
+    start_date=datetime(2023, 1, 1),
+    tags=['example'],
+    # Default json config example:
+    params={
+        "datarobot_jdbc_connection": "datarobot_jdbc_test",
+    },
+)
+def datarobot_test_datastore():
+    dataset_connect_op = GetOrCreateDataStoreOperator(
+        task_id="create_dataset_jdbc",
+        connection_param_name="datarobot_jdbc_connection",
+    )
+
+    dataset_connect_op
+
+
+datarobot_test_datastore_dag = datarobot_test_datastore()
+
+if __name__ == "__main__":
+    datarobot_test_datastore_dag.test()

--- a/datarobot_provider/operators/connections.py
+++ b/datarobot_provider/operators/connections.py
@@ -1,0 +1,77 @@
+# Copyright 2023 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+from typing import Any
+from typing import Dict
+from typing import Iterable
+
+from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowNotFoundException
+from airflow.models import BaseOperator
+
+from datarobot_provider.hooks.connections import JDBCDataSourceHook
+from datarobot_provider.hooks.datarobot import DataRobotHook
+
+DATAROBOT_MAX_WAIT = 3600
+DATAROBOT_AUTOPILOT_TIMEOUT = 86400
+DATETIME_FORMAT = "%Y-%m-%d %H:%M:%s"
+
+
+class GetOrCreateDataStoreOperator(BaseOperator):
+    """
+    Fetching DataStore by connection name or creating if it does not exist
+    and return DataStore ID.
+
+    :param connection_param_name: name of parameter in the config file corresponding to connection name
+    :type connection_param_name: str, optional
+    :param datarobot_conn_id: Connection ID, defaults to `datarobot_default`
+    :type datarobot_conn_id: str, optional
+    :return: DataRobot Credentials ID
+    :rtype: str
+    """
+
+    # Specify the arguments that are allowed to parse with jinja templating
+    template_fields: Iterable[str] = []
+    template_fields_renderers: Dict[str, str] = {}
+    template_ext: Iterable[str] = ()
+    ui_color = '#f4a460'
+
+    def __init__(
+        self,
+        *,
+        connection_param_name: str = "datarobot_connection_name",
+        datarobot_conn_id: str = "datarobot_default",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.datarobot_conn_id = datarobot_conn_id
+        self.connection_param_name = connection_param_name
+        if kwargs.get('xcom_push') is not None:
+            raise AirflowException(
+                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
+            )
+
+    def execute(self, context: Dict[str, Any]) -> str:
+        # Initialize DataRobot client
+        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
+
+        if self.connection_param_name not in context["params"]:
+            raise AirflowNotFoundException(
+                f"Attribute: {self.connection_param_name} not present in config"
+            )
+        # Getting connection name from config:
+        connection_name = context["params"][self.connection_param_name]
+
+        # Fetch stored JDBC Connection with credentials
+        credential_data, data_store = JDBCDataSourceHook(
+            datarobot_jdbc_conn_id=connection_name
+        ).run()
+
+        if data_store is not None:
+            self.log.info(f"Found preconfigured jdbc connection: {connection_name}")
+
+        return data_store.id

--- a/tests/unit/operators/test_connections.py
+++ b/tests/unit/operators/test_connections.py
@@ -6,7 +6,6 @@
 #
 # Released under the terms of DataRobot Tool and Utility Agreement.
 
-import datarobot as dr
 import pytest
 from airflow.exceptions import AirflowNotFoundException
 

--- a/tests/unit/operators/test_connections.py
+++ b/tests/unit/operators/test_connections.py
@@ -1,0 +1,49 @@
+# Copyright 2023 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+
+import datarobot as dr
+import pytest
+from airflow.exceptions import AirflowNotFoundException
+
+from datarobot_provider.operators.connections import GetOrCreateDataStoreOperator
+
+
+def test_operator_get_or_create_dataset(mock_airflow_connection_datarobot_jdbc):
+    test_params = {
+        "datarobot_connection_name": "datarobot_jdbc_default",
+    }
+
+    operator = GetOrCreateDataStoreOperator(
+        task_id='get_datastore_id', connection_param_name='datarobot_connection_name'
+    )
+
+    dataset_id = operator.execute(
+        context={
+            "params": test_params,
+        }
+    )
+
+    assert dataset_id == "test-datastore-id"
+
+
+def test_operator_get_or_create_dataset_not_found(mock_airflow_connection_datarobot_jdbc):
+    test_params = {
+        "datarobot_connection_name": "datarobot_jdbc_not_found",
+    }
+
+    with pytest.raises(AirflowNotFoundException):
+        operator = GetOrCreateDataStoreOperator(
+            task_id='get_datastore_id', connection_param_name='datarobot_connection_name'
+        )
+        operator.execute(
+            context={
+                "params": {
+                    "params": test_params,
+                },
+            }
+        )


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Added CreateDataStoreOperator that returned datastore_id by connection name. It creates new datastore using preconfigured jdbc connection in case if connection not exist

## Rationale
users should be able to fetch datastore_id for existing connections because it required for different operators