### PR TITLE
[AGENT-4766] Implement Airflow Operator to request model predictions on external dataset

### DIFF
--- a/datarobot_provider/example_dags/model_compute_predictions_dag.py
+++ b/datarobot_provider/example_dags/model_compute_predictions_dag.py
@@ -23,9 +23,9 @@ from datarobot_provider.sensors.model_insights import DataRobotJobSensor
     tags=['example', 'dataset'],
 )
 def compute_model_predictions(
-    project_id='64a7f21f1110f0df910ddb4f',
-    model_id="64a7f27e8e0fd5cae6282a8b",
-    dataset_id="64bfc36171d728b6fa2e369c",
+    project_id=None,
+    model_id=None,
+    dataset_id=None,
 ):
     if not project_id:
         raise ValueError("Invalid or missing `project_id` value")

--- a/datarobot_provider/operators/model_predictions.py
+++ b/datarobot_provider/operators/model_predictions.py
@@ -93,3 +93,69 @@ class AddExternalDatasetOperator(BaseOperator):
         )
 
         return external_dataset.id
+
+
+class RequestModelPredictionsOperator(BaseOperator):
+    """
+    Requests predictions against a previously uploaded dataset.
+    :param project_id: DataRobot project ID
+    :type project_id: str
+    :param model_id: DataRobot model ID
+    :type model_id: str
+    :param external_dataset_id: DataRobot external dataset ID
+    :type external_dataset_id: str
+    :param datarobot_conn_id: Connection ID, defaults to `datarobot_default`
+    :type datarobot_conn_id: str, optional
+    :return: Feature Effects job ID
+    :rtype: str
+    """
+
+    # Specify the arguments that are allowed to parse with jinja templating
+    template_fields: Iterable[str] = [
+        "project_id",
+        "model_id",
+        "external_dataset_id",
+    ]
+    template_fields_renderers: Dict[str, str] = {}
+    template_ext: Iterable[str] = ()
+    ui_color = '#f4a460'
+
+    def __init__(
+        self,
+        *,
+        project_id: str = None,
+        model_id: str = None,
+        external_dataset_id: str = None,
+        datarobot_conn_id: str = "datarobot_default",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.project_id = project_id
+        self.model_id = model_id
+        self.external_dataset_id = external_dataset_id
+        self.datarobot_conn_id = datarobot_conn_id
+        if kwargs.get('xcom_push') is not None:
+            raise AirflowException(
+                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
+            )
+
+    def execute(self, context: Dict[str, Any]) -> str:
+        # Initialize DataRobot client
+        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
+
+        if self.project_id is None:
+            raise ValueError("project_id is required to compute model predictions.")
+
+        if self.model_id is None:
+            raise ValueError("model_id is required to compute model predictions.")
+
+        if self.external_dataset_id is None:
+            raise ValueError("external_dataset_id is required to compute model predictions.")
+
+        model = dr.models.Model.get(self.project_id, self.model_id)
+
+        predict_job = model.request_predictions(dataset_id=self.external_dataset_id)
+
+        self.log.info(f"Model predictions requested, job_id={predict_job.id}")
+
+        return predict_job.id

--- a/tests/unit/operators/test_model_predictions.py
+++ b/tests/unit/operators/test_model_predictions.py
@@ -9,6 +9,7 @@
 import datarobot as dr
 
 from datarobot_provider.operators.model_predictions import AddExternalDatasetOperator
+from datarobot_provider.operators.model_predictions import RequestModelPredictionsOperator
 
 
 def test_operator_add_external_dataset(mocker):
@@ -48,3 +49,36 @@ def test_operator_add_external_dataset(mocker):
         max_wait=600,
     )
     assert result == external_dataset_id
+
+
+def test_operator_request_model_predictions(mocker):
+    project_id = "test-project-id"
+    model_id = "test-model-id"
+    external_dataset_id = "test-external-dataset-id"
+    predictions_job_id = "test-predictions-job-id"
+
+    model_mock = mocker.Mock()
+    model_mock.id = model_id
+    model_mock.project_id = project_id
+
+    get_model_mock = mocker.patch.object(dr.models.Model, "get", return_value=model_mock)
+
+    predictions_job_mock = mocker.Mock()
+    predictions_job_mock.id = predictions_job_id
+
+    request_predictions_mock = mocker.patch.object(
+        model_mock, "request_predictions", return_value=predictions_job_mock
+    )
+
+    operator = RequestModelPredictionsOperator(
+        task_id="request_model_predictions",
+        project_id=project_id,
+        model_id=model_id,
+        external_dataset_id=external_dataset_id,
+    )
+
+    result = operator.execute(context={"params": {}})
+
+    get_model_mock.assert_called_with(project_id, model_id)
+    request_predictions_mock.assert_called_with(dataset_id=external_dataset_id)
+    assert result == predictions_job_id


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
added RequestModelPredictionsOperator to request predictions from model
extended sample DAG: model_compute_predictions_dag.py
added unit-tests

## Rationale
Users should be able to run model predictions on external dataset for testing for model testing proposes
