### PR TITLE
[AGENT-4703] Extended Airflow Operator to create Custom Inference Version from previous

### DIFF
--- a/datarobot_provider/operators/custom_models.py
+++ b/datarobot_provider/operators/custom_models.py
@@ -280,7 +280,9 @@ class CreateCustomInferenceModelOperator(BaseOperator):
 
 class CreateCustomModelVersionOperator(BaseOperator):
     """
-    Create a custom model version without files from previous versions.
+    Create a custom model version.
+    Create a custom model version containing files from a previous version.
+     without files from previous versions.
 
     :param custom_model_id: The ID of the custom model.
     :type custom_model_id: str
@@ -294,6 +296,10 @@ class CreateCustomModelVersionOperator(BaseOperator):
     :param custom_model_folder: The ID of the holdout dataset to assign to the custom model.
             Can only be assigned for unstructured models.
     :type custom_model_folder: str, optional
+    :create_from_previous: if set to True - creates a custom model version containing files from a previous version.
+        if set to False - creates a custom model version without files from previous versions.
+        valuer by default is: False.
+    :create_from_previous: bool, optional
     :param max_wait:  Max time to wait for training data assignment.
     :type max_wait: int, optional
     :return: created custom model version ID
@@ -307,6 +313,7 @@ class CreateCustomModelVersionOperator(BaseOperator):
         "training_dataset_id",
         "holdout_dataset_id",
         "custom_model_folder",
+        "create_from_previous",
     ]
     template_fields_renderers: Dict[str, str] = {}
     template_ext: Iterable[str] = ()
@@ -320,6 +327,7 @@ class CreateCustomModelVersionOperator(BaseOperator):
         training_dataset_id: str = None,
         holdout_dataset_id: str = None,
         custom_model_folder: str = None,
+        create_from_previous: bool = False,
         max_wait_sec: int = DEFAULT_MAX_WAIT_SEC,
         datarobot_conn_id: str = "datarobot_default",
         **kwargs: Any,
@@ -330,6 +338,7 @@ class CreateCustomModelVersionOperator(BaseOperator):
         self.training_dataset_id = training_dataset_id
         self.holdout_dataset_id = holdout_dataset_id
         self.custom_model_folder = custom_model_folder
+        self.create_from_previous = create_from_previous
         self.max_wait_sec = max_wait_sec
         self.datarobot_conn_id = datarobot_conn_id
         if kwargs.get('xcom_push') is not None:
@@ -357,22 +366,45 @@ class CreateCustomModelVersionOperator(BaseOperator):
                 "base_environment_id is required attribute for CreateCustomModelVersionOperator"
             )
 
-        custom_model_version = dr.CustomModelVersion.create_clean(
-            custom_model_id=self.custom_model_id,
-            training_dataset_id=self.training_dataset_id,
-            base_environment_id=self.base_environment_id,
-            holdout_dataset_id=self.holdout_dataset_id,
-            folder_path=folder_path,
-            is_major_update=context["params"].get("is_major_update", None),
-            files=context["params"].get("files", None),
-            network_egress_policy=context["params"].get("network_egress_policy", None),
-            maximum_memory=context["params"].get("maximum_memory", None),
-            replicas=context["params"].get("replicas", None),
-            required_metadata_values=context["params"].get("required_metadata_values", None),
-            partition_column=context["params"].get("partition_column", None),
-            keep_training_holdout_data=context["params"].get("keep_training_holdout_data", None),
-            max_wait=self.max_wait_sec,
-        )
+        if self.create_from_previous:
+            custom_model_version = dr.CustomModelVersion.create_from_previous(
+                custom_model_id=self.custom_model_id,
+                training_dataset_id=self.training_dataset_id,
+                base_environment_id=self.base_environment_id,
+                holdout_dataset_id=self.holdout_dataset_id,
+                folder_path=folder_path,
+                is_major_update=context["params"].get("is_major_update", None),
+                files=context["params"].get("files", None),
+                files_to_delete=context["params"].get("files_to_delete", None),
+                network_egress_policy=context["params"].get("network_egress_policy", None),
+                maximum_memory=context["params"].get("maximum_memory", None),
+                replicas=context["params"].get("replicas", None),
+                required_metadata_values=context["params"].get("required_metadata_values", None),
+                partition_column=context["params"].get("partition_column", None),
+                keep_training_holdout_data=context["params"].get(
+                    "keep_training_holdout_data", None
+                ),
+                max_wait=self.max_wait_sec,
+            )
+        else:
+            custom_model_version = dr.CustomModelVersion.create_clean(
+                custom_model_id=self.custom_model_id,
+                training_dataset_id=self.training_dataset_id,
+                base_environment_id=self.base_environment_id,
+                holdout_dataset_id=self.holdout_dataset_id,
+                folder_path=folder_path,
+                is_major_update=context["params"].get("is_major_update", None),
+                files=context["params"].get("files", None),
+                network_egress_policy=context["params"].get("network_egress_policy", None),
+                maximum_memory=context["params"].get("maximum_memory", None),
+                replicas=context["params"].get("replicas", None),
+                required_metadata_values=context["params"].get("required_metadata_values", None),
+                partition_column=context["params"].get("partition_column", None),
+                keep_training_holdout_data=context["params"].get(
+                    "keep_training_holdout_data", None
+                ),
+                max_wait=self.max_wait_sec,
+            )
 
         self.log.info(
             f"Custom Model Version created, custom_model_version_id={custom_model_version.id}"
@@ -575,62 +607,3 @@ class CreateCustomModelDeploymentOperator(BaseOperator):
 
         self.log.info(f"Deployment created, deployment_id: {deployment.id}")
         return deployment.id
-
-
-class AssignTrainingDataCustomModelOperator(BaseOperator):
-    """
-    Assign training data to Custom Inference Model.
-
-    :param custom_model_id: The ID of the custom model.
-    :type custom_model_id: str
-    :param training_dataset_id: The ID of the training dataset to assign to the custom model.
-    :type training_dataset_id: str, optional
-    :param max_wait:  Max time to wait in seconds for training data assignment.
-    :type max_wait: int, optional
-    :return:
-    :rtype: dict
-    """
-
-    # Specify the arguments that are allowed to parse with jinja templating
-    template_fields: Iterable[str] = ["custom_model_id", "training_dataset_id", "partition_column"]
-    template_fields_renderers: Dict[str, str] = {}
-    template_ext: Iterable[str] = ()
-    ui_color = '#f4a460'
-
-    def __init__(
-        self,
-        *,
-        custom_model_id: str,
-        training_dataset_id: str,
-        partition_column: str = None,
-        max_wait_sec: int = DEFAULT_MAX_WAIT_SEC,
-        datarobot_conn_id: str = "datarobot_default",
-        **kwargs: Any,
-    ) -> None:
-        super().__init__(**kwargs)
-        self.custom_model_id = custom_model_id
-        self.training_dataset_id = training_dataset_id
-        self.partition_column = partition_column
-        self.max_wait_sec = max_wait_sec
-        self.datarobot_conn_id = datarobot_conn_id
-        if kwargs.get('xcom_push') is not None:
-            raise AirflowException(
-                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
-            )
-
-    def execute(self, context: Dict[str, Any]) -> None:
-        # Initialize DataRobot client
-        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
-
-        if self.custom_model_id is None:
-            raise ValueError("custom_model_id is required attribute")
-
-        if self.training_dataset_id is None:
-            raise ValueError("training_dataset_id is required attribute")
-
-        custom_model = dr.CustomInferenceModel.get(self.custom_model_id)
-        custom_model.assign_training_data(
-            dataset_id=self.training_dataset_id,
-            partition_column=self.partition_column,
-            max_wait=self.max_wait_sec,
-        )

--- a/datarobot_provider/operators/custom_models.py
+++ b/datarobot_provider/operators/custom_models.py
@@ -575,3 +575,62 @@ class CreateCustomModelDeploymentOperator(BaseOperator):
 
         self.log.info(f"Deployment created, deployment_id: {deployment.id}")
         return deployment.id
+
+
+class AssignTrainingDataCustomModelOperator(BaseOperator):
+    """
+    Assign training data to Custom Inference Model.
+
+    :param custom_model_id: The ID of the custom model.
+    :type custom_model_id: str
+    :param training_dataset_id: The ID of the training dataset to assign to the custom model.
+    :type training_dataset_id: str, optional
+    :param max_wait:  Max time to wait in seconds for training data assignment.
+    :type max_wait: int, optional
+    :return:
+    :rtype: dict
+    """
+
+    # Specify the arguments that are allowed to parse with jinja templating
+    template_fields: Iterable[str] = ["custom_model_id", "training_dataset_id", "partition_column"]
+    template_fields_renderers: Dict[str, str] = {}
+    template_ext: Iterable[str] = ()
+    ui_color = '#f4a460'
+
+    def __init__(
+        self,
+        *,
+        custom_model_id: str,
+        training_dataset_id: str,
+        partition_column: str = None,
+        max_wait_sec: int = DEFAULT_MAX_WAIT_SEC,
+        datarobot_conn_id: str = "datarobot_default",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.custom_model_id = custom_model_id
+        self.training_dataset_id = training_dataset_id
+        self.partition_column = partition_column
+        self.max_wait_sec = max_wait_sec
+        self.datarobot_conn_id = datarobot_conn_id
+        if kwargs.get('xcom_push') is not None:
+            raise AirflowException(
+                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
+            )
+
+    def execute(self, context: Dict[str, Any]) -> None:
+        # Initialize DataRobot client
+        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
+
+        if self.custom_model_id is None:
+            raise ValueError("custom_model_id is required attribute")
+
+        if self.training_dataset_id is None:
+            raise ValueError("training_dataset_id is required attribute")
+
+        custom_model = dr.CustomInferenceModel.get(self.custom_model_id)
+        custom_model.assign_training_data(
+            dataset_id=self.training_dataset_id,
+            partition_column=self.partition_column,
+            max_wait=self.max_wait_sec,
+        )

--- a/datarobot_provider/operators/custom_models.py
+++ b/datarobot_provider/operators/custom_models.py
@@ -281,8 +281,6 @@ class CreateCustomInferenceModelOperator(BaseOperator):
 class CreateCustomModelVersionOperator(BaseOperator):
     """
     Create a custom model version.
-    Create a custom model version containing files from a previous version.
-     without files from previous versions.
 
     :param custom_model_id: The ID of the custom model.
     :type custom_model_id: str
@@ -298,7 +296,7 @@ class CreateCustomModelVersionOperator(BaseOperator):
     :type custom_model_folder: str, optional
     :create_from_previous: if set to True - creates a custom model version containing files from a previous version.
         if set to False - creates a custom model version without files from previous versions.
-        valuer by default is: False.
+        value by default is: False.
     :create_from_previous: bool, optional
     :param max_wait:  Max time to wait for training data assignment.
     :type max_wait: int, optional


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Extended CreateCustomModelVersionOperator to create Custom Model Version from previous.
Added unit-tests

## Rationale
Users should be able to create new Custom Model version from previous version
