### PR TITLE
[AGENT-4485] Create Operator to configure Monitoring Settings for a deployment

### DIFF
--- a/datarobot_provider/example_dags/datarobot_dataset_new_version_dag.py
+++ b/datarobot_provider/example_dags/datarobot_dataset_new_version_dag.py
@@ -36,9 +36,7 @@ from datarobot_provider.operators.credentials import GetOrCreateCredentialOperat
         "table_name": "actuals_demo",
     },
 )
-def datarobot_dataset_new_version(
-    deployment_id=None, dataset_id=None
-):
+def datarobot_dataset_new_version(deployment_id=None, dataset_id=None):
     if not deployment_id:
         raise ValueError("Invalid or missing `deployment_id` value")
 

--- a/datarobot_provider/example_dags/deployment_update_monitoring_settings_dag.py
+++ b/datarobot_provider/example_dags/deployment_update_monitoring_settings_dag.py
@@ -62,8 +62,6 @@ def deployment_monitoring_settings(deployment_id=None):
             if model_monitoring_settings_after[setting] != model_monitoring_settings_before[setting]
         }
 
-        print(f"settings_changed:{str(settings_changed)}")
-
         return settings_changed
 
     example_service_stat_processing = monitoring_settings_processing(

--- a/datarobot_provider/example_dags/deployment_update_monitoring_settings_dag.py
+++ b/datarobot_provider/example_dags/deployment_update_monitoring_settings_dag.py
@@ -25,7 +25,8 @@ from datarobot_provider.operators.monitoring import (
         "target_drift_enabled": False,
         "feature_drift_enabled": True,
         "association_id_column": ["id"],
-        "required_association_id_in_prediction_requests": False,
+        "required_association_id": False,
+        "enable_challenger_analysis": False,
     },
 )
 def deployment_monitoring_settings(deployment_id="646fcfe9b01540a797f224b3"):
@@ -59,13 +60,12 @@ def deployment_monitoring_settings(deployment_id="646fcfe9b01540a797f224b3"):
         print(f"settings:{str(model_monitoring_settings_after)}")
 
         settings_changed = {
-            a: model_monitoring_settings_after[a]
-            for a in model_monitoring_settings_after
-            if model_monitoring_settings_after[a] != model_monitoring_settings_before[a]
+            setting: model_monitoring_settings_after[setting]
+            for setting in model_monitoring_settings_after
+            if model_monitoring_settings_after[setting] != model_monitoring_settings_before[setting]
         }
 
         print(f"settings_changed:{str(settings_changed)}")
-
 
         total_predictions = 10
         return total_predictions

--- a/datarobot_provider/example_dags/deployment_update_monitoring_settings_dag.py
+++ b/datarobot_provider/example_dags/deployment_update_monitoring_settings_dag.py
@@ -1,0 +1,89 @@
+# Copyright 2023 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+from datetime import datetime
+
+from airflow.decorators import dag
+from airflow.decorators import task
+
+from datarobot_provider.operators.monitoring import (
+    UpdateMonitoringSettingsOperator,
+    GetMonitoringSettingsOperator,
+)
+
+
+@dag(
+    schedule=None,
+    start_date=datetime(2023, 1, 1),
+    tags=['example', 'mlops'],
+    # Default json config example:
+    params={
+        "target_drift_enabled": False,
+        "feature_drift_enabled": True,
+        "association_id_column": ["id"],
+        "required_association_id_in_prediction_requests": False,
+    },
+)
+def deployment_monitoring_settings(deployment_id="646fcfe9b01540a797f224b3"):
+    get_monitoring_settings_before_op = GetMonitoringSettingsOperator(
+        task_id="get_monitoring_settings_before",
+        # you can pass deployment_id from previous operator here:
+        deployment_id=deployment_id,
+    )
+
+    update_monitoring_settings_op = UpdateMonitoringSettingsOperator(
+        task_id="update_monitoring_settings",
+        # you can pass deployment_id from previous operator here:
+        deployment_id=deployment_id,
+    )
+
+    get_monitoring_settings_after_op = GetMonitoringSettingsOperator(
+        task_id="get_monitoring_settings_after",
+        # you can pass deployment_id from previous operator here:
+        deployment_id=deployment_id,
+    )
+
+    @task(task_id="example_processing_python")
+    def monitoring_settings_processing(
+        model_monitoring_settings_before, model_monitoring_settings_after
+    ):
+        """Example of custom logic based on monitoring_settings from the deployment."""
+
+        # Put your service stat processing logic here:
+
+        print(f"settings:{str(model_monitoring_settings_before)}")
+        print(f"settings:{str(model_monitoring_settings_after)}")
+
+        settings_changed = {
+            a: model_monitoring_settings_after[a]
+            for a in model_monitoring_settings_after
+            if model_monitoring_settings_after[a] != model_monitoring_settings_before[a]
+        }
+
+        print(f"settings_changed:{str(settings_changed)}")
+
+
+        total_predictions = 10
+        return total_predictions
+
+    example_service_stat_processing = monitoring_settings_processing(
+        model_monitoring_settings_before=get_monitoring_settings_before_op.output,
+        model_monitoring_settings_after=get_monitoring_settings_after_op.output,
+    )
+
+    (
+        get_monitoring_settings_before_op
+        >> update_monitoring_settings_op
+        >> get_monitoring_settings_after_op
+        >> example_service_stat_processing
+    )
+
+
+deployment_monitoring_settings_dag = deployment_monitoring_settings()
+
+if __name__ == "__main__":
+    deployment_monitoring_settings_dag.test()

