### PR TITLE
[AGENT-4613] Add Airflow DAG predictions examples with Scoring Code

### DIFF
--- a/datarobot_provider/example_dags/download_scoring_code_from_deployment_dag.py
+++ b/datarobot_provider/example_dags/download_scoring_code_from_deployment_dag.py
@@ -1,0 +1,74 @@
+# Copyright 2023 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+from datetime import datetime
+
+from airflow.decorators import dag
+from airflow.decorators import task
+
+from datarobot_provider.operators.scoring_code import DownloadDeploymentScoringCodeOperator
+
+
+@dag(
+    schedule=None,
+    start_date=datetime(2023, 1, 1),
+    tags=['example', 'scoring_code'],
+    # Default json config example:
+    params={
+        'source_code': False,
+        'include_agent': False,
+        'include_prediction_explanations': False,
+        'include_prediction_intervals': False,
+        # as an option you can pass base_path here:
+        # 'scoring_code_filepath': "/home/airflow/gcs/data/",
+    },
+)
+def download_scoring_code(deployment_id=None):
+    if not deployment_id:
+        raise ValueError("Invalid or missing `deployment_id` value")
+
+    download_deployment_scoring_code_op = DownloadDeploymentScoringCodeOperator(
+        task_id="download_scoring_code_from_deployment",
+        # you can pass deployment_id from previous operator here:
+        deployment_id=deployment_id,
+        # you can pass base_path from previous operator here:
+        base_path="/.../models/",
+    )
+
+    @task(task_id="example_using_scoring_code")
+    def using_scoring_code_example(scoring_code_filepath):
+        """Example of using scoring code locally"""
+
+        # Put your logic with the scoring code here:
+        # Note that local scoring is not recommended to use because its burden an Airflow worker node.
+        # The next scoring code example is only for demo and testing proposes,
+        # should be used only with a very small datasets (not higher than a few megabytes).
+        # To run this example, DataRobot Prediction Library (https://datarobot.github.io/datarobot-predict)
+        # should be installed first.
+
+        input_file = "/.../input_file.csv"
+        output_file = "/.../output_predictions.csv"
+
+        import pandas as pd
+        from datarobot_predict.scoring_code import ScoringCodeModel
+
+        model = ScoringCodeModel(scoring_code_filepath)
+        input_df = pd.read_csv(input_file)
+        output_df = model.predict(input_df)
+        output_df.to_csv(output_file)
+
+    example_using_scoring_code = using_scoring_code_example(
+        scoring_code_filepath=download_deployment_scoring_code_op.output,
+    )
+
+    download_deployment_scoring_code_op >> example_using_scoring_code
+
+
+download_scoring_code_dag = download_scoring_code()
+
+if __name__ == "__main__":
+    download_scoring_code_dag.test()

