### PR TITLE
[AGENT-4708] Implement Airflow Operator for creating deployment from Model Package

### DIFF
--- a/datarobot_provider/operators/model_package.py
+++ b/datarobot_provider/operators/model_package.py
@@ -13,6 +13,7 @@ import datarobot as dr
 from airflow.exceptions import AirflowException
 from airflow.exceptions import AirflowFailException
 from airflow.models import BaseOperator
+from datarobot.utils.waiters import wait_for_async_resolution
 
 from datarobot_provider.hooks.datarobot import DataRobotHook
 
@@ -81,3 +82,132 @@ class CreateExternalModelPackageOperator(BaseOperator):
         self.log.info(f"External Model Package Created, model_package_id={model_package_id}")
 
         return model_package_id
+
+
+class DeployModelPackageOperator(BaseOperator):
+    """
+    Create a deployment from a DataRobot model package.
+    :deployment_name: A human readable label of the deployment.
+    :deployment_name: str
+    :model_package_id: The ID of the DataRobot model package to deploy.
+    :model_package_id: str
+    :default_prediction_server_id: an identifier of a prediction server to be used as the default prediction server
+        When working with prediction environments, default prediction server Id should not be provided
+    :default_prediction_server_id: str, optional
+    :prediction_environment_id:  An identifier of a prediction environment to be used for model deployment.
+    :prediction_environment_id: str, optional
+    :description: A human readable description of the deployment.
+    :description: str, optional
+    :importance: Deployment importance level.
+    :importance: str, optional
+    :user_provided_id: A user-provided unique ID associated with a deployment definition in a remote git repository.
+    :user_provided_id: str, optional
+    :user_provided_id: A Key/Value pair dict, with additional metadata
+    :user_provided_id: dict, optional
+    :max_wait: The amount of seconds to wait for successful resolution of a deployment creation job.
+        Deployment supports making predictions only after a deployment creating job has successfully finished.
+    :max_wait: int, optional
+    :return: The created deployment ID
+    :rtype: str
+    """
+
+    # Specify the arguments that are allowed to parse with jinja templating
+    template_fields: Iterable[str] = [
+        "deployment_name",
+        "model_package_id",
+        "default_prediction_server_id",
+        "prediction_environment_id",
+        "description",
+        "importance",
+        "user_provided_id",
+        "additional_metadata",
+    ]
+    template_fields_renderers: Dict[str, str] = {}
+    template_ext: Iterable[str] = ()
+    ui_color = '#f4a460'
+
+    def __init__(
+        self,
+        *,
+        deployment_name: str,
+        model_package_id: str,
+        default_prediction_server_id: str = None,
+        prediction_environment_id: str = None,
+        description: str = None,
+        importance: str = None,
+        user_provided_id: str = None,
+        additional_metadata: Dict[str, str] = None,
+        max_wait_sec: int = DEFAULT_MAX_WAIT_SEC,
+        datarobot_conn_id: str = "datarobot_default",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.deployment_name = deployment_name
+        self.model_package_id = model_package_id
+        self.default_prediction_server_id = default_prediction_server_id
+        self.prediction_environment_id = prediction_environment_id
+        self.description = description
+        self.importance = importance
+        self.user_provided_id = user_provided_id
+        self.additional_metadata = additional_metadata
+        self.max_wait_sec = max_wait_sec
+        self.datarobot_conn_id = datarobot_conn_id
+        if kwargs.get('xcom_push') is not None:
+            raise AirflowException(
+                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
+            )
+
+    # Utility method to support creating Deployment from Model Package
+    # Will be refactored after release 3.3 of DataRobot public python client
+    def _create_from_model_package(self) -> str:
+        deployment_payload: Dict[str, Any] = {
+            "model_package_id": self.model_package_id,
+            "label": self.deployment_name,
+            "description": self.description,
+        }
+        if self.default_prediction_server_id and self.prediction_environment_id:
+            raise ValueError(
+                "When working with prediction environments, default prediction server Id should not be provided"
+            )
+        elif self.default_prediction_server_id and self.prediction_environment_id is None:
+            deployment_payload["default_prediction_server_id"] = self.default_prediction_server_id
+        elif self.prediction_environment_id and self.default_prediction_server_id is None:
+            deployment_payload["prediction_environment_id"] = self.prediction_environment_id
+
+        if self.importance:
+            deployment_payload["importance"] = self.importance
+        if self.user_provided_id:
+            deployment_payload["user_provided_id"] = self.user_provided_id
+        if self.additional_metadata:
+            deployment_payload["additional_metadata"] = self.additional_metadata
+        dr_client = dr.client.get_client()
+
+        response = dr_client.post("deployments/fromModelPackage/", data=deployment_payload)
+
+        if response.status_code == 202 and "Location" in response.headers:
+            wait_for_async_resolution(dr_client, response.headers["Location"], self.max_wait_sec)
+            deployment_id = response.json()["id"]
+            return deployment_id
+        else:
+            e_msg = "Server unexpectedly returned status code {}"
+            raise AirflowFailException(e_msg.format(response.status_code))
+
+    def execute(self, context: Dict[str, Any]) -> str:
+        # Initialize DataRobot client
+        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
+
+        if self.deployment_name is None:
+            raise ValueError("deployment_name is required.")
+
+        if self.model_package_id is None:
+            raise ValueError("model_package_id is required.")
+
+        if self.additional_metadata is None:
+            # If additional_metadata not provided, trying to get it from DAG params:
+            self.additional_metadata = context["params"].get("additional_metadata")
+
+        deployment_id = self._create_from_model_package()
+
+        self.log.info(f"Deployment Created, deployment_id={deployment_id}")
+
+        return deployment_id

--- a/tests/unit/operators/test_external_deployment.py
+++ b/tests/unit/operators/test_external_deployment.py
@@ -1,0 +1,121 @@
+# Copyright 2023 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+
+import pytest
+from datarobot.enums import DEPLOYMENT_IMPORTANCE
+
+from datarobot_provider.operators.model_package import DeployModelPackageOperator
+
+
+@pytest.fixture
+def external_deployment_params():
+    return {
+        "model_package_id": "test-model-package-id",
+        "deployment_name": "Test Deployment",
+        "description": "Test Description",
+        "user_provided_id": "test-user-provided-id",
+        "importance": DEPLOYMENT_IMPORTANCE.LOW,
+        "additional_metadata": {"key": "test-key", "value": "test-value"},
+    }
+
+
+def test_operator_create_external_deployment_op(mocker, external_deployment_params):
+    external_deployment_id = "test-external-deployment-id"
+    prediction_environment_id = "test-prediction-environment-id"
+    create_external_deployment_mock = mocker.patch.object(
+        DeployModelPackageOperator,
+        "_create_from_model_package",
+        return_value=external_deployment_id,
+    )
+
+    operator = DeployModelPackageOperator(
+        task_id='create_external_deployment',
+        deployment_name=external_deployment_params["deployment_name"],
+        description=external_deployment_params["description"],
+        model_package_id=external_deployment_params["model_package_id"],
+        prediction_environment_id=prediction_environment_id,
+        importance=external_deployment_params["importance"],
+        user_provided_id=external_deployment_params["user_provided_id"],
+        additional_metadata=external_deployment_params["additional_metadata"],
+        max_wait_sec=1000,
+    )
+
+    operator_result = operator.execute(context={"params": external_deployment_params})
+
+    create_external_deployment_mock.assert_called_with(
+        model_package_id=external_deployment_params["model_package_id"],
+        deployment_name=external_deployment_params["deployment_name"],
+        description=external_deployment_params["description"],
+        default_prediction_server_id=None,
+        prediction_environment_id=prediction_environment_id,
+        importance=DEPLOYMENT_IMPORTANCE.LOW,
+        user_provided_id=external_deployment_params["user_provided_id"],
+        additional_metadata=external_deployment_params["additional_metadata"],
+        max_wait_sec=1000,
+    )
+
+    assert operator_result == external_deployment_id
+
+
+def test_operator_create_deployment_op(mocker, external_deployment_params):
+    default_prediction_server_id = "test-default-prediction-server-id"
+    external_deployment_id = "test-external-deployment-id"
+    create_external_deployment_mock = mocker.patch.object(
+        DeployModelPackageOperator,
+        "_create_from_model_package",
+        return_value=external_deployment_id,
+    )
+
+    operator = DeployModelPackageOperator(
+        task_id='create_external_deployment',
+        deployment_name=external_deployment_params["deployment_name"],
+        description=external_deployment_params["description"],
+        model_package_id=external_deployment_params["model_package_id"],
+        default_prediction_server_id=default_prediction_server_id,
+        importance=external_deployment_params["importance"],
+        user_provided_id=external_deployment_params["user_provided_id"],
+        additional_metadata=external_deployment_params["additional_metadata"],
+        max_wait_sec=1000,
+    )
+
+    operator_result = operator.execute(context={"params": external_deployment_params})
+
+    create_external_deployment_mock.assert_called_with(
+        model_package_id=external_deployment_params["model_package_id"],
+        deployment_name=external_deployment_params["deployment_name"],
+        description=external_deployment_params["description"],
+        default_prediction_server_id=default_prediction_server_id,
+        prediction_environment_id=None,
+        importance=DEPLOYMENT_IMPORTANCE.LOW,
+        user_provided_id=external_deployment_params["user_provided_id"],
+        additional_metadata=external_deployment_params["additional_metadata"],
+        max_wait_sec=1000,
+    )
+
+    assert operator_result == external_deployment_id
+
+
+def test_operator_create_external_deployment_invalid_params_op(mocker, external_deployment_params):
+    default_prediction_server_id = "test-default-prediction-server-id"
+    prediction_environment_id = "test-prediction-environment-id"
+
+    operator = DeployModelPackageOperator(
+        task_id='create_external_deployment',
+        deployment_name=external_deployment_params["deployment_name"],
+        description=external_deployment_params["description"],
+        model_package_id=external_deployment_params["model_package_id"],
+        default_prediction_server_id=default_prediction_server_id,
+        prediction_environment_id=prediction_environment_id,
+        importance=external_deployment_params["importance"],
+        user_provided_id=external_deployment_params["user_provided_id"],
+        additional_metadata=external_deployment_params["additional_metadata"],
+        max_wait_sec=1000,
+    )
+
+    with pytest.raises(ValueError):
+        operator.execute(context={"params": external_deployment_params})


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Added DeployModelPackageOperator for creating deployment from model package
extended sample DAG
added unit-tests

## Rationale
users should be able to create external model deployment using Airflow operators
