### PR TITLE
[AGENT-4494]-connections-refactoring-and-bug-fixes

### DIFF
--- a/datarobot_provider/__init__.py
+++ b/datarobot_provider/__init__.py
@@ -18,27 +18,27 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "datarobot_provider.hooks.connections.JDBCDataSourceHook",
-                "connection-type": "datarobot:datasource:jdbc",
+                "connection-type": "datarobot.datasource.jdbc",
             },
             {
                 "hook-class-name": "datarobot_provider.hooks.credentials.BasicCredentialsHook",
-                "connection-type": "datarobot:credentials:basic",
+                "connection-type": "datarobot.credentials.basic",
             },
             {
                 "hook-class-name": "datarobot_provider.hooks.credentials.GoogleCloudCredentialsHook",
-                "connection-type": "datarobot:credentials:gcp",
+                "connection-type": "datarobot.credentials.gcp",
             },
             {
                 "hook-class-name": "datarobot_provider.hooks.credentials.AwsCredentialsHook",
-                "connection-type": "datarobot:credentials:aws",
+                "connection-type": "datarobot.credentials.aws",
             },
             {
                 "hook-class-name": "datarobot_provider.hooks.credentials.AzureStorageCredentialsHook",
-                "connection-type": "datarobot:credentials:azure",
+                "connection-type": "datarobot.credentials.azure",
             },
             {
                 "hook-class-name": "datarobot_provider.hooks.credentials.OAuthCredentialsHook",
-                "connection-type": "datarobot:credentials:oauth",
+                "connection-type": "datarobot.credentials.oauth",
             },
         ],
         "extra-links": [],

--- a/datarobot_provider/hooks/credentials.py
+++ b/datarobot_provider/hooks/credentials.py
@@ -68,6 +68,7 @@ class CredentialsBaseHook(BaseHook):
             self.log.info(
                 f"Credentials:{self.datarobot_credentials_conn_id} successfully created, id={credential.credential_id}"
             )
+        return credential
 
     def get_conn(self) -> (Credential, dict):
         """Get or Create DataRobot associated credentials managed by Airflow provider."""
@@ -112,7 +113,7 @@ class CredentialsBaseHook(BaseHook):
 
 class BasicCredentialsHook(CredentialsBaseHook):
     hook_name = 'DataRobot Basic Credentials'
