### PR TITLE
[AGENT-4928] Fix warning related to user_agent_suffix deprecation

### DIFF
--- a/datarobot_provider/example_dags/datarobot_custom_model_pipeline_dag.py
+++ b/datarobot_provider/example_dags/datarobot_custom_model_pipeline_dag.py
@@ -39,6 +39,7 @@ from datarobot_provider.operators.custom_models import GetCustomModelTestOverall
         "target_type": TARGET_TYPE.REGRESSION,
         "target_name": 'Grade 2014',
         "is_major_update": True,
+        "is_training_data_for_versions_permanently_enabled": True,
         "docker_context_path": "/usr/local/airflow/dags/datarobot-user-models/public_dropin_environments/python3_pytorch/",
         "custom_model_folder": "/usr/local/airflow/dags/datarobot-user-models/model_templates/python3_pytorch/",
         "test_dataset_file_path": "/usr/local/airflow/dags/datarobot-user-models/tests/testdata/juniors_3_year_stats_regression.csv",

--- a/datarobot_provider/hooks/datarobot.py
+++ b/datarobot_provider/hooks/datarobot.py
@@ -86,7 +86,7 @@ class DataRobotHook(BaseHook):
             provider_package_name, provider_versions, AIRFLOW_VERSION
         )
         self.log.info("Initialize DataRobot Client, user_agent_suffix:{}".format(user_agent_suffix))
-        return Client(token=api_key, endpoint=endpoint, user_agent_suffix=user_agent_suffix)
+        return Client(token=api_key, endpoint=endpoint, trace_context=user_agent_suffix)
 
     def run(self) -> Any:
         # Initialize DataRobot client


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Changed to trace_context because of user_agent_suffix deprecation

## Rationale
Changed to trace_context because of user_agent_suffix deprecation