--- a/datarobot_provider/operators/scoring_code.py
+++ b/datarobot_provider/operators/scoring_code.py
@@ -1,0 +1,162 @@
+# Copyright 2023 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+import os
+from typing import Any
+from typing import Dict
+from typing import Iterable
+
+import datarobot as dr
+from airflow.exceptions import AirflowException
+from airflow.models import BaseOperator
+
+from datarobot_provider.hooks.datarobot import DataRobotHook
+
+
+class DownloadDeploymentScoringCodeOperator(BaseOperator):
+    """
+    Downloads scoring code from a deployment.
+
+    :param deployment_id: DataRobot deployment ID
+    :type deployment_id: str
+    :param base_path: base path for storing downloaded model artifact
+    :type base_path: str
+    :param datarobot_conn_id: Connection ID, defaults to `datarobot_default`
+    :type datarobot_conn_id: str, optional
+    :return: path to the downloaded jar file
+    :rtype: String
+    """
+
+    # Specify the arguments that are allowed to parse with jinja templating
+    template_fields: Iterable[str] = ["deployment_id", "base_path"]
+    template_fields_renderers: Dict[str, str] = {}
+    template_ext: Iterable[str] = ()
+    ui_color = "#f4a460"
+
+    def __init__(
+        self,
+        *,
+        deployment_id: str,
+        base_path: str = None,
+        datarobot_conn_id: str = "datarobot_default",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.deployment_id = deployment_id
+        self.base_path = base_path
+        self.datarobot_conn_id = datarobot_conn_id
+        if kwargs.get("xcom_push") is not None:
+            raise AirflowException(
+                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
+            )
+
+    def execute(self, context: Dict[str, Any]) -> str:
+        # Initialize DataRobot client
+        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
+
+        self.log.info(f"Getting model scoring code for deployment_id={self.deployment_id}")
+        deployment = dr.Deployment.get(self.deployment_id)
+        # in case if params provided
+        self.base_path = context["params"].get("scoring_code_filepath", self.base_path)
+        if self.base_path is None or not os.path.exists(self.base_path):
+            raise ValueError("Invalid or missing base path value, make sure that directory exists")
+
+        scoring_code_path = os.path.join(
+            self.base_path, f"{deployment.id}-{deployment.model['id']}.jar"
+        )
+
+        source_code = context["params"].get("source_code", False)
+        include_agent = context["params"].get("include_agent", False)
+        include_prediction_explanations = context["params"].get(
+            "include_prediction_explanations", False
+        )
+        include_prediction_intervals = context["params"].get("include_prediction_intervals", False)
+
+        self.log.debug(f"Trying to download scoring code for deployment_id={self.deployment_id}")
+
+        deployment.download_scoring_code(
+            filepath=scoring_code_path,
+            source_code=source_code,
+            include_agent=include_agent,
+            include_prediction_explanations=include_prediction_explanations,
+            include_prediction_intervals=include_prediction_intervals,
+        )
+
+        self.log.info(
+            f"Scoring code for deployment_id={self.deployment_id} downloaded to the filepath={scoring_code_path}"
+        )
+
+        return scoring_code_path
+
+
+class DownloadModelScoringCodeOperator(BaseOperator):
+    """
+    Downloads scoring code from a model.
+
+    :param project_id: DataRobot project ID
+    :type project_id: str
+    :param model_id: DataRobot model ID
+    :type model_id: str
+    :param base_path: base path for storing downloaded model artifact
+    :type base_path: str
+    :param datarobot_conn_id: Connection ID, defaults to `datarobot_default`
+    :type datarobot_conn_id: str, optional
+    :return: path to the downloaded jar file
+    :rtype: String
+    """
+
+    # Specify the arguments that are allowed to parse with jinja templating
+    template_fields: Iterable[str] = ["project_id", "model_id"]
+    template_fields_renderers: Dict[str, str] = {}
+    template_ext: Iterable[str] = ()
+    ui_color = "#f4a460"
+
+    def __init__(
+        self,
+        *,
+        project_id: str,
+        model_id: str,
+        base_path: str = None,
+        datarobot_conn_id: str = "datarobot_default",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.project_id = project_id
+        self.model_id = model_id
+        self.base_path = base_path
+        self.datarobot_conn_id = datarobot_conn_id
+        if kwargs.get("xcom_push") is not None:
+            raise AirflowException(
+                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
+            )
+
+    def execute(self, context: Dict[str, Any]) -> str:
+        # Initialize DataRobot client
+        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
+
+        # in case if params provided
+        self.base_path = context["params"].get("scoring_code_filepath", self.base_path)
+        if self.base_path is None or not os.path.exists(self.base_path):
+            raise ValueError("Invalid or missing base path value, make sure that directory exists")
+
+        scoring_code_path = os.path.join(self.base_path, f"{self.model_id}.jar")
+
+        source_code = context["params"].get("source_code", False)
+
+        self.log.info(
+            f"Trying to download scoring code for project_id={self.project_id} and model_id={self.model_id}"
+        )
+
+        model = dr.Model.get(project=self.project_id, model_id=self.model_id)
+        model.download_scoring_code(file_name=scoring_code_path, source_code=source_code)
+
+        self.log.info(
+            f"Scoring code for project_id={self.project_id} and model_id={self.model_id} "
+            f"downloaded to the filepath={scoring_code_path}"
+        )
+
+        return scoring_code_path

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 apache-airflow>=2.3.0
 black>=22.12.0
-datarobot-early-access>=3.2.0.2023.6.19
+datarobot>=3.2.0b1
 flake8>=4.0.1
 isort>=5.11.4
 mypy>=0.931

--- a/tests/unit/operators/test_scoring_code.py
+++ b/tests/unit/operators/test_scoring_code.py
@@ -1,0 +1,178 @@
+# Copyright 2023 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+import os
+
+import datarobot as dr
+import pytest
+
+from datarobot_provider.operators.scoring_code import DownloadDeploymentScoringCodeOperator
+from datarobot_provider.operators.scoring_code import DownloadModelScoringCodeOperator
+
+
+@pytest.fixture
+def scoring_code_download_params():
+    return {
+        'source_code': False,
+        'include_agent': False,
+        'include_prediction_explanations': False,
+        'include_prediction_intervals': False,
+    }
+
+
+def test_operator_download_deployment_scoring_code(
+    mocker, monkeypatch, scoring_code_download_params
+):
+    deployment_id = "deployment-id"
+    model_id = "model-id"
+    scoring_code_filepath = '/home/airflow/gcs/data/'
+    expected_scoring_code_path = os.path.join(
+        scoring_code_filepath, f"{deployment_id}-{model_id}.jar"
+    )
+
+    mocker.patch.object(
+        dr.Deployment, "get", return_value=dr.Deployment(id=deployment_id, model={'id': model_id})
+    )
+
+    monkeypatch.setattr(os.path, 'exists', lambda path: True)
+
+    download_scoring_code_from_deployment_mock = mocker.patch.object(
+        dr.Deployment, "download_scoring_code"
+    )
+
+    operator = DownloadDeploymentScoringCodeOperator(
+        task_id="download_scoring_code_from_deployment",
+        deployment_id="deployment-id",
+        base_path=scoring_code_filepath,
+    )
+
+    operator_result = operator.execute(context={'params': scoring_code_download_params})
+    assert operator_result == expected_scoring_code_path
+    scoring_code_download_params['filepath'] = expected_scoring_code_path
+    download_scoring_code_from_deployment_mock.assert_called_with(**scoring_code_download_params)
+
+
+def test_operator_download_deployment_scoring_code_invalid_params(
+    mocker, monkeypatch, scoring_code_download_params
+):
+    deployment_id = "deployment-id"
+    model_id = "model-id"
+    scoring_code_filepath = None
+
+    mocker.patch.object(
+        dr.Deployment, "get", return_value=dr.Deployment(id=deployment_id, model={'id': model_id})
+    )
+
+    mocker.patch.object(dr.Deployment, "download_scoring_code")
+
+    operator = DownloadDeploymentScoringCodeOperator(
+        task_id="download_scoring_code_from_deployment",
+        deployment_id="deployment-id",
+        base_path=scoring_code_filepath,
+    )
+
+    with pytest.raises(ValueError):
+        operator.execute(context={'params': scoring_code_download_params})
+
+
+def test_operator_download_deployment_scoring_code_invalid_path(
+    mocker, monkeypatch, scoring_code_download_params
+):
+    deployment_id = "deployment-id"
+    model_id = "model-id"
+    scoring_code_filepath = '/home/airflow/gcs/data/'
+
+    mocker.patch.object(
+        dr.Deployment, "get", return_value=dr.Deployment(id=deployment_id, model={'id': model_id})
+    )
+
+    monkeypatch.setattr(os.path, 'exists', lambda path: False)
+
+    operator = DownloadDeploymentScoringCodeOperator(
+        task_id="download_scoring_code_from_deployment",
+        deployment_id="deployment-id",
+        base_path=scoring_code_filepath,
+    )
+
+    with pytest.raises(ValueError):
+        operator.execute(context={'params': scoring_code_download_params})
+
+
+def test_operator_download_model_scoring_code(mocker, monkeypatch, scoring_code_download_params):
+    project_id = "deployment-id"
+    model_id = "model-id"
+    scoring_code_filepath = '/home/airflow/gcs/data/'
+    expected_scoring_code_path = os.path.join(scoring_code_filepath, f"{model_id}.jar")
+
+    mocker.patch.object(dr.Model, "get", return_value=dr.Model(id=model_id, project_id=project_id))
+
+    monkeypatch.setattr(os.path, 'exists', lambda path: True)
+
+    download_scoring_code_from_deployment_mock = mocker.patch.object(
+        dr.Model, "download_scoring_code"
+    )
+
+    operator = DownloadModelScoringCodeOperator(
+        task_id="download_scoring_code_from_model",
+        project_id=project_id,
+        model_id=model_id,
+        base_path=scoring_code_filepath,
+    )
+
+    operator_result = operator.execute(context={'params': scoring_code_download_params})
+    assert operator_result == expected_scoring_code_path
+    params = {
+        'file_name': expected_scoring_code_path,
+        'source_code': scoring_code_download_params['source_code'],
+    }
+    download_scoring_code_from_deployment_mock.assert_called_with(**params)
+
+
+def test_operator_download_model_scoring_code_none_path(
+    mocker, monkeypatch, scoring_code_download_params
+):
+    project_id = "deployment-id"
+    model_id = "model-id"
+    scoring_code_filepath = None
+
+    mocker.patch.object(dr.Model, "get", return_value=dr.Model(id=model_id, project_id=project_id))
+
+    mocker.patch.object(dr.Model, "download_scoring_code")
+
+    operator = DownloadModelScoringCodeOperator(
+        task_id="download_scoring_code_from_model",
+        project_id=project_id,
+        model_id=model_id,
+        base_path=scoring_code_filepath,
+    )
+
+    with pytest.raises(ValueError):
+        operator.execute(context={'params': scoring_code_download_params})
+
+
+def test_operator_download_model_scoring_code_invalid_path(
+    mocker, monkeypatch, scoring_code_download_params
+):
+    project_id = "deployment-id"
+    model_id = "model-id"
+    scoring_code_filepath = '/home/airflow/gcs/data/'
+
+    mocker.patch.object(dr.Model, "get", return_value=dr.Model(id=model_id, project_id=project_id))
+
+    monkeypatch.setattr(os.path, 'exists', lambda path: False)
+
+    mocker.patch.object(dr.Model, "download_scoring_code")
+
+    operator = DownloadModelScoringCodeOperator(
+        task_id="download_scoring_code_from_model",
+        project_id=project_id,
+        model_id=model_id,
+        base_path=scoring_code_filepath,
+    )
+
+    with pytest.raises(ValueError):
+        operator.execute(context={'params': scoring_code_download_params})


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Added Airflow DAG predictions examples with Scoring Code
Added Operators for scoring code downloading from deployment and from model

## Rationale
Users should be able to use Airflow with scoring code to run predictions
