### PR TITLE
[AGENT-5162] Migrate cicd pipelines for repository airflow-provider-datarobot to harness added lint check

### DIFF
--- a/.harness/default_input_set.yaml
+++ b/.harness/default_input_set.yaml
@@ -1,0 +1,14 @@
+inputSet:
+  name: default_input_set
+  identifier: default_input_set
+  orgIdentifier: AGENTS
+  projectIdentifier: airflowproviderdatarobot
+  pipeline:
+    identifier: lint_check
+    properties:
+      ci:
+        codebase:
+          build:
+            type: PR
+            spec:
+              number: <+trigger.prNumber>

--- a/.harness/lint_check.yaml
+++ b/.harness/lint_check.yaml
@@ -1,0 +1,45 @@
+pipeline:
+  name: lint_check
+  identifier: lint_check
+  projectIdentifier: airflowproviderdatarobot
+  orgIdentifier: AGENTS
+  tags: {}
+  properties:
+    ci:
+      codebase:
+        connectorRef: account.svc_harness_git1
+        repoName: airflow-provider-datarobot
+        build: <+input>
+  stages:
+    - parallel:
+        - stage:
+            name: lint
+            identifier: lint
+            description: ""
+            type: CI
+            spec:
+              infrastructure:
+                type: KubernetesDirect
+                spec:
+                  connectorRef: account.cigeneral
+                  namespace: harness-delegate-ng
+                  automountServiceAccountToken: true
+                  nodeSelector: {}
+                  os: Linux
+              cloneCodebase: true
+              execution:
+                steps:
+                  - step:
+                      type: Run
+                      name: lint check step
+                      identifier: Run_1
+                      spec:
+                        connectorRef: account.dockerhub_datarobot_read
+                        image: python:3.9
+                        shell: Bash
+                        command: |-
+                          set -exuo pipefail
+                          pip install -U pip
+                          pip install -r requirements.txt
+                          pip install pylint
+                          make lint


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
 - Added harness pipeline with lint check and configured trigger for each commit in scope of migrating cicd pipelines to harness.io

## Rationale
