### PR TITLE
[AGENT-4486] Implement Airflow Operators to create new dataset versions from datasource

### DIFF
--- a/datarobot_provider/example_dags/datarobot_aws_s3_batch_scoring_dag.py
+++ b/datarobot_provider/example_dags/datarobot_aws_s3_batch_scoring_dag.py
@@ -37,7 +37,7 @@ from datarobot_provider.sensors.datarobot import ScoringCompleteSensor
 
 
 @dag(
-    schedule_interval=None,
+    schedule=None,
     start_date=datetime(2023, 1, 1),
     tags=['example', 'aws'],
     params={

--- a/datarobot_provider/example_dags/datarobot_azure_storage_batch_scoring_dag.py
+++ b/datarobot_provider/example_dags/datarobot_azure_storage_batch_scoring_dag.py
@@ -37,7 +37,7 @@ from datarobot_provider.sensors.datarobot import ScoringCompleteSensor
 
 
 @dag(
-    schedule_interval=None,
+    schedule=None,
     start_date=datetime(2023, 1, 1),
     tags=['example', 'azure'],
     params={

--- a/datarobot_provider/example_dags/datarobot_bigquery_batch_scoring_dag.py
+++ b/datarobot_provider/example_dags/datarobot_bigquery_batch_scoring_dag.py
@@ -40,7 +40,7 @@ from datarobot_provider.sensors.datarobot import ScoringCompleteSensor
 
 
 @dag(
-    schedule_interval=None,
+    schedule=None,
     start_date=datetime(2023, 1, 1),
     tags=['example', 'gcp', 'bigquery'],
     params={

--- a/datarobot_provider/example_dags/datarobot_create_project_from_ai_catalog_dag.py
+++ b/datarobot_provider/example_dags/datarobot_create_project_from_ai_catalog_dag.py
@@ -26,7 +26,7 @@ from datarobot_provider.operators.datarobot import CreateProjectOperator
 
 
 @dag(
-    schedule_interval=None,
+    schedule=None,
     start_date=datetime(2022, 1, 1),
     tags=['example'],
     params={

--- a/datarobot_provider/example_dags/datarobot_create_project_from_dataset_version_dag.py
+++ b/datarobot_provider/example_dags/datarobot_create_project_from_dataset_version_dag.py
@@ -27,7 +27,7 @@ from datarobot_provider.operators.datarobot import CreateProjectOperator
 
 
 @dag(
-    schedule_interval=None,
+    schedule=None,
     start_date=datetime(2022, 1, 1),
     tags=['example'],
     params={

--- a/datarobot_provider/example_dags/datarobot_dataset_new_version_dag.py
+++ b/datarobot_provider/example_dags/datarobot_dataset_new_version_dag.py
@@ -37,7 +37,7 @@ from datarobot_provider.operators.credentials import GetOrCreateCredentialOperat
     },
 )
 def datarobot_dataset_new_version(
-    deployment_id='646fcfe9b01540a797f224b3', dataset_id='647f3d5ec731b1fd66eadb29'
+    deployment_id=None, dataset_id=None
 ):
     if not deployment_id:
         raise ValueError("Invalid or missing `deployment_id` value")

--- a/datarobot_provider/example_dags/datarobot_dataset_new_version_dag.py
+++ b/datarobot_provider/example_dags/datarobot_dataset_new_version_dag.py
@@ -1,0 +1,73 @@
+# Copyright 2023 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+"""
+Config example for this dag:
+{
+    "datarobot_jdbc_connection": "datarobot_jdbc_demo",
+    "dataset_name": "integration_example_demo",
+    "table_schema": "integration_example_demo",
+    "table_name": "actuals_demo",
+}
+"""
+from datetime import datetime
+
+from airflow.decorators import dag
+
+from datarobot_provider.operators.ai_catalog import CreateDatasetVersionOperator
+from datarobot_provider.operators.ai_catalog import CreateOrUpdateDataSourceOperator
+from datarobot_provider.operators.connections import GetOrCreateDataStoreOperator
+from datarobot_provider.operators.credentials import GetOrCreateCredentialOperator
+
+
+@dag(
+    schedule=None,
+    start_date=datetime(2023, 1, 1),
+    tags=['example', 'mlops'],
+    # Default json config example:
+    params={
+        "datarobot_jdbc_connection": "datarobot_jdbc_demo",
+        "dataset_name": "integration_example_demo",
+        "table_schema": "integration_example_demo",
+        "table_name": "actuals_demo",
+    },
+)
+def datarobot_dataset_new_version(
+    deployment_id='646fcfe9b01540a797f224b3', dataset_id='647f3d5ec731b1fd66eadb29'
+):
+    if not deployment_id:
+        raise ValueError("Invalid or missing `deployment_id` value")
+
+    get_credentials_op = GetOrCreateCredentialOperator(
+        task_id="get_jdbc_credentials",
+        credentials_param_name="datarobot_jdbc_connection",
+    )
+
+    get_datastore_op = GetOrCreateDataStoreOperator(
+        task_id="get_datastore",
+        connection_param_name="datarobot_jdbc_connection",
+    )
+
+    get_datasource_op = CreateOrUpdateDataSourceOperator(
+        task_id="get_datasource",
+        data_store_id=get_datastore_op.output,
+    )
+
+    create_dataset_version_op = CreateDatasetVersionOperator(
+        task_id="create_new_version_of_dataset",
+        dataset_id=dataset_id,
+        datasource_id=get_datasource_op.output,
+        credential_id=get_credentials_op.output,
+    )
+
+    get_datastore_op >> get_datasource_op >> get_credentials_op >> create_dataset_version_op
+
+
+datarobot_dataset_new_version_dag = datarobot_dataset_new_version()
+
+if __name__ == "__main__":
+    datarobot_dataset_new_version_dag.test()

--- a/datarobot_provider/example_dags/datarobot_dataset_upload_dag.py
+++ b/datarobot_provider/example_dags/datarobot_dataset_upload_dag.py
@@ -19,7 +19,7 @@ from datarobot_provider.operators.ai_catalog import UploadDatasetOperator
 
 
 @dag(
-    schedule_interval=None,
+    schedule=None,
     start_date=datetime(2022, 1, 1),
     tags=['example'],
     params={"dataset_file_path": "./titanic.csv"},

--- a/datarobot_provider/example_dags/datarobot_gcp_storage_batch_scoring_dag.py
+++ b/datarobot_provider/example_dags/datarobot_gcp_storage_batch_scoring_dag.py
@@ -37,7 +37,7 @@ from datarobot_provider.sensors.datarobot import ScoringCompleteSensor
 
 
 @dag(
-    schedule_interval=None,
+    schedule=None,
     start_date=datetime(2023, 1, 1),
     tags=['example', 'gcp'],
     params={

--- a/datarobot_provider/example_dags/datarobot_get_datastore_dag.py
+++ b/datarobot_provider/example_dags/datarobot_get_datastore_dag.py
@@ -19,7 +19,7 @@ from datarobot_provider.operators.connections import GetOrCreateDataStoreOperato
 
 
 @dag(
-    schedule_interval=None,
+    schedule=None,
     start_date=datetime(2023, 1, 1),
     tags=['example'],
     # Default json config example:

--- a/datarobot_provider/example_dags/datarobot_jdbc_batch_scoring_dag.py
+++ b/datarobot_provider/example_dags/datarobot_jdbc_batch_scoring_dag.py
@@ -41,7 +41,7 @@ from datarobot_provider.sensors.datarobot import ScoringCompleteSensor
 
 
 @dag(
-    schedule_interval=None,
+    schedule=None,
     start_date=datetime(2023, 1, 1),
     tags=['example', 'jdbc'],
     params={

--- a/datarobot_provider/example_dags/datarobot_jdbc_dataset_dag.py
+++ b/datarobot_provider/example_dags/datarobot_jdbc_dataset_dag.py
@@ -26,7 +26,7 @@ from datarobot_provider.operators.datarobot import CreateProjectOperator
 
 
 @dag(
-    schedule_interval=None,
+    schedule=None,
     start_date=datetime(2023, 1, 1),
     tags=['example'],
     # Default json config example:

--- a/datarobot_provider/example_dags/datarobot_jdbc_dynamic_dataset_dag.py
+++ b/datarobot_provider/example_dags/datarobot_jdbc_dynamic_dataset_dag.py
@@ -27,7 +27,7 @@ from datarobot_provider.operators.datarobot import CreateProjectOperator
 
 
 @dag(
-    schedule_interval=None,
+    schedule=None,
     start_date=datetime(2023, 1, 1),
     tags=['example'],
     # Default json config example:

--- a/datarobot_provider/example_dags/datarobot_pipeline_dag.py
+++ b/datarobot_provider/example_dags/datarobot_pipeline_dag.py
@@ -20,7 +20,7 @@ from datarobot_provider.sensors.datarobot import ScoringCompleteSensor
 
 
 @dag(
-    schedule_interval=None,
+    schedule=None,
     start_date=datetime(2022, 1, 1),
     tags=['example'],
 )

--- a/datarobot_provider/example_dags/datarobot_score_dag.py
+++ b/datarobot_provider/example_dags/datarobot_score_dag.py
@@ -30,7 +30,7 @@ from datarobot_provider.sensors.datarobot import ScoringCompleteSensor
 
 
 @dag(
-    schedule_interval=None,
+    schedule=None,
     start_date=datetime(2022, 1, 1),
     tags=['example'],
 )

--- a/datarobot_provider/example_dags/deployment_service_stats_dag.py
+++ b/datarobot_provider/example_dags/deployment_service_stats_dag.py
@@ -14,7 +14,7 @@ from datarobot_provider.operators.monitoring import GetServiceStatsOperator
 
 
 @dag(
-    schedule_interval=None,
+    schedule=None,
     start_date=datetime(2023, 1, 1),
     tags=['example', 'mlops'],
 )

--- a/datarobot_provider/example_dags/deployment_stat_and_accuracy_dag.py
+++ b/datarobot_provider/example_dags/deployment_stat_and_accuracy_dag.py
@@ -15,7 +15,7 @@ from datarobot_provider.operators.monitoring import GetServiceStatsOperator
 
 
 @dag(
-    schedule_interval=None,
+    schedule=None,
     start_date=datetime(2023, 1, 1),
     tags=['example', 'mlops'],
 )

--- a/datarobot_provider/operators/ai_catalog.py
+++ b/datarobot_provider/operators/ai_catalog.py
@@ -209,3 +209,149 @@ class CreateDatasetFromDataStoreOperator(BaseOperator):
         )
         self.log.info(f"Dataset created: dataset_id={ai_catalog_dataset.id}")
         return ai_catalog_dataset.id
+
+
+class CreateDatasetVersionOperator(BaseOperator):
+    """
+    Creating new version of existing dataset in AI Catalog and return dataset version ID.
+
+    :param dataset_id: DataRobot AI Catalog dataset ID
+    :type dataset_id: str
+    :param datasource_id: existing DataRobot datasource ID
+    :type datasource_id: str
+    :param credential_id: existing DataRobot credential ID
+    :type credential_id: str
+    :param datarobot_conn_id: Connection ID, defaults to `datarobot_default`
+    :type datarobot_conn_id: str, optional
+    :return: DataRobot AI Catalog dataset version ID
+    :rtype: str
+    """
+
+    # Specify the arguments that are allowed to parse with jinja templating
+    template_fields: Iterable[str] = ["dataset_id", "datasource_id", "credential_id"]
+    template_fields_renderers: Dict[str, str] = {}
+    template_ext: Iterable[str] = ()
+    ui_color = '#f4a460'
+
+    def __init__(
+        self,
+        *,
+        dataset_id: str,
+        datasource_id: str,
+        credential_id: str,
+        datarobot_conn_id: str = "datarobot_default",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.dataset_id = dataset_id
+        self.datasource_id = datasource_id
+        self.credential_id = credential_id
+        self.datarobot_conn_id = datarobot_conn_id
+        if kwargs.get('xcom_push') is not None:
+            raise AirflowException(
+                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
+            )
+
+    def execute(self, context: Dict[str, Any]) -> str:
+        # Initialize DataRobot client
+        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
+
+        self.log.debug(
+            f"Creation new version of dataset: dataset_id={self.dataset_id}, "
+            f"using datasource: datasource_id={self.datasource_id}, "
+            f"with credentials: credentials_id={self.credential_id}."
+        )
+
+        ai_catalog_dataset = dr.Dataset.create_version_from_data_source(
+            dataset_id=self.dataset_id,
+            data_source_id=self.datasource_id,
+            credential_id=self.credential_id,
+            max_wait=DATAROBOT_MAX_WAIT_SEC,
+        )
+
+        self.log.info(
+            f"Dataset version created: dataset_id={ai_catalog_dataset.id},"
+            f" version_id={ai_catalog_dataset.version_id}"
+        )
+
+        return ai_catalog_dataset.version_id
+
+
+class CreateOrUpdateDataSourceOperator(BaseOperator):
+    """
+    Creates the data source or updates it if its already exist and return data source ID.
+
+    :param data_store_id: DataRobot data store ID
+    :type data_store_id: str
+    :param datarobot_conn_id: Connection ID, defaults to `datarobot_default`
+    :type datarobot_conn_id: str, optional
+    :return: DataRobot AI Catalog dataset ID
+    :rtype: str
+    """
+
+    # Specify the arguments that are allowed to parse with jinja templating
+    template_fields: Iterable[str] = ["data_store_id"]
+    template_fields_renderers: Dict[str, str] = {}
+    template_ext: Iterable[str] = ()
+    ui_color = '#f4a460'
+
+    def __init__(
+        self,
+        *,
+        data_store_id: str,
+        datarobot_conn_id: str = "datarobot_default",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.data_store_id = data_store_id
+        self.datarobot_conn_id = datarobot_conn_id
+        if kwargs.get('xcom_push') is not None:
+            raise AirflowException(
+                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
+            )
+
+    def execute(self, context: Dict[str, Any]) -> str:
+        # Initialize DataRobot client
+        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
+
+        self.log.debug(f"Trying to get existing DataStore by data_store_id={self.data_store_id}")
+        data_store = dr.DataStore.get(data_store_id=self.data_store_id)
+        self.log.debug(f"Found existing DataStore: {data_store.canonical_name}, id={data_store.id}")
+
+        dataset_name = context["params"]["dataset_name"]
+
+        # Creating DataSourceParameters:
+        if "query" in context["params"] and context["params"]["query"]:
+            # using sql statement if provided:
+            params = dr.DataSourceParameters(query=context["params"]["query"])
+        else:
+            # otherwise using schema and table:
+            params = dr.DataSourceParameters(
+                schema=context["params"]["table_schema"], table=context["params"]["table_name"]
+            )
+
+        self.log.debug(f"Trying to get existing DataSource by name={dataset_name}")
+        for dr_source_item in dr.DataSource.list():
+            if dr_source_item.canonical_name == dataset_name:
+                data_source = dr_source_item
+                self.log.info(f"Found existing DataSource:{dataset_name}, id={data_source.id}")
+                # Checking if there are any changes in params:
+                if params != data_source.params:
+                    # If params in changed, updating data source:
+                    self.log.info(f"Updating DataSource:{dataset_name} with new params")
+                    data_source.update(canonical_name=dataset_name, params=params)
+                    self.log.info(
+                        f"DataSource:{dataset_name} successfully updated, id={data_source.id}"
+                    )
+                break
+        else:
+            # Adding data_store_id to params (required for DataSource creation):
+            params.data_store_id = data_store.id
+            # Creating DataSource using params with data_store_id
+            self.log.info(f"Creating DataSource: {dataset_name}")
+            data_source = dr.DataSource.create(
+                data_source_type='jdbc', canonical_name=dataset_name, params=params
+            )
+            self.log.info(f"DataSource:{dataset_name} successfully created, id={data_source.id}")
+
+        return data_source.id

--- a/datarobot_provider/operators/ai_catalog.py
+++ b/datarobot_provider/operators/ai_catalog.py
@@ -285,7 +285,7 @@ class CreateOrUpdateDataSourceOperator(BaseOperator):
     :type data_store_id: str
     :param datarobot_conn_id: Connection ID, defaults to `datarobot_default`
     :type datarobot_conn_id: str, optional
-    :return: DataRobot AI Catalog dataset ID
+    :return: DataRobot AI Catalog data source ID
     :rtype: str
     """
 

--- a/tests/unit/operators/test_ai_catalog.py
+++ b/tests/unit/operators/test_ai_catalog.py
@@ -11,6 +11,8 @@ import datarobot as dr
 from datarobot_provider.operators.ai_catalog import CreateDatasetFromDataStoreOperator
 from datarobot_provider.operators.ai_catalog import UpdateDatasetFromFileOperator
 from datarobot_provider.operators.ai_catalog import UploadDatasetOperator
+from datarobot_provider.operators.ai_catalog import CreateDatasetVersionOperator
+from datarobot_provider.operators.ai_catalog import CreateOrUpdateDataSourceOperator
 
 
 def test_operator_upload_dataset(mocker):
@@ -105,3 +107,134 @@ def test_operator_create_dataset_from_jdbc(mocker, mock_airflow_connection_datar
         do_snapshot=test_params["do_snapshot"],
         max_wait=3600,
     )
+
+
+def test_operator_create_dataset_version(mocker):
+    dataset_id = "test-dataset-id"
+    datasource_id = "test-datasource-id"
+    credential_id = "test-credential-id"
+
+    dataset_version_mock = mocker.Mock()
+    dataset_version_mock.version_id = "test-dataset-version-id"
+    create_dataset_version_mock = mocker.patch.object(
+        dr.Dataset, "create_version_from_data_source", return_value=dataset_version_mock
+    )
+
+    operator = CreateDatasetVersionOperator(
+        task_id='create_dataset_version',
+        dataset_id=dataset_id,
+        datasource_id=datasource_id,
+        credential_id=credential_id,
+    )
+    dataset_version_id = operator.execute(context={})
+
+    assert dataset_version_id == "test-dataset-version-id"
+    create_dataset_version_mock.assert_called_with(
+        dataset_id=dataset_id,
+        data_source_id=datasource_id,
+        credential_id=credential_id,
+        max_wait=3600,
+    )
+
+
+def test_operator_create_datasource_operator(mocker):
+    data_store_id = "test-data-store-id"
+
+    test_params = {
+        "datarobot_jdbc_connection": "datarobot_test_connection_jdbc_test",
+        "dataset_name": "test_dataset_name",
+        "table_schema": "integration_demo",
+        "table_name": "test_table",
+        "query": 'SELECT * FROM "integration_demo"."test_table"',
+        "persist_data_after_ingestion": True,
+        "do_snapshot": True,
+        "max_wait": 3600,
+    }
+
+    datastore_mock = mocker.Mock()
+    datastore_mock.version_id = data_store_id
+
+    datasource_params_mock = dr.DataSourceParameters(
+        query='SELECT * FROM "integration_demo"."test_new_table"'
+    )
+
+    other_datasource_mock = mocker.Mock()
+    other_datasource_mock.id = "test-other-datasource-id"
+    other_datasource_mock.canonical_name = "other-datasource-name"
+    other_datasource_mock.params = datasource_params_mock
+    mocker.patch.object(dr.DataSource, "list", return_value=[other_datasource_mock])
+
+    datasource_mock = mocker.Mock()
+    datasource_mock.id = "test-datasource-id"
+    datasource_mock.canonical_name = test_params["dataset_name"]
+    datasource_mock.params = datasource_params_mock
+    datastore_get_mock = mocker.patch.object(dr.DataStore, "get", return_value=datastore_mock)
+    mocker.patch.object(dr.DataSource, "create", return_value=datasource_mock)
+
+    datasource_update_mock = mocker.patch.object(datasource_mock, "update")
+
+    create_dataset_mock = mocker.patch.object(dr.DataSource, "create", return_value=datasource_mock)
+
+    operator = CreateOrUpdateDataSourceOperator(
+        task_id='create_dataset_version',
+        data_store_id=data_store_id,
+    )
+    data_source_id = operator.execute(
+        context={
+            "params": test_params,
+        }
+    )
+
+    assert data_source_id == "test-datasource-id"
+    datastore_get_mock.assert_called_with(data_store_id=data_store_id)
+
+    datasource_update_mock.assert_not_called()
+    create_dataset_mock.assert_called()
+
+
+def test_operator_update_datasource_operator(mocker):
+    data_store_id = "test-data-store-id"
+
+    test_params = {
+        "datarobot_jdbc_connection": "datarobot_test_connection_jdbc_test",
+        "dataset_name": "test_dataset_name",
+        "table_schema": "integration_demo",
+        "table_name": "test_table",
+        "query": 'SELECT * FROM "integration_demo"."test_table22"',
+        "persist_data_after_ingestion": True,
+        "do_snapshot": True,
+        "max_wait": 3600,
+    }
+
+    datastore_mock = mocker.Mock()
+    datastore_mock.version_id = data_store_id
+
+    datasource_mock = mocker.Mock()
+    datasource_mock.id = "test-datasource-id"
+    datasource_mock.canonical_name = test_params["dataset_name"]
+    datasource_mock.params = dr.DataSourceParameters(
+        query='SELECT * FROM "integration_demo"."test_table"'
+    )
+    datastore_get_mock = mocker.patch.object(dr.DataStore, "get", return_value=datastore_mock)
+    mocker.patch.object(dr.DataSource, "list", return_value=[datasource_mock])
+    mocker.patch.object(dr.DataSource, "create", return_value=datasource_mock)
+
+    datasource_update_mock = mocker.patch.object(datasource_mock, "update")
+
+    create_dataset_mock = mocker.patch.object(dr.DataSource, "create", return_value=datasource_mock)
+
+    operator = CreateOrUpdateDataSourceOperator(
+        task_id='create_dataset_version',
+        data_store_id=data_store_id,
+    )
+    data_source_id = operator.execute(
+        context={
+            "params": test_params,
+        }
+    )
+
+    assert data_source_id == "test-datasource-id"
+    datastore_get_mock.assert_called_with(data_store_id=data_store_id)
+
+    datasource_update_mock.assert_called()
+    create_dataset_mock.assert_not_called()

--- a/tests/unit/operators/test_monitoring.py
+++ b/tests/unit/operators/test_monitoring.py
@@ -9,8 +9,7 @@ from datetime import datetime
 
 import datarobot as dr
 import pytest
-from datarobot.models import Accuracy
-from datarobot.models import ServiceStats
+from datarobot.models.deployment import ServiceStats, Accuracy
 
 from datarobot_provider.operators.monitoring import GetAccuracyOperator
 from datarobot_provider.operators.monitoring import GetServiceStatsOperator


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Added Airflow Operators: CreateDatasetVersionOperator and CreateDatasetFromDataStoreOperator to support creating new versions of existing datasets
changed "schedule_interval" to "schedule" for all DAGs because "schedule_interval" was deprecated

## Rationale
Users should be able to create new versions of existing datasets in AI Catalog. Also it required for submit actuals DAG because "dynamic" dataset is not supported for submit actuals method