-    conn_type = 'datarobot:credentials:basic'
+    conn_type = 'datarobot.credentials.basic'
 
     def __init__(
         self,
@@ -179,7 +180,7 @@ class BasicCredentialsHook(CredentialsBaseHook):
 
 class GoogleCloudCredentialsHook(CredentialsBaseHook):
     hook_name = 'DataRobot GCP Credentials'
-    conn_type = 'datarobot:credentials:gcp'
+    conn_type = 'datarobot.credentials.gcp'
 
     def create_credentials(self, conn) -> Credential:
         """Returns Google Cloud credentials for params in connection object"""
@@ -252,7 +253,7 @@ class GoogleCloudCredentialsHook(CredentialsBaseHook):
 
 class AwsCredentialsHook(CredentialsBaseHook):
     hook_name = 'DataRobot AWS Credentials'
-    conn_type = 'datarobot:credentials:aws'
+    conn_type = 'datarobot.credentials.aws'
 
     def create_credentials(self, conn) -> Credential:
         """Returns AWS credentials for params in connection object"""
@@ -335,7 +336,7 @@ class AwsCredentialsHook(CredentialsBaseHook):
 
 class AzureStorageCredentialsHook(CredentialsBaseHook):
     hook_name = 'DataRobot Azure Storage Credentials'
-    conn_type = 'datarobot:credentials:azure'
+    conn_type = 'datarobot.credentials.azure'
 
     def create_credentials(self, conn) -> Credential:
         """Returns Azure Storage credentials for params in connection object"""
@@ -410,7 +411,7 @@ class AzureStorageCredentialsHook(CredentialsBaseHook):
 
 class OAuthCredentialsHook(CredentialsBaseHook):
     hook_name = 'DataRobot OAuth Credentials'
-    conn_type = 'datarobot:credentials:oauth'
+    conn_type = 'datarobot.credentials.oauth'
 
     def create_credentials(self, conn) -> Credential:
         """Returns OAuth credentials for params in connection object"""

--- a/datarobot_provider/operators/ai_catalog.py
+++ b/datarobot_provider/operators/ai_catalog.py
@@ -158,8 +158,8 @@ class CreateDatasetFromDataStoreOperator(BaseOperator):
         DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
 
         # Fetch stored JDBC Connection with credentials
-        credential_data, data_store = JDBCDataSourceHook(
-            datarobot_jdbc_conn_id=context["params"]["datarobot_jdbc_connection"]
+        credential, credential_data, data_store = JDBCDataSourceHook(
+            datarobot_credentials_conn_id=context["params"]["datarobot_jdbc_connection"]
         ).run()
 
         dataset_name = context["params"]["dataset_name"]

--- a/datarobot_provider/operators/connections.py
+++ b/datarobot_provider/operators/connections.py
@@ -63,8 +63,8 @@ class GetOrCreateDataStoreOperator(BaseOperator):
         connection_name = context["params"][self.connection_param_name]
 
         # Fetch stored JDBC Connection with credentials
-        credential_data, data_store = JDBCDataSourceHook(
-            datarobot_jdbc_conn_id=connection_name
+        credential, credential_data, data_store = JDBCDataSourceHook(
+            datarobot_credentials_conn_id=connection_name
         ).run()
 
         if data_store is not None:

--- a/datarobot_provider/operators/datarobot.py
+++ b/datarobot_provider/operators/datarobot.py
@@ -36,7 +36,7 @@ class CreateProjectOperator(BaseOperator):
     """
 
     # Specify the arguments that are allowed to parse with jinja templating
-    template_fields: Iterable[str] = ["dataset_id", "dataset_version_id"]
+    template_fields: Iterable[str] = ["dataset_id", "dataset_version_id", "credential_id"]
     template_fields_renderers: Dict[str, str] = {}
     template_ext: Iterable[str] = ()
     ui_color = '#f4a460'
@@ -46,6 +46,7 @@ class CreateProjectOperator(BaseOperator):
         *,
         dataset_id: str = None,
         dataset_version_id: str = None,
+        credential_id: str = None,
         datarobot_conn_id: str = "datarobot_default",
         **kwargs: Any,
     ) -> None:
@@ -53,6 +54,7 @@ class CreateProjectOperator(BaseOperator):
         self.dataset_id = dataset_id
         self.dataset_version_id = dataset_version_id
         self.datarobot_conn_id = datarobot_conn_id
+        self.credential_id = credential_id
         if kwargs.get('xcom_push') is not None:
             raise AirflowException(
                 "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
@@ -88,6 +90,7 @@ class CreateProjectOperator(BaseOperator):
             project = dr.Project.create_from_dataset(
                 dataset_id=training_dataset_id,
                 dataset_version_id=self.dataset_version_id,
+                credential_id=self.credential_id,
                 project_name=context['params']['project_name'],
             )
             self.log.info(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -38,65 +38,6 @@ def mock_airflow_connection(mocker, dr_conn_details):
     mocker.patch.dict("os.environ", AIRFLOW_CONN_DATAROBOT_DEFAULT=conn.get_uri())
 
 
-# For JDBC Connection
-@pytest.fixture
-def dr_jdbc_conn_details():
-    return {
-        "login": "test_login",
-        "password": "test_password",
-        "datarobot_connection": "datarobot_default",
-        "jdbc_driver": "test JDBC Driver",
-        "jdbc_url": "jdbc:test_jdbc_connection_string",
-    }
-
-
-@pytest.fixture()
-def mock_datarobot_driver(mocker):
-    driver_list_mock = [
-        mocker.Mock(
-            id='test-jdbc-driver-id',
-            canonical_name='test JDBC Driver',
-        )
-    ]
-
-    mocker.patch(
-        "datarobot_provider.hooks.connections.DataDriver.list", return_value=driver_list_mock
-    )
-
-
-@pytest.fixture()
-def mock_datarobot_datastore(mocker, dr_jdbc_conn_details, mock_datarobot_driver):
-    datastore_create_mock = mocker.Mock(
-        id='test-datastore-id',
-        canonical_name='datarobot_jdbc_default',
-        params=mocker.Mock(
-            driver_id='test-jdbc-driver-id', jdbc_url=dr_jdbc_conn_details["jdbc_url"]
-        ),
-    )
-
-    mocker.patch("datarobot_provider.hooks.connections.DataStore.list", return_value=[])
-    mocker.patch(
-        "datarobot_provider.hooks.connections.DataStore.create", return_value=datastore_create_mock
-    )
-
-
-@pytest.fixture(autouse=True)
-def mock_airflow_connection_datarobot_jdbc(mocker, dr_jdbc_conn_details, mock_datarobot_datastore):
-    conn = Connection(
-        conn_type="datarobot_jdbc_datasource",
-        login=dr_jdbc_conn_details["login"],
-        password=dr_jdbc_conn_details["password"],
-        extra=json.dumps(
-            {
-                "datarobot_connection": dr_jdbc_conn_details["datarobot_connection"],
-                "jdbc_driver": dr_jdbc_conn_details["jdbc_driver"],
-                "jdbc_url": dr_jdbc_conn_details["jdbc_url"],
-            }
-        ),
-    )
-    mocker.patch.dict("os.environ", AIRFLOW_CONN_DATAROBOT_JDBC_DEFAULT=conn.get_uri())
-
-
 # For Basic Credentials test
 @pytest.fixture
 def dr_basic_credentials_conn_details():
@@ -314,3 +255,64 @@ def mock_airflow_connection_datarobot_oauth_credentials(
         ),
     )
     mocker.patch.dict("os.environ", AIRFLOW_CONN_DATAROBOT_OAUTH_CREDENTIALS_TEST=conn.get_uri())
+
+
+# For JDBC Connection
+@pytest.fixture
+def dr_jdbc_conn_details():
+    return {
+        "login": "test_login",
+        "password": "test_password",
+        "datarobot_connection": "datarobot_default",
+        "jdbc_driver": "test JDBC Driver",
+        "jdbc_url": "jdbc:test_jdbc_connection_string",
+    }
+
+
+@pytest.fixture()
+def mock_datarobot_driver(mocker):
+    driver_list_mock = [
+        mocker.Mock(
+            id='test-jdbc-driver-id',
+            canonical_name='test JDBC Driver',
+        )
+    ]
+
+    mocker.patch(
+        "datarobot_provider.hooks.connections.DataDriver.list", return_value=driver_list_mock
+    )
+
+
+@pytest.fixture()
+def mock_datarobot_datastore(mocker, dr_jdbc_conn_details, mock_datarobot_driver):
+    datastore_create_mock = mocker.Mock(
+        id='test-datastore-id',
+        canonical_name='datarobot_test_connection_jdbc_test',
+        params=mocker.Mock(
+            driver_id='test-jdbc-driver-id', jdbc_url=dr_jdbc_conn_details["jdbc_url"]
+        ),
+    )
+
+    mocker.patch("datarobot_provider.hooks.connections.DataStore.list", return_value=[])
+    mocker.patch(
+        "datarobot_provider.hooks.connections.DataStore.create", return_value=datastore_create_mock
+    )
+
+
+@pytest.fixture()
+def mock_airflow_connection_datarobot_jdbc(
+    mocker, dr_jdbc_conn_details, mock_datarobot_basic_credentials, mock_datarobot_datastore
+):
+    conn = Connection(
+        conn_type="datarobot.datasource.jdbc",
+        login=dr_jdbc_conn_details["login"],
+        password=dr_jdbc_conn_details["password"],
+        extra=json.dumps(
+            {
+                "datarobot_connection": dr_jdbc_conn_details["datarobot_connection"],
+                "jdbc_driver": dr_jdbc_conn_details["jdbc_driver"],
+                "jdbc_url": dr_jdbc_conn_details["jdbc_url"],
+            }
+        ),
+    )
+    mocker.patch.dict("os.environ", AIRFLOW_CONN_DATAROBOT_TEST_CONNECTION_JDBC_TEST=conn.get_uri())

--- a/tests/unit/hooks/test_connections.py
+++ b/tests/unit/hooks/test_connections.py
@@ -8,10 +8,17 @@
 from datarobot_provider.hooks.connections import JDBCDataSourceHook
 
 
-def test_datarobot_jdbc_get_conn(dr_jdbc_conn_details, mock_airflow_connection_datarobot_jdbc):
-    hook = JDBCDataSourceHook(datarobot_jdbc_conn_id="datarobot_jdbc_default")
-    dr_credentials, dr_datastore = hook.get_conn()
+def test_datarobot_jdbc_get_conn(
+    dr_jdbc_conn_details,
+    dr_basic_credentials_conn_details,
+    mock_airflow_connection_datarobot_jdbc,
+    mock_datarobot_basic_credentials,
+    mock_datarobot_datastore,
+):
+    hook = JDBCDataSourceHook(datarobot_credentials_conn_id="datarobot_test_connection_jdbc_test")
+    dr_credentials, dr_credentials_data, dr_datastore = hook.get_conn()
 
-    assert dr_credentials["user"] == dr_jdbc_conn_details["login"]
-    assert dr_credentials["password"] == dr_jdbc_conn_details["password"]
+    assert dr_credentials.credential_id == 'test-credentials-id'
+    assert dr_credentials_data["user"] == dr_jdbc_conn_details["login"]
+    assert dr_credentials_data["password"] == dr_jdbc_conn_details["password"]
     assert dr_datastore.params.jdbc_url == dr_jdbc_conn_details["jdbc_url"]

--- a/tests/unit/operators/test_ai_catalog.py
+++ b/tests/unit/operators/test_ai_catalog.py
@@ -60,7 +60,7 @@ def test_operator_update_dataset_from_file(mocker):
 def test_operator_create_dataset_from_jdbc(mocker, mock_airflow_connection_datarobot_jdbc):
     credential_data = {"credentialType": "basic", "user": "test_login", "password": "test_password"}
     test_params = {
-        "datarobot_jdbc_connection": "datarobot_jdbc_default",
+        "datarobot_jdbc_connection": "datarobot_test_connection_jdbc_test",
         "dataset_name": "test_dataset_name",
         "table_schema": "integration_demo",
         "table_name": "test_table",

--- a/tests/unit/operators/test_connections.py
+++ b/tests/unit/operators/test_connections.py
@@ -14,7 +14,7 @@ from datarobot_provider.operators.connections import GetOrCreateDataStoreOperato
 
 def test_operator_get_or_create_dataset(mock_airflow_connection_datarobot_jdbc):
     test_params = {
-        "datarobot_connection_name": "datarobot_jdbc_default",
+        "datarobot_connection_name": "datarobot_test_connection_jdbc_test",
     }
 
     operator = GetOrCreateDataStoreOperator(

--- a/tests/unit/operators/test_datarobot.py
+++ b/tests/unit/operators/test_datarobot.py
@@ -65,7 +65,10 @@ def test_operator_create_project_from_dataset(mocker):
 
     assert project_id == "project-id"
     create_project_mock.assert_called_with(
-        dataset_id='some_dataset_id', dataset_version_id=None, project_name='test project'
+        dataset_id='some_dataset_id',
+        dataset_version_id=None,
+        project_name='test project',
+        credential_id=None,
     )
 
 
@@ -91,7 +94,10 @@ def test_operator_create_project_from_dataset_id(mocker):
 
     assert project_id == "project-id"
     create_project_mock.assert_called_with(
-        dataset_id='some_dataset_id', dataset_version_id=None, project_name='test project'
+        dataset_id='some_dataset_id',
+        dataset_version_id=None,
+        project_name='test project',
+        credential_id=None,
     )
 
 
@@ -122,6 +128,7 @@ def test_operator_create_project_from_dataset_id_and_version_id(mocker):
         dataset_id='some_dataset_id',
         dataset_version_id='some_dataset_version_id',
         project_name='test project',
+        credential_id=None,
     )
 
 


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
- fixed issue with connection type delimiter switched from ":" to "."
- now JDBCDataSourceHook extending BasicCredentialsHook to support basic credentials for Project Creation and Batch Scoring with JDBC
- added example of project creation from dynamic jdbc dataset: datarobot_jdbc_dynamic_dataset_dag
- fixed unit-tests

## Rationale
Users should be able to use dynamic datasets for project creation.
Fixed bug related to connection type delimiter
