### PR TITLE
[AGENT-4488] Implement Airflow Operator for reading Deployment metrics

### DIFF
--- a/datarobot_provider/example_dags/deployment_service_stats_dag.py
+++ b/datarobot_provider/example_dags/deployment_service_stats_dag.py
@@ -1,0 +1,48 @@
+# Copyright 2023 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+from datetime import datetime
+
+from airflow.decorators import dag
+from airflow.decorators import task
+
+from datarobot_provider.operators.monitoring import GetServiceStatsOperator
+
+
+@dag(
+    schedule_interval=None,
+    start_date=datetime(2023, 1, 1),
+    tags=['example', 'mlops'],
+)
+def deployment_service_stats():
+    service_stats_op = GetServiceStatsOperator(
+        task_id="get_service_stats",
+        deployment_id="63eb7dfce1274472579f6e1c",
+    )
+
+    @task(task_id="example_processing_python")
+    def service_stat_processing(model_service_stat):
+        """Example of custom logic based on service stats from the deployment."""
+
+        # Put your service stat processing logic here:
+        current_model_id = model_service_stat['model_id']
+        total_predictions = model_service_stat['metrics']['totalPredictions']
+        print(f"model_id:{current_model_id}, total_predictions:{total_predictions}")
+
+        return total_predictions
+
+    example_service_stat_processing = service_stat_processing(
+        model_service_stat=service_stats_op.output
+    )
+
+    service_stats_op >> example_service_stat_processing
+
+
+deployment_service_stats_dag = deployment_service_stats()
+
+if __name__ == "__main__":
+    deployment_service_stats_dag.test()

--- a/datarobot_provider/example_dags/deployment_service_stats_dag.py
+++ b/datarobot_provider/example_dags/deployment_service_stats_dag.py
@@ -21,7 +21,8 @@ from datarobot_provider.operators.monitoring import GetServiceStatsOperator
 def deployment_service_stats():
     service_stats_op = GetServiceStatsOperator(
         task_id="get_service_stats",
-        deployment_id="63eb7dfce1274472579f6e1c",
+        # you can pass deployment_id from previous operator here:
+        deployment_id="put your deployment_id here",
     )
 
     @task(task_id="example_processing_python")

--- a/datarobot_provider/operators/monitoring.py
+++ b/datarobot_provider/operators/monitoring.py
@@ -1,0 +1,72 @@
+# Copyright 2023 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+from typing import Any
+from typing import Dict
+from typing import Iterable
+from typing import List
+
+import datarobot as dr
+from airflow.exceptions import AirflowException
+from airflow.models import BaseOperator
+
+from datarobot_provider.hooks.datarobot import DataRobotHook
+
+DATETIME_FORMAT = "%Y-%m-%d %H:%M:%s"
+
+
+class GetServiceStatsOperator(BaseOperator):
+    """
+    Gets service stats measurements from a deployment.
+
+    :param deployment_id: DataRobot deployment ID
+    :type deployment_id: str
+    :param datarobot_conn_id: Connection ID, defaults to `datarobot_default`
+    :type datarobot_conn_id: str, optional
+    :return: Service stats for a Deployment
+    :rtype: List[dict]
+    """
+
+    # Specify the arguments that are allowed to parse with jinja templating
+    template_fields: Iterable[str] = ["deployment_id"]
+    template_fields_renderers: Dict[str, str] = {}
+    template_ext: Iterable[str] = ()
+    ui_color = "#f4a460"
+
+    def __init__(
+        self,
+        *,
+        deployment_id: str,
+        datarobot_conn_id: str = "datarobot_default",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.deployment_id = deployment_id
+        self.datarobot_conn_id = datarobot_conn_id
+        if kwargs.get("xcom_push") is not None:
+            raise AirflowException(
+                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
+            )
+
+    def execute(self, context: Dict[str, Any]) -> List[dict]:
+        # Initialize DataRobot client
+        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
+
+        self.log.info(f"Getting service stats for deployment_id={self.deployment_id}")
+        deployment = dr.Deployment.get(self.deployment_id)
+        service_stats_params = context["params"].get("service_stats", {})
+        service_stats = deployment.get_service_stats(**service_stats_params)
+        return _serialize_service_stats(service_stats)
+
+
+def _serialize_service_stats(service_stats_obj, date_format=DATETIME_FORMAT):
+    service_stats_dict = service_stats_obj.__dict__.copy()
+    service_stats_dict["period"] = {
+        "start": service_stats_obj.period["start"].strftime(date_format),
+        "end": service_stats_obj.period["end"].strftime(date_format),
+    }
+    return service_stats_dict

--- a/tests/unit/operators/test_monitoring.py
+++ b/tests/unit/operators/test_monitoring.py
@@ -50,7 +50,6 @@ def test_operator_get_service_stat(mocker, service_stat_details):
     )
 
     operator = GetServiceStatsOperator(task_id="get_service_stat", deployment_id="deployment-id")
