### PR TITLE
[AGENT-4491] Implement Airflow Operator to turn on segmentation, bias and fairness thresholds

### DIFF
--- a/datarobot_provider/example_dags/deployment_update_segment_analysis_settings_dag.py
+++ b/datarobot_provider/example_dags/deployment_update_segment_analysis_settings_dag.py
@@ -1,0 +1,122 @@
+# Copyright 2023 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+from datetime import datetime
+
+from airflow.decorators import dag
+from airflow.decorators import task
+
+from datarobot_provider.operators.bias_and_fairness import (
+    GetBiasAndFairnessSettingsOperator,
+    UpdateBiasAndFairnessSettingsOperator,
+)
+from datarobot_provider.operators.segment_analysis import (
+    GetSegmentAnalysisSettingsOperator,
+    UpdateSegmentAnalysisSettingsOperator,
+)
+
+
+@dag(
+    schedule=None,
+    start_date=datetime(2023, 1, 1),
+    tags=['example', 'mlops'],
+    # Default json config example:
+    params={
+        'segment_analysis_enabled': True,
+        'segment_analysis_attributes': ['race', 'gender'],
+        'protected_features': ['gender'],
+        'preferable_target_value': 'True',
+        'fairness_metrics_set': 'equalParity',
+        'fairness_threshold': 0.1
+    },
+)
+def deployment_segment_analysis_settings(deployment_id='641db050023431666af91a90'):
+    if not deployment_id:
+        raise ValueError("Invalid or missing `deployment_id` value")
+    get_segment_analysis_settings_before_op = GetSegmentAnalysisSettingsOperator(
+        task_id="get_segment_analysis_settings_before",
+        # you can pass deployment_id from previous operator here:
+        deployment_id=deployment_id,
+    )
+
+    get_bias_and_fairness_settings_before_op = GetBiasAndFairnessSettingsOperator(
+        task_id="get_bias_and_fairness_settings_before",
+        # you can pass deployment_id from previous operator here:
+        deployment_id=deployment_id,
+    )
+
+    update_segment_analysis_settings_op = UpdateSegmentAnalysisSettingsOperator(
+        task_id="update_segment_analysis_settings",
+        # you can pass deployment_id from previous operator here:
+        deployment_id=deployment_id,
+    )
+
+    update_bias_and_fairness_settings_op = UpdateBiasAndFairnessSettingsOperator(
+        task_id="update_bias_and_fairness_settings",
+        # you can pass deployment_id from previous operator here:
+        deployment_id=deployment_id,
+    )
+
+    get_segment_analysis_settings_after_op = GetSegmentAnalysisSettingsOperator(
+        task_id="get_segment_analysis_after",
+        # you can pass deployment_id from previous operator here:
+        deployment_id=deployment_id,
+    )
+
+    get_bias_and_fairness_settings_after_op = GetBiasAndFairnessSettingsOperator(
+        task_id="get_bias_and_fairness_settings_after",
+        # you can pass deployment_id from previous operator here:
+        deployment_id=deployment_id,
+    )
+
+    @task(task_id="example_processing_python")
+    def settings_processing(
+        segment_analysis_settings_before,
+        segment_analysis_settings_after,
+        bias_and_fairness_settings_before,
+        bias_and_fairness_settings_after,
+    ):
+        """Example of custom logic based on segment analysis settings from the deployment."""
+
+        # Put your service stat processing logic here:
+
+        segment_analysis_settings_changed = {
+            setting: segment_analysis_settings_after[setting]
+            for setting in segment_analysis_settings_after
+            if segment_analysis_settings_after[setting] != segment_analysis_settings_before[setting]
+        }
+
+        bias_and_fairness_settings_changed = {
+            setting: bias_and_fairness_settings_after[setting]
+            for setting in bias_and_fairness_settings_after
+            if bias_and_fairness_settings_after[setting] != bias_and_fairness_settings_before[setting]
+        }
+
+        return segment_analysis_settings_changed, bias_and_fairness_settings_changed
+
+    example_service_stat_processing = settings_processing(
+        segment_analysis_settings_before=get_segment_analysis_settings_before_op.output,
+        segment_analysis_settings_after=get_segment_analysis_settings_after_op.output,
+        bias_and_fairness_settings_before=get_bias_and_fairness_settings_before_op.output,
+        bias_and_fairness_settings_after=get_bias_and_fairness_settings_after_op.output,
+    )
+
+    (
+        get_segment_analysis_settings_before_op
+        >> get_bias_and_fairness_settings_before_op
+        >> update_segment_analysis_settings_op
+        >> update_bias_and_fairness_settings_op
+        >> get_segment_analysis_settings_after_op
+        >> get_bias_and_fairness_settings_after_op
+        >> example_service_stat_processing
+    )
+
+
+deployment_segment_analysis_dag = deployment_segment_analysis_settings()
+
+if __name__ == "__main__":
+    deployment_segment_analysis_dag.test()