--- a/datarobot_provider/operators/monitoring.py
+++ b/datarobot_provider/operators/monitoring.py
@@ -200,7 +200,7 @@ class UpdateMonitoringSettingsOperator(BaseOperator):
                 "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
             )
 
-    def execute(self, context: Dict[str, Any]) -> List[dict]:
+    def execute(self, context: Dict[str, Any]) -> None:
         # Initialize DataRobot client
         DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
 
@@ -260,11 +260,17 @@ class UpdateMonitoringSettingsOperator(BaseOperator):
                 f"No need to update association_id settings for deployment_id={self.deployment_id}"
             )
 
-        current_predictions_data_collection_settings = deployment.predictions_data_collection_settings()
-        predictions_data_collection_settings = context["params"].get(
-            "enable_challenger_analysis", current_predictions_data_collection_settings["enabled"]
+        current_predictions_data_collection_settings = (
+            deployment.get_predictions_data_collection_settings()
         )
-        if predictions_data_collection_settings != current_predictions_data_collection_settings["enabled"]:
+        predictions_data_collection_settings = context["params"].get(
+            "predictions_data_collection_enabled",
+            current_predictions_data_collection_settings["enabled"],
+        )
+        if (
+            predictions_data_collection_settings
+            != current_predictions_data_collection_settings["enabled"]
+        ):
             deployment.update_predictions_data_collection_settings(
                 enabled=predictions_data_collection_settings,
             )
@@ -275,5 +281,3 @@ class UpdateMonitoringSettingsOperator(BaseOperator):
             self.log.info(
                 f"No need to update predictions data collection settings for deployment_id={self.deployment_id}"
             )
-
-        #segment_analysis_settings = deployment.get_segment_analysis_settings()

--- a/datarobot_provider/operators/monitoring.py
+++ b/datarobot_provider/operators/monitoring.py
@@ -114,3 +114,164 @@ class GetAccuracyOperator(BaseOperator):
         accuracy_params = context["params"].get("accuracy", {})
         accuracy = deployment.get_accuracy(**accuracy_params)
         return _serialize_metrics(accuracy)
+
+
+class GetMonitoringSettingsOperator(BaseOperator):
+    """
+    Get monitoring settings for deployment.
+
+    :param deployment_id: DataRobot deployment ID
+    :type deployment_id: str
+    :param datarobot_conn_id: Connection ID, defaults to `datarobot_default`
+    :type datarobot_conn_id: str, optional
+    """
+
+    # Specify the arguments that are allowed to parse with jinja templating
+    template_fields: Iterable[str] = ["deployment_id"]
+    template_fields_renderers: Dict[str, str] = {}
+    template_ext: Iterable[str] = ()
+    ui_color = "#f4a460"
+
+    def __init__(
+        self,
+        *,
+        deployment_id: str,
+        datarobot_conn_id: str = "datarobot_default",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.deployment_id = deployment_id
+        self.datarobot_conn_id = datarobot_conn_id
+        if kwargs.get("xcom_push") is not None:
+            raise AirflowException(
+                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
+            )
+
+    def execute(self, context: Dict[str, Any]) -> List[dict]:
+        # Initialize DataRobot client
+        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
+
+        self.log.info(f"Get Deployment for deployment_id={self.deployment_id}")
+        deployment = dr.Deployment.get(deployment_id=self.deployment_id)
+
+        drift_tracking_settings = deployment.get_drift_tracking_settings()
+        association_id_settings = deployment.get_association_id_settings()
+        prediction_warning_settings = deployment.get_prediction_warning_settings()
+        predictions_data_collection_settings = deployment.get_predictions_data_collection_settings()
+        segment_analysis_settings = deployment.get_segment_analysis_settings()
+
+        monitoring_settings = {
+            "drift_tracking_settings": drift_tracking_settings,
+            "association_id_settings": association_id_settings,
+            "prediction_warning_settings": prediction_warning_settings,
+            "predictions_data_collection_settings": predictions_data_collection_settings,
+            "segment_analysis_settings": segment_analysis_settings,
+        }
+
+        return monitoring_settings
+
+
+class UpdateMonitoringSettingsOperator(BaseOperator):
+    """
+    Update monitoring settings for deployment.
+
+    :param deployment_id: DataRobot deployment ID
+    :type deployment_id: str
+    :param datarobot_conn_id: Connection ID, defaults to `datarobot_default`
+    :type datarobot_conn_id: str, optional
+    """
+
+    # Specify the arguments that are allowed to parse with jinja templating
+    template_fields: Iterable[str] = ["deployment_id"]
+    template_fields_renderers: Dict[str, str] = {}
+    template_ext: Iterable[str] = ()
+    ui_color = "#f4a460"
+
+    def __init__(
+        self,
+        *,
+        deployment_id: str,
+        monitoring_settings: dict = None,
+        datarobot_conn_id: str = "datarobot_default",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.deployment_id = deployment_id
+        self.monitoring_settings = (monitoring_settings,)
+        self.datarobot_conn_id = datarobot_conn_id
+        if kwargs.get("xcom_push") is not None:
+            raise AirflowException(
+                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
+            )
+
+    def execute(self, context: Dict[str, Any]) -> List[dict]:
+        # Initialize DataRobot client
+        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
+
+        self.log.info(f"Getting Deployment for deployment_id={self.deployment_id}")
+        deployment = dr.Deployment.get(deployment_id=self.deployment_id)
+
+        current_drift_tracking_settings = deployment.get_drift_tracking_settings()
+
+        target_drift_enabled = context["params"].get(
+            "target_drift_enabled", current_drift_tracking_settings['target_drift']['enabled']
+        )
+        feature_drift_enabled = context["params"].get(
+            "feature_drift_enabled", current_drift_tracking_settings['feature_drift']['enabled']
+        )
+
+        if (target_drift_enabled != current_drift_tracking_settings['target_drift']['enabled']) or (
+            feature_drift_enabled != current_drift_tracking_settings['feature_drift']['enabled']
+        ):
+            deployment.update_drift_tracking_settings(
+                target_drift_enabled=target_drift_enabled,
+                feature_drift_enabled=feature_drift_enabled,
+            )
+            self.log.info(
+                f"Deployment drift settings updated for deployment_id={self.deployment_id}"
+            )
+        else:
+            self.log.info(
+                f"No need to update drift settings for deployment_id={self.deployment_id}"
+            )
+
+        current_association_id_settings = deployment.get_association_id_settings()
+
+        association_id_column = context["params"].get(
+            "association_id_column", current_association_id_settings['column_names']
+        )
+        required_in_prediction_requests = context["params"].get(
+            "required_association_id_in_prediction_requests",
+            current_association_id_settings['required_in_prediction_requests'],
+        )
+
+        if (association_id_column != current_association_id_settings['column_names']) or (
+            required_in_prediction_requests
+            != current_association_id_settings['required_in_prediction_requests']
+        ):
+            deployment.update_association_id_settings(
+                column_names=association_id_column,
+                required_in_prediction_requests=required_in_prediction_requests,
+            )
+            self.log.info(
+                f"Deployment association_id settings updated for deployment_id={self.deployment_id}"
+            )
+        else:
+            self.log.info(
+                f"No need to update association_id settings for deployment_id={self.deployment_id}"
+            )
+
+        if "enable_challenger_analysis" in context["params"]:
+            current_challenger_models_settings = deployment.get_challenger_models_settings()
+            challenger_models_settings = ""
+            if association_id_column != current_challenger_models_settings[""]:
+                deployment.update_challenger_models_settings(
+                    challenger_models_enabled=challenger_models_settings,
+                )
+                self.log.info(
+                    f"Deployment challenger analysis settings updated for deployment_id={self.deployment_id}"
+                )
+            else:
+                self.log.info(
+                    f"No need to update challenger analysis settings for deployment_id={self.deployment_id}"
+                )

--- a/datarobot_provider/operators/monitoring.py
+++ b/datarobot_provider/operators/monitoring.py
@@ -147,7 +147,7 @@ class GetMonitoringSettingsOperator(BaseOperator):
                 "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
             )
 
-    def execute(self, context: Dict[str, Any]) -> List[dict]:
+    def execute(self, context: Dict[str, Any]) -> dict:
         # Initialize DataRobot client
         DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
 

--- a/tests/unit/operators/test_ai_catalog.py
+++ b/tests/unit/operators/test_ai_catalog.py
@@ -9,10 +9,10 @@
 import datarobot as dr
 
 from datarobot_provider.operators.ai_catalog import CreateDatasetFromDataStoreOperator
-from datarobot_provider.operators.ai_catalog import UpdateDatasetFromFileOperator
-from datarobot_provider.operators.ai_catalog import UploadDatasetOperator
 from datarobot_provider.operators.ai_catalog import CreateDatasetVersionOperator
 from datarobot_provider.operators.ai_catalog import CreateOrUpdateDataSourceOperator
+from datarobot_provider.operators.ai_catalog import UpdateDatasetFromFileOperator
+from datarobot_provider.operators.ai_catalog import UploadDatasetOperator
 
 
 def test_operator_upload_dataset(mocker):

--- a/tests/unit/operators/test_monitoring.py
+++ b/tests/unit/operators/test_monitoring.py
@@ -9,11 +9,13 @@ from datetime import datetime
 
 import datarobot as dr
 import pytest
-from datarobot.models.deployment import ServiceStats, Accuracy
-from datarobot.models.deployment.deployment import DriftTrackingSettings
+from datarobot.models.deployment import Accuracy
+from datarobot.models.deployment import ServiceStats
 
-from datarobot_provider.operators.monitoring import GetAccuracyOperator, GetMonitoringSettingsOperator
+from datarobot_provider.operators.monitoring import GetAccuracyOperator
+from datarobot_provider.operators.monitoring import GetMonitoringSettingsOperator
 from datarobot_provider.operators.monitoring import GetServiceStatsOperator
+from datarobot_provider.operators.monitoring import UpdateMonitoringSettingsOperator
 from datarobot_provider.operators.monitoring import _serialize_metrics
 
 
@@ -162,35 +164,167 @@ def test_operator_get_accuracy_with_params(mocker, accuracy_details):
     assert accuracy_result == expected_accuracy
     get_accuracy_mock.assert_called_with(**accuracy_params["accuracy"])
 
+
+@pytest.fixture
+def monitoring_settings_details():
+    return {
+        "drift_tracking_settings": {
+            'target_drift': {'enabled': False},
+            'feature_drift': {'enabled': False},
+        },
+        "association_id_settings": {
+            'column_names': ['id'],
+            'required_in_prediction_requests': False,
+        },
+        "predictions_data_collection_settings": {'enabled': False},
+    }
+
+
 def test_operator_get_monitoring_settings(mocker, monitoring_settings_details):
     deployment_id = "deployment-id"
 
-    current_drift_tracking_settings = {
-            'target_drift': {'enabled': False},
-            'feature_drift': {'enabled': True}
-    }
-
-    updated_drift_tracking_settings = {
-            'target_drift': {'enabled': False},
-            'feature_drift': {'enabled': True}
-    }
-
-    monitoring_settings = {
-        "drift_tracking_settings": {
-            'target_drift': {'enabled': False},
-            'feature_drift': {'enabled': True}
-        }
-    }
-
-    expected_monitoring_settings = _serialize_metrics(monitoring_settings)
-
     mocker.patch.object(dr.Deployment, "get", return_value=dr.Deployment(deployment_id))
-    get_drift_tracking_settings_mock = mocker.patch.object(dr.Deployment, "get_drift_tracking_settings", return_value=current_drift_tracking_settings)
-    update_drift_tracking_settings_mock = mocker.patch.object(dr.Deployment, "update_drift_tracking_settings")
 
-    operator = GetMonitoringSettingsOperator(task_id="get_monitoring_settings", deployment_id="deployment-id")
-    monitoring_settings_params = {}
+    mocker.patch.object(
+        dr.Deployment,
+        "get_drift_tracking_settings",
+        return_value=monitoring_settings_details["drift_tracking_settings"],
+    )
+
+    mocker.patch.object(
+        dr.Deployment,
+        "get_association_id_settings",
+        return_value=monitoring_settings_details["association_id_settings"],
+    )
+
+    mocker.patch.object(
+        dr.Deployment,
+        "get_predictions_data_collection_settings",
+        return_value=monitoring_settings_details["predictions_data_collection_settings"],
+    )
+
+    operator = GetMonitoringSettingsOperator(
+        task_id="get_monitoring_settings", deployment_id="deployment-id"
+    )
+
     monitoring_settings_result = operator.execute(context={'params': {}})
 
-    #assert monitoring_settings_result == expected_monitoring_settings
-    #get_accuracy_mock.assert_called_with(**accuracy_params)
+    assert monitoring_settings_result == monitoring_settings_details
+
+
+def test_operator_update_monitoring_settings(mocker, monitoring_settings_details):
+    deployment_id = "deployment-id"
+
+    monitoring_settings_params = {
+        "target_drift_enabled": True,
+        "feature_drift_enabled": True,
+        "association_id_column": ["association_id"],
+        "required_association_id": True,
+        "predictions_data_collection_enabled": True,
+    }
+
+    mocker.patch.object(dr.Deployment, "get", return_value=dr.Deployment(deployment_id))
+
+    mocker.patch.object(
+        dr.Deployment,
+        "get_drift_tracking_settings",
+        return_value=monitoring_settings_details["drift_tracking_settings"],
+    )
+
+    mocker.patch.object(
+        dr.Deployment,
+        "get_association_id_settings",
+        return_value=monitoring_settings_details["association_id_settings"],
+    )
+
+    mocker.patch.object(
+        dr.Deployment,
+        "get_predictions_data_collection_settings",
+        return_value=monitoring_settings_details["predictions_data_collection_settings"],
+    )
+
+    update_drift_tracking_settings_mock = mocker.patch.object(
+        dr.Deployment, "update_drift_tracking_settings"
+    )
+
+    update_association_id_settings_mock = mocker.patch.object(
+        dr.Deployment, "update_association_id_settings"
+    )
+
+    update_predictions_data_collection_settings_mock = mocker.patch.object(
+        dr.Deployment, "update_predictions_data_collection_settings", return_value=None
+    )
+
+    operator = UpdateMonitoringSettingsOperator(
+        task_id="update_monitoring_settings", deployment_id="deployment-id"
+    )
+
+    operator.execute(context={'params': monitoring_settings_params})
+
+    update_drift_tracking_settings_mock.assert_called_with(
+        target_drift_enabled=monitoring_settings_params['target_drift_enabled'],
+        feature_drift_enabled=monitoring_settings_params['feature_drift_enabled'],
+    )
+
+    update_association_id_settings_mock.assert_called_with(
+        column_names=monitoring_settings_params['association_id_column'],
+        required_in_prediction_requests=monitoring_settings_params['required_association_id'],
+    )
+
+    update_predictions_data_collection_settings_mock.assert_called_with(
+        enabled=monitoring_settings_params['predictions_data_collection_enabled']
+    )
+
+
+def test_operator_no_need_update_monitoring_settings(mocker, monitoring_settings_details):
+    deployment_id = "deployment-id"
+
+    monitoring_settings_params = {
+        "target_drift_enabled": False,
+        "feature_drift_enabled": False,
+        "association_id_column": ["id"],
+        "required_association_id": False,
+        "predictions_data_collection_enabled": False,
+    }
+
+    mocker.patch.object(dr.Deployment, "get", return_value=dr.Deployment(deployment_id))
+
+    mocker.patch.object(
+        dr.Deployment,
+        "get_drift_tracking_settings",
+        return_value=monitoring_settings_details["drift_tracking_settings"],
+    )
+
+    mocker.patch.object(
+        dr.Deployment,
+        "get_association_id_settings",
+        return_value=monitoring_settings_details["association_id_settings"],
+    )
+
+    mocker.patch.object(
+        dr.Deployment,
+        "get_predictions_data_collection_settings",
+        return_value=monitoring_settings_details["predictions_data_collection_settings"],
+    )
+
+    update_drift_tracking_settings_mock = mocker.patch.object(
+        dr.Deployment, "update_drift_tracking_settings"
+    )
+
+    update_association_id_settings_mock = mocker.patch.object(
+        dr.Deployment, "update_association_id_settings"
+    )
+
+    update_predictions_data_collection_settings_mock = mocker.patch.object(
+        dr.Deployment, "update_predictions_data_collection_settings", return_value=None
+    )
+
+    operator = UpdateMonitoringSettingsOperator(
+        task_id="update_monitoring_settings", deployment_id="deployment-id"
+    )
+
+    operator.execute(context={'params': monitoring_settings_params})
+
+    update_drift_tracking_settings_mock.assert_not_called()
+    update_association_id_settings_mock.assert_not_called()
+    update_predictions_data_collection_settings_mock.assert_not_called()

--- a/tests/unit/operators/test_monitoring.py
+++ b/tests/unit/operators/test_monitoring.py
@@ -10,8 +10,9 @@ from datetime import datetime
 import datarobot as dr
 import pytest
 from datarobot.models.deployment import ServiceStats, Accuracy
+from datarobot.models.deployment.deployment import DriftTrackingSettings
 
-from datarobot_provider.operators.monitoring import GetAccuracyOperator
+from datarobot_provider.operators.monitoring import GetAccuracyOperator, GetMonitoringSettingsOperator
 from datarobot_provider.operators.monitoring import GetServiceStatsOperator
 from datarobot_provider.operators.monitoring import _serialize_metrics
 
@@ -160,3 +161,36 @@ def test_operator_get_accuracy_with_params(mocker, accuracy_details):
 
     assert accuracy_result == expected_accuracy
     get_accuracy_mock.assert_called_with(**accuracy_params["accuracy"])
+
+def test_operator_get_monitoring_settings(mocker, monitoring_settings_details):
+    deployment_id = "deployment-id"
+
+    current_drift_tracking_settings = {
+            'target_drift': {'enabled': False},
+            'feature_drift': {'enabled': True}
+    }
+
+    updated_drift_tracking_settings = {
+            'target_drift': {'enabled': False},
+            'feature_drift': {'enabled': True}
+    }
+
+    monitoring_settings = {
+        "drift_tracking_settings": {
+            'target_drift': {'enabled': False},
+            'feature_drift': {'enabled': True}
+        }
+    }
+
+    expected_monitoring_settings = _serialize_metrics(monitoring_settings)
+
+    mocker.patch.object(dr.Deployment, "get", return_value=dr.Deployment(deployment_id))
+    get_drift_tracking_settings_mock = mocker.patch.object(dr.Deployment, "get_drift_tracking_settings", return_value=current_drift_tracking_settings)
+    update_drift_tracking_settings_mock = mocker.patch.object(dr.Deployment, "update_drift_tracking_settings")
+
+    operator = GetMonitoringSettingsOperator(task_id="get_monitoring_settings", deployment_id="deployment-id")
+    monitoring_settings_params = {}
+    monitoring_settings_result = operator.execute(context={'params': {}})
+
+    #assert monitoring_settings_result == expected_monitoring_settings
+    #get_accuracy_mock.assert_called_with(**accuracy_params)


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Added GetMonitoringSettingsOperator and UpdateMonitoringSettingsOperator Airflow operators and simple DAG example

## Rationale
Users should be able to get and configure monitoring setting using Airflow Operators
