### PR TITLE
[AGENT-4596] changed to datarobot-early-access

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 apache-airflow>=2.3.0
 black>=22.12.0
-datarobot>=3.1.1
+datarobot-early-access>=3.2.0.2023.6.19
 flake8>=4.0.1
 isort>=5.11.4
 mypy>=0.931

--- a/tests/unit/operators/test_datarobot.py
+++ b/tests/unit/operators/test_datarobot.py
@@ -10,8 +10,8 @@ from datetime import datetime
 import datarobot as dr
 import pytest
 from airflow.exceptions import AirflowFailException
-from datarobot.models.data_drift import FeatureDrift
-from datarobot.models.data_drift import TargetDrift
+from datarobot.models.deployment.data_drift import FeatureDrift
+from datarobot.models.deployment.data_drift import TargetDrift
 
 from datarobot_provider.operators.datarobot import CreateProjectOperator
 from datarobot_provider.operators.datarobot import DeployModelOperator


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
temporary switched to “datarobot-early-access>=3.2.0.2023.6.19” to pass tests

## Rationale
