### PR TITLE
[AGENT-4707] Implement Airflow Operator for External Creating Model package

### DIFF
--- a/datarobot_provider/example_dags/datarobot_external_model_pipeline_dag.py
+++ b/datarobot_provider/example_dags/datarobot_external_model_pipeline_dag.py
@@ -75,11 +75,11 @@ Example JSON for a multiclass classification model:
 @dag(
     schedule=None,
     start_date=datetime(2023, 1, 1),
-    tags=['example', 'custom model'],
+    tags=['example', 'mlops', 'external model'],
     params={
-        "model_package": {
-            "name": "Lending club regression",
-            "modelDescription": {"description": "Regression on lending club dataset"},
+        "model_package_json": {
+            "name": "Demo Regression Model",
+            "modelDescription": {"description": "Regression on demo dataset"},
             "target": {"type": TARGET_TYPE.REGRESSION, "name": 'Grade 2014'},
         },
     },

--- a/datarobot_provider/example_dags/datarobot_external_model_pipeline_dag.py
+++ b/datarobot_provider/example_dags/datarobot_external_model_pipeline_dag.py
@@ -1,0 +1,98 @@
+# Copyright 2023 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+
+from datetime import datetime
+
+from airflow.decorators import dag
+from datarobot import TARGET_TYPE
+
+from datarobot_provider.operators.model_package import CreateModelPackageOperator
+
+"""
+Example of JSON configuration for a regression model:
+
+.. code-block:: python
+
+    {
+         "name": "Lending club regression",
+         "modelDescription": {
+                 "description": "Regression on lending club dataset"
+             }
+         "target": {
+             "type": "Regression",
+             "name": "loan_amnt"
+         }
+    }
+
+
+Example JSON for a binary classification model:
+
+.. code-block:: python
+
+    {
+        "name": "Surgical Model",
+        "modelDescription": {
+            "description": "Binary classification on surgical dataset",
+            "location": "/tmp/myModel"
+            },
+            "target": {
+                "type": "Binary",
+                "name": "complication",
+                "classNames": ["Yes","No"],  # minority/positive class should be listed first
+                "predictionThreshold": 0.5
+            }
+        }
+    }
+
+Example JSON for a multiclass classification model:
+
+.. code-block:: python
+
+    {
+        "name": "Iris classifier",
+        "modelDescription": {
+        "description": "Classification on iris dataset",
+        "location": "/tmp/myModel"
+    },
+        "target": {
+            "type": "Multiclass",
+            "name": "Species",
+            "classNames": [
+                "Iris-versicolor",
+                "Iris-virginica",
+                "Iris-setosa"
+            ]
+        }
+    }
+"""
+
+
+@dag(
+    schedule=None,
+    start_date=datetime(2023, 1, 1),
+    tags=['example', 'custom model'],
+    params={
+        "model_package": {
+            "name": "Lending club regression",
+            "modelDescription": {"description": "Regression on lending club dataset"},
+            "target": {"type": TARGET_TYPE.REGRESSION, "name": 'Grade 2014'},
+        },
+    },
+)
+def create_external_deployment_pipeline():
+    create_model_package_op = CreateModelPackageOperator(
+        task_id='create_model_package',
+    )
+
+    create_model_package_op
+
+
+create_external_deployment_pipeline_dag = create_external_deployment_pipeline()
+
+if __name__ == "__main__":
+    create_external_deployment_pipeline_dag.test()

--- a/datarobot_provider/example_dags/datarobot_external_model_pipeline_dag.py
+++ b/datarobot_provider/example_dags/datarobot_external_model_pipeline_dag.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from airflow.decorators import dag
 from datarobot import TARGET_TYPE
 
-from datarobot_provider.operators.model_package import CreateModelPackageOperator
+from datarobot_provider.operators.model_package import CreateExternalModelPackageOperator
 
 """
 Example of JSON configuration for a regression model:
@@ -85,7 +85,7 @@ Example JSON for a multiclass classification model:
     },
 )
 def create_external_deployment_pipeline():
-    create_model_package_op = CreateModelPackageOperator(
+    create_model_package_op = CreateExternalModelPackageOperator(
         task_id='create_model_package',
     )
 

--- a/datarobot_provider/operators/model_package.py
+++ b/datarobot_provider/operators/model_package.py
@@ -18,7 +18,7 @@ from datarobot_provider.hooks.datarobot import DataRobotHook
 DEFAULT_MAX_WAIT_SEC = 600
 
 
-class CreateModelPackageOperator(BaseOperator):
+class CreateExternalModelPackageOperator(BaseOperator):
     """
     Create an external model package in DataRobot MLOps from JSON configuration
 

--- a/datarobot_provider/operators/model_package.py
+++ b/datarobot_provider/operators/model_package.py
@@ -1,0 +1,77 @@
+# Copyright 2023 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+from typing import Any
+from typing import Dict
+from typing import Iterable
+
+import datarobot as dr
+from airflow.exceptions import AirflowException
+from airflow.models import BaseOperator
+
+from datarobot_provider.hooks.datarobot import DataRobotHook
+
+DEFAULT_MAX_WAIT_SEC = 600
+
+
+class CreateModelPackageOperator(BaseOperator):
+    """
+    Create an external model package in DataRobot MLOps from JSON configuration
+
+    :param model_info: A JSON object of external model parameters.
+    :type model_info: dict
+    :return: A model package ID of newly created ModelPackage.
+    :rtype: str
+    """
+
+    # Specify the arguments that are allowed to parse with jinja templating
+    template_fields: Iterable[str] = [
+        "model_package_json",
+    ]
+    template_fields_renderers: Dict[str, str] = {}
+    template_ext: Iterable[str] = ()
+    ui_color = '#f4a460'
+
+    def __init__(
+        self,
+        *,
+        model_package_json: dict = None,
+        datarobot_conn_id: str = "datarobot_default",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.model_package_json = model_package_json
+        self.datarobot_conn_id = datarobot_conn_id
+        if kwargs.get('xcom_push') is not None:
+            raise AirflowException(
+                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
+            )
+
+    # Utility method to support old Model Registry API
+    def create_model_package_from_json(self, model_info: Dict[str, Any]) -> str:
+        response = dr.client.get_client().post("modelPackages/fromJSON/", data=model_info)
+        response_json = response.json()
+        model_package_id = response_json["id"]
+        self.log.info(f"Created Model Package, id={model_package_id}")
+        return model_package_id
+
+    def execute(self, context: Dict[str, Any]) -> str:
+        # Initialize DataRobot client
+        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
+
+        if self.model_package_json is None:
+            # If model_package_json not provided, trying to get it from DAG params:
+            self.model_package_json = context["params"].get("model_package_json")
+
+        if self.model_package_json is None:
+            raise ValueError("model_package_json is required.")
+
+        model_package_id = self.create_model_package_from_json(self.model_package_json)
+
+        self.log.info(f"External Model Package Created, model_package_id={model_package_id}")
+
+        return model_package_id

--- a/tests/unit/operators/test_model_package.py
+++ b/tests/unit/operators/test_model_package.py
@@ -1,0 +1,80 @@
+# Copyright 2023 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+
+import pytest
+from datarobot import TARGET_TYPE
+
+from datarobot_provider.operators.model_package import CreateExternalModelPackageOperator
+
+
+@pytest.fixture
+def external_model_params():
+    return {
+        "model_package_json": {
+            "name": "Demo regression model",
+            "modelDescription": {"description": "Regression on demo dataset"},
+            "target": {"type": TARGET_TYPE.REGRESSION, "name": 'Grade 2014'},
+        }
+    }
+
+
+def test_operator_create_external_model_package_op(mocker, external_model_params):
+    external_model_package_id = "test-external-model-package-id"
+
+    create_external_model_package_mock = mocker.patch.object(
+        CreateExternalModelPackageOperator,
+        "create_model_package_from_json",
+        return_value=external_model_package_id,
+    )
+
+    operator = CreateExternalModelPackageOperator(
+        task_id='create_external_model_package',
+    )
+
+    operator_result = operator.execute(context={"params": external_model_params})
+
+    create_external_model_package_mock.assert_called()
+
+    assert operator_result == external_model_package_id
+
+
+def test_operator_create_external_model_package_param_op(mocker, external_model_params):
+    external_model_package_id = "test-external-model-package-id"
+
+    create_external_model_package_mock = mocker.patch.object(
+        CreateExternalModelPackageOperator,
+        "create_model_package_from_json",
+        return_value=external_model_package_id,
+    )
+
+    operator = CreateExternalModelPackageOperator(
+        task_id='create_external_model_package', model_package_json=external_model_params
+    )
+
+    operator_result = operator.execute(context={"params": {}})
+
+    create_external_model_package_mock.assert_called()
+
+    assert operator_result == external_model_package_id
+
+
+def test_operator_create_external_model_package_none_op(mocker):
+    external_model_package_id = "test-external-model-package-id"
+
+    create_external_model_package_mock = mocker.patch.object(
+        CreateExternalModelPackageOperator,
+        "create_model_package_from_json",
+        return_value=external_model_package_id,
+    )
+
+    operator = CreateExternalModelPackageOperator(task_id='create_external_model_package')
+
+    create_external_model_package_mock.assert_not_called()
+
+    with pytest.raises(ValueError):
+        operator.execute(context={"params": {}})


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Added CreateExternalModelPackageOperator to support  External Model package creation
Added sample DAG (will be extended)
Added unit-tests

## Rationale
Users should be able to create External Model package using Airflow Operators
