### PR TITLE
[AGENT-5162] Adding build-and-publish cicd pipeline to harness

### DIFF
--- a/.harness/build_and_publish_pipy.yaml
+++ b/.harness/build_and_publish_pipy.yaml
@@ -1,0 +1,71 @@
+pipeline:
+  name: build_and_publish_pipy
+  identifier: build_and_publish_pipy
+  projectIdentifier: airflowproviderdatarobot
+  orgIdentifier: AGENTS
+  tags: {}
+  properties:
+    ci:
+      codebase:
+        connectorRef: account.svc_harness_git1
+        repoName: airflow-provider-datarobot
+        build: <+input>
+  stages:
+    - parallel:
+        - stage:
+            name: build_and_publish
+            identifier: build_and_publish
+            description: ""
+            type: CI
+            spec:
+              infrastructure:
+                type: KubernetesDirect
+                spec:
+                  connectorRef: account.cigeneral
+                  namespace: harness-delegate-ng
+                  automountServiceAccountToken: true
+                  nodeSelector: {}
+                  os: Linux
+              cloneCodebase: true
+              execution:
+                steps:
+                  - step:
+                      type: Run
+                      name: build_step
+                      identifier: Run_build
+                      spec:
+                        connectorRef: account.dockerhub_datarobot_read
+                        image: python:3.9
+                        shell: Bash
+                        command: |-
+                          set -exuo pipefail
+                          pip install -U pip
+                          pip install --upgrade pip wheel setuptools
+                          pip install -r requirements.txt
+                          pip install --upgrade build twine
+                          echo "Building wheel..."
+                          python -m build --no-isolation
+                          echo "Building wheel...OK"
+                          echo $(ls)
+                  - step:
+                      type: Run
+                      name: publish_step
+                      identifier: Run_publish
+                      spec:
+                        envVariables:
+                          PYPI_TOKEN: <+secrets.getValue("airflow-provider-datarobot")>
+                        connectorRef: account.dockerhub_datarobot_read
+                        image: python:3.9
+                        shell: Bash
+                        command: |-
+                          set -exuo pipefail
+                          pip install --upgrade twine
+                          echo "Publishing wheel to pip..."
+                          echo $(ls dist)
+                          twine upload dist/*.whl \
+                            --username "__token__" \
+                            --password "$PYPI_TOKEN" \
+                            --non-interactive \
+                            --verbose \
+                            --disable-progress-bar
+                          echo "Finished successfully!"


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Added build-and-publish cicd pipeline to harness.io

## Rationale