-    # service_stats_params = {"feature_drift": {"model_id": "test-model-id"}}
     service_stats_params = {}
     service_stats_result = operator.execute(context={'params': {}})
 

--- a/tests/unit/operators/test_monitoring.py
+++ b/tests/unit/operators/test_monitoring.py
@@ -1,0 +1,84 @@
+# Copyright 2023 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+from datetime import datetime
+
+import datarobot as dr
+import pytest
+from datarobot.models import ServiceStats
+
+from datarobot_provider.operators.monitoring import GetServiceStatsOperator
+from datarobot_provider.operators.monitoring import _serialize_service_stats
+
+
+@pytest.fixture
+def service_stat_details():
+    return {
+        "model_id": "test-model-id",
+        "period": {
+            "start": datetime.fromisoformat("2023-01-01"),
+            "end": datetime.fromisoformat("2023-01-07"),
+        },
+        "metrics": {
+            'totalPredictions': 1000,
+            'totalRequests': 10,
+            'slowRequests': 5,
+            'executionTime': 500.0,
+            'responseTime': 1000.0,
+            'userErrorRate': 0.0,
+            'serverErrorRate': 0.0,
+            'numConsumers': 1,
+            'cacheHitRatio': 1.0,
+            'medianLoad': 0.0,
+            'peakLoad': 1,
+        },
+    }
+
+
+def test_operator_get_service_stat(mocker, service_stat_details):
+    deployment_id = "deployment-id"
+    service_stat = ServiceStats(**service_stat_details)
+    expected_service_stats = _serialize_service_stats(service_stat)
+
+    mocker.patch.object(dr.Deployment, "get", return_value=dr.Deployment(deployment_id))
+    get_service_stats_mock = mocker.patch.object(
+        dr.Deployment, "get_service_stats", return_value=service_stat
+    )
+
+    operator = GetServiceStatsOperator(task_id="get_service_stat", deployment_id="deployment-id")
+    # service_stats_params = {"feature_drift": {"model_id": "test-model-id"}}
+    service_stats_params = {}
+    service_stats_result = operator.execute(context={'params': {}})
+
+    assert service_stats_result == expected_service_stats
+    get_service_stats_mock.assert_called_with(**service_stats_params)
+
+
+def test_operator_get_service_stat_with_params(mocker, service_stat_details):
+    deployment_id = "deployment-id"
+    service_stat = ServiceStats(**service_stat_details)
+    expected_service_stats = _serialize_service_stats(service_stat)
+
+    mocker.patch.object(dr.Deployment, "get", return_value=dr.Deployment(deployment_id))
+    get_service_stats_mock = mocker.patch.object(
+        dr.Deployment, "get_service_stats", return_value=service_stat
+    )
+
+    operator = GetServiceStatsOperator(task_id="get_service_stat", deployment_id="deployment-id")
+
+    service_stats_params = {
+        "service_stats": {
+            "model_id": "test-model-id",
+            "start_time": datetime.fromisoformat("2023-01-01"),
+            "end_time": datetime.fromisoformat("2023-01-07"),
+        }
+    }
+
+    service_stats_result = operator.execute(context={'params': service_stats_params})
+
+    assert service_stats_result == expected_service_stats
+    get_service_stats_mock.assert_called_with(**service_stats_params["service_stats"])


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Implemented GetServiceStatsOperator to read Deployment metrics and serialize it to pass to the next operator with user logic. Added example DAG with GetServiceStatsOperator and custom Python operator template

## Rationale
Users should be able to read service metrics from Deployment to use it with their custom logic