--- a/datarobot_provider/example_dags/deployment_update_segment_analysis_settings_dag.py
+++ b/datarobot_provider/example_dags/deployment_update_segment_analysis_settings_dag.py
@@ -30,7 +30,7 @@ from datarobot_provider.operators.segment_analysis import UpdateSegmentAnalysisS
         'fairness_threshold': 0.1,
     },
 )
-def deployment_segment_analysis_settings(deployment_id='641db050023431666af91a90'):
+def deployment_segment_analysis_settings(deployment_id=None):
     if not deployment_id:
         raise ValueError("Invalid or missing `deployment_id` value")
     get_segment_analysis_settings_before_op = GetSegmentAnalysisSettingsOperator(

--- a/datarobot_provider/example_dags/deployment_update_segment_analysis_settings_dag.py
+++ b/datarobot_provider/example_dags/deployment_update_segment_analysis_settings_dag.py
@@ -10,14 +10,10 @@ from datetime import datetime
 from airflow.decorators import dag
 from airflow.decorators import task
 
-from datarobot_provider.operators.bias_and_fairness import (
-    GetBiasAndFairnessSettingsOperator,
-    UpdateBiasAndFairnessSettingsOperator,
-)
-from datarobot_provider.operators.segment_analysis import (
-    GetSegmentAnalysisSettingsOperator,
-    UpdateSegmentAnalysisSettingsOperator,
-)
+from datarobot_provider.operators.bias_and_fairness import GetBiasAndFairnessSettingsOperator
+from datarobot_provider.operators.bias_and_fairness import UpdateBiasAndFairnessSettingsOperator
+from datarobot_provider.operators.segment_analysis import GetSegmentAnalysisSettingsOperator
+from datarobot_provider.operators.segment_analysis import UpdateSegmentAnalysisSettingsOperator
 
 
 @dag(

--- a/datarobot_provider/example_dags/deployment_update_segment_analysis_settings_dag.py
+++ b/datarobot_provider/example_dags/deployment_update_segment_analysis_settings_dag.py
@@ -31,7 +31,7 @@ from datarobot_provider.operators.segment_analysis import (
         'protected_features': ['gender'],
         'preferable_target_value': 'True',
         'fairness_metrics_set': 'equalParity',
-        'fairness_threshold': 0.1
+        'fairness_threshold': 0.1,
     },
 )
 def deployment_segment_analysis_settings(deployment_id='641db050023431666af91a90'):
@@ -93,7 +93,8 @@ def deployment_segment_analysis_settings(deployment_id='641db050023431666af91a90
         bias_and_fairness_settings_changed = {
             setting: bias_and_fairness_settings_after[setting]
             for setting in bias_and_fairness_settings_after
-            if bias_and_fairness_settings_after[setting] != bias_and_fairness_settings_before[setting]
+            if bias_and_fairness_settings_after[setting]
+            != bias_and_fairness_settings_before[setting]
         }
 
         return segment_analysis_settings_changed, bias_and_fairness_settings_changed

--- a/datarobot_provider/operators/bias_and_fairness.py
+++ b/datarobot_provider/operators/bias_and_fairness.py
@@ -100,14 +100,12 @@ class UpdateBiasAndFairnessSettingsOperator(BaseOperator):
         current_bias_and_fairness_settings = deployment.get_bias_and_fairness_settings()
 
         if current_bias_and_fairness_settings is None:
-            current_bias_and_fairness_settings = dict.fromkeys(
-                [
-                    'protected_features',
-                    'fairness_metrics_set',
-                    'fairness_threshold',
-                    'preferable_target_value',
-                ]
-            )
+            current_bias_and_fairness_settings = {
+                "protected_features": None,
+                "fairness_metrics_set": None,
+                "fairness_threshold": None,
+                "preferable_target_value": None,
+            }
 
         protected_features = context["params"].get(
             "protected_features", current_bias_and_fairness_settings['protected_features']

--- a/datarobot_provider/operators/bias_and_fairness.py
+++ b/datarobot_provider/operators/bias_and_fairness.py
@@ -1,0 +1,148 @@
+# Copyright 2023 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+from typing import Any
+from typing import Dict
+from typing import Iterable
+
+import datarobot as dr
+from airflow.exceptions import AirflowException
+from airflow.models import BaseOperator
+
+from datarobot_provider.hooks.datarobot import DataRobotHook
+
+
+class GetBiasAndFairnessSettingsOperator(BaseOperator):
+    """
+    Get Bias And Fairness settings for deployment.
+
+    :param deployment_id: DataRobot deployment ID
+    :type deployment_id: str
+    :param datarobot_conn_id: Connection ID, defaults to `datarobot_default`
+    :type datarobot_conn_id: str, optional
+    """
+
+    # Specify the arguments that are allowed to parse with jinja templating
+    template_fields: Iterable[str] = ["deployment_id"]
+    template_fields_renderers: Dict[str, str] = {}
+    template_ext: Iterable[str] = ()
+    ui_color = "#f4a460"
+
+    def __init__(
+        self,
+        *,
+        deployment_id: str,
+        datarobot_conn_id: str = "datarobot_default",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.deployment_id = deployment_id
+        self.datarobot_conn_id = datarobot_conn_id
+        if kwargs.get("xcom_push") is not None:
+            raise AirflowException(
+                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
+            )
+
+    def execute(self, context: Dict[str, Any]) -> dict:
+        # Initialize DataRobot client
+        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
+
+        self.log.info(f"Get Deployment for deployment_id={self.deployment_id}")
+        deployment = dr.Deployment.get(deployment_id=self.deployment_id)
+
+        bias_and_fairness_settings = deployment.get_bias_and_fairness_settings()
+
+        return bias_and_fairness_settings
+
+
+class UpdateBiasAndFairnessSettingsOperator(BaseOperator):
+    """
+    Update Bias And Fairness settings for deployment.
+
+    :param deployment_id: DataRobot deployment ID
+    :type deployment_id: str
+    :param datarobot_conn_id: Connection ID, defaults to `datarobot_default`
+    :type datarobot_conn_id: str, optional
+    """
+
+    # Specify the arguments that are allowed to parse with jinja templating
+    template_fields: Iterable[str] = ["deployment_id"]
+    template_fields_renderers: Dict[str, str] = {}
+    template_ext: Iterable[str] = ()
+    ui_color = "#f4a460"
+
+    def __init__(
+        self,
+        *,
+        deployment_id: str,
+        datarobot_conn_id: str = "datarobot_default",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.deployment_id = deployment_id
+        self.datarobot_conn_id = datarobot_conn_id
+        if kwargs.get("xcom_push") is not None:
+            raise AirflowException(
+                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
+            )
+
+    def execute(self, context: Dict[str, Any]) -> None:
+        # Initialize DataRobot client
+        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
+
+        self.log.info(f"Getting Deployment for deployment_id={self.deployment_id}")
+        deployment = dr.Deployment.get(deployment_id=self.deployment_id)
+
+        current_bias_and_fairness_settings = deployment.get_bias_and_fairness_settings()
+
+        if current_bias_and_fairness_settings is None:
+            current_bias_and_fairness_settings = dict.fromkeys(
+                [
+                    'protected_features',
+                    'fairness_metrics_set',
+                    'fairness_threshold',
+                    'preferable_target_value',
+                ]
+            )
+
+        protected_features = context["params"].get(
+            "protected_features", current_bias_and_fairness_settings['protected_features']
+        )
+
+        fairness_metrics_set = context["params"].get(
+            "fairness_metrics_set", current_bias_and_fairness_settings['fairness_metrics_set']
+        )
+
+        fairness_threshold = context["params"].get(
+            "fairness_threshold", current_bias_and_fairness_settings['fairness_threshold']
+        )
+
+        preferable_target_value = context["params"].get(
+            "preferable_target_value", current_bias_and_fairness_settings['preferable_target_value']
+        )
+
+        if (protected_features != current_bias_and_fairness_settings['protected_features']) or (
+            fairness_metrics_set != current_bias_and_fairness_settings['fairness_metrics_set']) or (
+            fairness_threshold != current_bias_and_fairness_settings['fairness_threshold']) or (
+            preferable_target_value != current_bias_and_fairness_settings['preferable_target_value']) or (
+        ):
+            self.log.debug(
+                f"Trying to update bias and fairness settings for deployment_id={self.deployment_id}"
+            )
+            deployment.update_bias_and_fairness_settings(
+                protected_features=protected_features,
+                fairness_metric_set=fairness_metrics_set,
+                fairness_threshold=fairness_threshold,
+                preferable_target_value=preferable_target_value,
+            )
+            self.log.info(
+                f"Deployment bias and fairness settings updated for deployment_id={self.deployment_id}"
+            )
+        else:
+            self.log.info(
+                f"No need to update bias and fairness settings for deployment_id={self.deployment_id}"
+            )

--- a/datarobot_provider/operators/bias_and_fairness.py
+++ b/datarobot_provider/operators/bias_and_fairness.py
@@ -131,7 +131,6 @@ class UpdateBiasAndFairnessSettingsOperator(BaseOperator):
                 preferable_target_value
                 != current_bias_and_fairness_settings['preferable_target_value']
             )
-            or ()
         ):
             self.log.debug(
                 f"Trying to update bias and fairness settings for deployment_id={self.deployment_id}"

--- a/datarobot_provider/operators/bias_and_fairness.py
+++ b/datarobot_provider/operators/bias_and_fairness.py
@@ -125,10 +125,15 @@ class UpdateBiasAndFairnessSettingsOperator(BaseOperator):
             "preferable_target_value", current_bias_and_fairness_settings['preferable_target_value']
         )
 
-        if (protected_features != current_bias_and_fairness_settings['protected_features']) or (
-            fairness_metrics_set != current_bias_and_fairness_settings['fairness_metrics_set']) or (
-            fairness_threshold != current_bias_and_fairness_settings['fairness_threshold']) or (
-            preferable_target_value != current_bias_and_fairness_settings['preferable_target_value']) or (
+        if (
+            (protected_features != current_bias_and_fairness_settings['protected_features'])
+            or (fairness_metrics_set != current_bias_and_fairness_settings['fairness_metrics_set'])
+            or (fairness_threshold != current_bias_and_fairness_settings['fairness_threshold'])
+            or (
+                preferable_target_value
+                != current_bias_and_fairness_settings['preferable_target_value']
+            )
+            or ()
         ):
             self.log.debug(
                 f"Trying to update bias and fairness settings for deployment_id={self.deployment_id}"

--- a/datarobot_provider/operators/segment_analysis.py
+++ b/datarobot_provider/operators/segment_analysis.py
@@ -1,0 +1,125 @@
+# Copyright 2023 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+from typing import Any
+from typing import Dict
+from typing import Iterable
+
+import datarobot as dr
+from airflow.exceptions import AirflowException
+from airflow.models import BaseOperator
+
+from datarobot_provider.hooks.datarobot import DataRobotHook
+
+
+class GetSegmentAnalysisSettingsOperator(BaseOperator):
+    """
+    Get segment analysis settings for deployment.
+
+    :param deployment_id: DataRobot deployment ID
+    :type deployment_id: str
+    :param datarobot_conn_id: Connection ID, defaults to `datarobot_default`
+    :type datarobot_conn_id: str, optional
+    """
+
+    # Specify the arguments that are allowed to parse with jinja templating
+    template_fields: Iterable[str] = ["deployment_id"]
+    template_fields_renderers: Dict[str, str] = {}
+    template_ext: Iterable[str] = ()
+    ui_color = "#f4a460"
+
+    def __init__(
+        self,
+        *,
+        deployment_id: str,
+        datarobot_conn_id: str = "datarobot_default",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.deployment_id = deployment_id
+        self.datarobot_conn_id = datarobot_conn_id
+        if kwargs.get("xcom_push") is not None:
+            raise AirflowException(
+                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
+            )
+
+    def execute(self, context: Dict[str, Any]) -> dict:
+        # Initialize DataRobot client
+        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
+
+        self.log.info(f"Get Deployment for deployment_id={self.deployment_id}")
+        deployment = dr.Deployment.get(deployment_id=self.deployment_id)
+
+        segment_analysis_settings = deployment.get_segment_analysis_settings()
+
+        return segment_analysis_settings
+
+
+class UpdateSegmentAnalysisSettingsOperator(BaseOperator):
+    """
+    Update segment analysis settings for deployment.
+
+    :param deployment_id: DataRobot deployment ID
+    :type deployment_id: str
+    :param datarobot_conn_id: Connection ID, defaults to `datarobot_default`
+    :type datarobot_conn_id: str, optional
+    """
+
+    # Specify the arguments that are allowed to parse with jinja templating
+    template_fields: Iterable[str] = ["deployment_id"]
+    template_fields_renderers: Dict[str, str] = {}
+    template_ext: Iterable[str] = ()
+    ui_color = "#f4a460"
+
+    def __init__(
+        self,
+        *,
+        deployment_id: str,
+        datarobot_conn_id: str = "datarobot_default",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.deployment_id = deployment_id
+        self.datarobot_conn_id = datarobot_conn_id
+        if kwargs.get("xcom_push") is not None:
+            raise AirflowException(
+                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
+            )
+
+    def execute(self, context: Dict[str, Any]) -> None:
+        # Initialize DataRobot client
+        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
+
+        self.log.info(f"Getting Deployment for deployment_id={self.deployment_id}")
+        deployment = dr.Deployment.get(deployment_id=self.deployment_id)
+
+        current_segment_analysis_settings = deployment.get_segment_analysis_settings()
+
+        segment_analysis_enabled = context["params"].get(
+            "segment_analysis_enabled", current_segment_analysis_settings['enabled']
+        )
+        segment_analysis_attributes = context["params"].get(
+            "segment_analysis_attributes", current_segment_analysis_settings['attributes']
+        )
+
+        if (segment_analysis_enabled != current_segment_analysis_settings['enabled']) or (
+            segment_analysis_attributes != current_segment_analysis_settings['attributes']
+        ):
+            self.log.debug(
+                f"Trying to update segment analysis settings for deployment_id={self.deployment_id}"
+            )
+            deployment.update_segment_analysis_settings(
+                segment_analysis_enabled=segment_analysis_enabled,
+                segment_analysis_attributes=segment_analysis_attributes,
+            )
+            self.log.info(
+                f"Deployment segment analysis settings updated for deployment_id={self.deployment_id}"
+            )
+        else:
+            self.log.info(
+                f"No need to update segment analysis settings for deployment_id={self.deployment_id}"
+            )

--- a/tests/unit/operators/test_bias_and_fairness.py
+++ b/tests/unit/operators/test_bias_and_fairness.py
@@ -5,15 +5,12 @@
 # This is proprietary source code of DataRobot, Inc. and its affiliates.
 #
 # Released under the terms of DataRobot Tool and Utility Agreement.
-from datetime import datetime
 
 import datarobot as dr
 import pytest
 
-from datarobot_provider.operators.bias_and_fairness import (
-    GetBiasAndFairnessSettingsOperator,
-    UpdateBiasAndFairnessSettingsOperator,
-)
+from datarobot_provider.operators.bias_and_fairness import GetBiasAndFairnessSettingsOperator
+from datarobot_provider.operators.bias_and_fairness import UpdateBiasAndFairnessSettingsOperator
 
 
 @pytest.fixture
@@ -81,7 +78,10 @@ def test_operator_update_bias_and_fairness_settings(mocker, bias_and_fairness_se
         preferable_target_value=bias_and_fairness_settings_params['preferable_target_value'],
     )
 
-def test_operator_no_need_update_bias_and_fairness_settings(mocker, bias_and_fairness_settings_details):
+
+def test_operator_no_need_update_bias_and_fairness_settings(
+    mocker, bias_and_fairness_settings_details
+):
     deployment_id = "deployment-id"
 
     bias_and_fairness_settings_params = {

--- a/tests/unit/operators/test_bias_and_fairness.py
+++ b/tests/unit/operators/test_bias_and_fairness.py
@@ -1,0 +1,112 @@
+# Copyright 2023 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+from datetime import datetime
+
+import datarobot as dr
+import pytest
+
+from datarobot_provider.operators.bias_and_fairness import (
+    GetBiasAndFairnessSettingsOperator,
+    UpdateBiasAndFairnessSettingsOperator,
+)
+
+
+@pytest.fixture
+def bias_and_fairness_settings_details():
+    return {
+        'protected_features': ['gender'],
+        'preferable_target_value': 'True',
+        'fairness_metrics_set': 'equalParity',
+        'fairness_threshold': 0.1,
+    }
+
+
+def test_operator_get_bias_and_fairness_settings(mocker, bias_and_fairness_settings_details):
+    deployment_id = "deployment-id"
+
+    mocker.patch.object(dr.Deployment, "get", return_value=dr.Deployment(deployment_id))
+
+    mocker.patch.object(
+        dr.Deployment,
+        "get_bias_and_fairness_settings",
+        return_value=bias_and_fairness_settings_details,
+    )
+
+    operator = GetBiasAndFairnessSettingsOperator(
+        task_id="get_bias_and_fairness_settings", deployment_id="deployment-id"
+    )
+
+    bias_and_fairness_settings_result = operator.execute(context={'params': {}})
+
+    assert bias_and_fairness_settings_result == bias_and_fairness_settings_details
+
+
+def test_operator_update_bias_and_fairness_settings(mocker, bias_and_fairness_settings_details):
+    deployment_id = "deployment-id"
+
+    bias_and_fairness_settings_params = {
+        'protected_features': ['gender'],
+        'preferable_target_value': 'True',
+        'fairness_metrics_set': 'equalParity',
+        'fairness_threshold': 0.25,
+    }
+
+    mocker.patch.object(dr.Deployment, "get", return_value=dr.Deployment(deployment_id))
+
+    mocker.patch.object(
+        dr.Deployment,
+        "get_bias_and_fairness_settings",
+        return_value=bias_and_fairness_settings_details,
+    )
+
+    update_bias_and_fairness_settings_mock = mocker.patch.object(
+        dr.Deployment, "update_bias_and_fairness_settings"
+    )
+
+    operator = UpdateBiasAndFairnessSettingsOperator(
+        task_id="update_bias_and_fairness_settings", deployment_id="deployment-id"
+    )
+
+    operator.execute(context={'params': bias_and_fairness_settings_params})
+
+    update_bias_and_fairness_settings_mock.assert_called_with(
+        protected_features=bias_and_fairness_settings_params['protected_features'],
+        fairness_metric_set=bias_and_fairness_settings_params['fairness_metrics_set'],
+        fairness_threshold=bias_and_fairness_settings_params['fairness_threshold'],
+        preferable_target_value=bias_and_fairness_settings_params['preferable_target_value'],
+    )
+
+def test_operator_no_need_update_bias_and_fairness_settings(mocker, bias_and_fairness_settings_details):
+    deployment_id = "deployment-id"
+
+    bias_and_fairness_settings_params = {
+        'protected_features': ['gender'],
+        'preferable_target_value': 'True',
+        'fairness_metrics_set': 'equalParity',
+        'fairness_threshold': 0.1,
+    }
+
+    mocker.patch.object(dr.Deployment, "get", return_value=dr.Deployment(deployment_id))
+
+    mocker.patch.object(
+        dr.Deployment,
+        "get_bias_and_fairness_settings",
+        return_value=bias_and_fairness_settings_details,
+    )
+
+    update_bias_and_fairness_settings_mock = mocker.patch.object(
+        dr.Deployment, "update_bias_and_fairness_settings"
+    )
+
+    operator = UpdateBiasAndFairnessSettingsOperator(
+        task_id="update_bias_and_fairness_settings", deployment_id="deployment-id"
+    )
+
+    operator.execute(context={'params': bias_and_fairness_settings_params})
+
+    update_bias_and_fairness_settings_mock.assert_not_called()

--- a/tests/unit/operators/test_segment_analysis.py
+++ b/tests/unit/operators/test_segment_analysis.py
@@ -1,0 +1,105 @@
+# Copyright 2023 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+from datetime import datetime
+
+import datarobot as dr
+import pytest
+
+from datarobot_provider.operators.segment_analysis import (
+    GetSegmentAnalysisSettingsOperator,
+    UpdateSegmentAnalysisSettingsOperator,
+)
+
+
+@pytest.fixture
+def segment_analysis_settings_details():
+    return {
+        'enabled': True,
+        'attributes': ['race'],
+    }
+
+
+def test_operator_get_segment_analysis_settings(mocker, segment_analysis_settings_details):
+    deployment_id = "deployment-id"
+
+    mocker.patch.object(dr.Deployment, "get", return_value=dr.Deployment(deployment_id))
+
+    mocker.patch.object(
+        dr.Deployment,
+        "get_segment_analysis_settings",
+        return_value=segment_analysis_settings_details,
+    )
+
+    operator = GetSegmentAnalysisSettingsOperator(
+        task_id="get_segment_analysis_settings", deployment_id="deployment-id"
+    )
+
+    segment_analysis_settings_result = operator.execute(context={'params': {}})
+
+    assert segment_analysis_settings_result == segment_analysis_settings_details
+
+
+def test_operator_update_segment_analysis_settings(mocker, segment_analysis_settings_details):
+    deployment_id = "deployment-id"
+
+    segment_analysis_settings_params = {
+        'segment_analysis_enabled': True,
+        'segment_analysis_attributes': ['race', 'gender'],
+    }
+
+    mocker.patch.object(dr.Deployment, "get", return_value=dr.Deployment(deployment_id))
+
+    mocker.patch.object(
+        dr.Deployment,
+        "get_segment_analysis_settings",
+        return_value=segment_analysis_settings_details,
+    )
+
+    update_segment_analysis_settings_mock = mocker.patch.object(
+        dr.Deployment, "update_segment_analysis_settings"
+    )
+
+    operator = UpdateSegmentAnalysisSettingsOperator(
+        task_id="update_segment_analysis_settings", deployment_id="deployment-id"
+    )
+
+    operator.execute(context={'params': segment_analysis_settings_params})
+
+    update_segment_analysis_settings_mock.assert_called_with(
+        segment_analysis_enabled=segment_analysis_settings_params['segment_analysis_enabled'],
+        segment_analysis_attributes=segment_analysis_settings_params['segment_analysis_attributes'],
+    )
+
+
+def test_operator_non_need_update_segment_analysis_settings(mocker, segment_analysis_settings_details):
+    deployment_id = "deployment-id"
+
+    segment_analysis_settings_params = {
+        'segment_analysis_enabled': True,
+        'segment_analysis_attributes': ['race'],
+    }
+
+    mocker.patch.object(dr.Deployment, "get", return_value=dr.Deployment(deployment_id))
+
+    mocker.patch.object(
+        dr.Deployment,
+        "get_segment_analysis_settings",
+        return_value=segment_analysis_settings_details,
+    )
+
+    update_segment_analysis_settings_mock = mocker.patch.object(
+        dr.Deployment, "update_segment_analysis_settings"
+    )
+
+    operator = UpdateSegmentAnalysisSettingsOperator(
+        task_id="update_segment_analysis_settings", deployment_id="deployment-id"
+    )
+
+    operator.execute(context={'params': segment_analysis_settings_params})
+
+    update_segment_analysis_settings_mock.assert_not_called()

--- a/tests/unit/operators/test_segment_analysis.py
+++ b/tests/unit/operators/test_segment_analysis.py
@@ -5,15 +5,12 @@
 # This is proprietary source code of DataRobot, Inc. and its affiliates.
 #
 # Released under the terms of DataRobot Tool and Utility Agreement.
-from datetime import datetime
 
 import datarobot as dr
 import pytest
 
-from datarobot_provider.operators.segment_analysis import (
-    GetSegmentAnalysisSettingsOperator,
-    UpdateSegmentAnalysisSettingsOperator,
-)
+from datarobot_provider.operators.segment_analysis import GetSegmentAnalysisSettingsOperator
+from datarobot_provider.operators.segment_analysis import UpdateSegmentAnalysisSettingsOperator
 
 
 @pytest.fixture
@@ -76,7 +73,9 @@ def test_operator_update_segment_analysis_settings(mocker, segment_analysis_sett
     )
 
 
-def test_operator_non_need_update_segment_analysis_settings(mocker, segment_analysis_settings_details):
+def test_operator_non_need_update_segment_analysis_settings(
+    mocker, segment_analysis_settings_details
+):
     deployment_id = "deployment-id"
 
     segment_analysis_settings_params = {


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
added the next new Airflow Operators:
 - GetSegmentAnalysisSettingsOperator
 - UpdateSegmentAnalysisSettingsOperator
 - GetBiasAndFairnessSettingsOperator
 - UpdateBiasAndFairnessSettingsOperator
 also added sample DAG

## Rationale
users should be able to configure Segment Analysis and Bias&Fairness Settings using Airflow operators
