### PR TITLE
[AGENT-4806] upgraded DataRobot python client to 3.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The DataRobot provider for Apache Airflow requires an environment with the follo
 
 * [Apache Airflow](https://pypi.org/project/apache-airflow/) >= 2.3
 
-* [DataRobot Python API Client](https://pypi.org/project/datarobot/) >= 3.2.0b1
+* [DataRobot Python API Client](https://pypi.org/project/datarobot/) >= 3.2.0
 
 To install the DataRobot provider, run the following command:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 apache-airflow>=2.3.0
 black>=22.12.0
-datarobot>=3.2.0b1
+datarobot>=3.2.0
 flake8>=4.0.1
 isort>=5.11.4
 mypy>=0.931

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         'datarobot_provider.sensors',
         'datarobot_provider.operators',
     ],
-    install_requires=['apache-airflow>=2.3.0', 'datarobot>=3.2.0b1'],
+    install_requires=['apache-airflow>=2.3.0', 'datarobot>=3.2.0'],
     setup_requires=['setuptools', 'wheel'],
     author='DataRobot',
     author_email='support@datarobot.com',


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
upgraded DataRobot python client to 3.2.0

## Rationale
upgraded DataRobot python client to 3.2.0