### PR TITLE
[AGENT-4685] Implement Airflow Operator to Kickoff SHAP

### DIFF
--- a/datarobot_provider/example_dags/model_compute_shap_dag.py
+++ b/datarobot_provider/example_dags/model_compute_shap_dag.py
@@ -18,7 +18,7 @@ from datarobot_provider.sensors.model_insights import DataRobotJobSensor
     start_date=datetime(2023, 1, 1),
     tags=['example', 'insights'],
 )
-def compute_model_shap(project_id="64d64ce68b2faa0a4908b955", model_id="64d64d7c764d63adb2a1ffcf"):
+def compute_model_shap(project_id=None, model_id=None):
     if not project_id:
         raise ValueError("Invalid or missing `project_id` value")
     if not model_id:

--- a/datarobot_provider/example_dags/model_compute_shap_dag.py
+++ b/datarobot_provider/example_dags/model_compute_shap_dag.py
@@ -1,0 +1,47 @@
+# Copyright 2023 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+from datetime import datetime
+
+from airflow.decorators import dag
+
+from datarobot_provider.operators.model_insights import ComputeShapOperator
+from datarobot_provider.sensors.model_insights import DataRobotJobSensor
+
+
+@dag(
+    schedule=None,
+    start_date=datetime(2023, 1, 1),
+    tags=['example', 'insights'],
+)
+def compute_model_shap(project_id="64d64ce68b2faa0a4908b955", model_id="64d64d7c764d63adb2a1ffcf"):
+    if not project_id:
+        raise ValueError("Invalid or missing `project_id` value")
+    if not model_id:
+        raise ValueError("Invalid or missing `model_id` value")
+
+    compute_shap_op = ComputeShapOperator(
+        task_id="compute_feature_impact",
+        project_id=project_id,
+        model_id=model_id,
+    )
+
+    shap_complete_sensor = DataRobotJobSensor(
+        task_id="feature_impact_complete",
+        project_id=project_id,
+        job_id=compute_shap_op.output,
+        poke_interval=5,
+        timeout=3600,
+    )
+
+    compute_shap_op >> shap_complete_sensor
+
+
+compute_model_shap_dag = compute_model_shap()
+
+if __name__ == "__main__":
+    compute_model_shap_dag.test()

--- a/datarobot_provider/operators/model_insights.py
+++ b/datarobot_provider/operators/model_insights.py
@@ -130,3 +130,59 @@ class ComputeFeatureEffectsOperator(BaseOperator):
         self.log.info(f"Feature Effects Job submitted, job_id={job.id}")
 
         return job.id
+
+
+class ComputeShapOperator(BaseOperator):
+    """
+    Creates SHAP impact job in DataRobot.
+    :param project_id: DataRobot project ID
+    :type project_id: str
+    :param model_id: DataRobot model ID
+    :type model_id: str
+    :param datarobot_conn_id: Connection ID, defaults to `datarobot_default`
+    :type datarobot_conn_id: str, optional
+    :return: SHAP impact job ID
+    :rtype: str
+    """
+
+    # Specify the arguments that are allowed to parse with jinja templating
+    template_fields: Iterable[str] = [
+        "project_id",
+        "model_id",
+    ]
+    template_fields_renderers: Dict[str, str] = {}
+    template_ext: Iterable[str] = ()
+    ui_color = '#f4a460'
+
+    def __init__(
+        self,
+        *,
+        project_id: str = None,
+        model_id: str = None,
+        datarobot_conn_id: str = "datarobot_default",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.project_id = project_id
+        self.model_id = model_id
+        self.datarobot_conn_id = datarobot_conn_id
+        if kwargs.get('xcom_push') is not None:
+            raise AirflowException(
+                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
+            )
+
+    def execute(self, context: Dict[str, Any]) -> str:
+        # Initialize DataRobot client
+        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
+
+        if self.project_id is None:
+            raise ValueError("project_id is required to compute SHAP impact.")
+
+        if self.model_id is None:
+            raise ValueError("model_id is required to compute SHAP impact.")
+
+        shap_impact_job = dr.ShapImpact.create(project_id=self.project_id, model_id=self.model_id)
+
+        self.log.info(f"Compute SHAP impact Job submitted, job_id={shap_impact_job.id}")
+
+        return shap_impact_job.id

--- a/tests/unit/operators/test_model_insights_job.py
+++ b/tests/unit/operators/test_model_insights_job.py
@@ -11,6 +11,7 @@ import pytest
 
 from datarobot_provider.operators.model_insights import ComputeFeatureEffectsOperator
 from datarobot_provider.operators.model_insights import ComputeFeatureImpactOperator
+from datarobot_provider.operators.model_insights import ComputeShapOperator
 
 
 def test_operator_compute_feature_impact(mocker):
@@ -124,6 +125,52 @@ def test_operator_compute_feature_effects_no_model_id(mocker):
     operator = ComputeFeatureEffectsOperator(
         task_id="compute_feature_effects", project_id=project_id
     )
+
+    with pytest.raises(ValueError):
+        operator.execute(context={"params": {}})
+
+
+def test_operator_compute_shap(mocker):
+    project_id = "test-project-id"
+    model_id = "test-model-id"
+    job_id = 123
+
+    job_mock = mocker.Mock()
+    job_mock.id = job_id
+
+    request_shap_mock = mocker.patch.object(dr.ShapImpact, "create", return_value=job_mock)
+
+    operator = ComputeShapOperator(task_id="compute_shap", project_id=project_id, model_id=model_id)
+
+    result = operator.execute(context={"params": {}})
+
+    request_shap_mock.assert_called_with(project_id=project_id, model_id=model_id)
+    assert result == job_id
+
+
+def test_operator_compute_shap_no_project_id(mocker):
+    project_id = "test-project-id"
+    model_id = "test-model-id"
+
+    model_mock = mocker.Mock()
+    model_mock.id = model_id
+    model_mock.project_id = project_id
+
+    operator = ComputeShapOperator(task_id="compute_shap", model_id=model_id)
+
+    with pytest.raises(ValueError):
+        operator.execute(context={"params": {}})
+
+
+def test_operator_compute_shap_no_model_id(mocker):
+    project_id = "test-project-id"
+    model_id = "test-model-id"
+
+    model_mock = mocker.Mock()
+    model_mock.id = model_id
+    model_mock.project_id = project_id
+
+    operator = ComputeShapOperator(task_id="compute_shap", project_id=project_id)
 
     with pytest.raises(ValueError):
         operator.execute(context={"params": {}})


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Added ComputeShapOperator that creates SHAP impact job in DataRobot

## Rationale
Users should be able to Kickoff SHAP impact compute using airflow operators