### PR TITLE
[PRED-11010] Fix GetOrCreateCredentialOperator occurring when JDBCDataSourceHook is used.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @elatt @oleksandr-saienko @dulcardo @alexromanyuk
+*       @elatt @oleksandr-saienko @dulcardo @alexromanyuk @andrius-senulis

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @elatt @oleksandr-saienko @dulcardo @alexromanyuk @andrius-senulis
+*       @elatt @alexromanyuk @andrius-senulis

--- a/datarobot_provider/operators/credentials.py
+++ b/datarobot_provider/operators/credentials.py
@@ -67,10 +67,12 @@ class GetOrCreateCredentialOperator(BaseOperator):
             # Trying to find an Airflow preconfigured credentials for provided credential name
             # to replicate credentials on DataRobot side:
             self.log.info(
-                f'Credentials :{credential.name} not found, id={credential.credential_id} '
-                f'for param {self.credentials_param_name}'
+                f'Credentials with name {credential_name} not found in DataRobot, trying to find '
+                'Airflow connection with the same name'
             )
-            credentials, credentials_data = CredentialsBaseHook.get_hook(
-                conn_id=credential_name
-            ).run()
+            hook = CredentialsBaseHook.get_hook(conn_id=credential_name)
+            if hook.conn_type == 'datarobot.datasource.jdbc':
+                credentials, _, _ = hook.run()
+            else:
+                credentials, _ = hook.run()
             return credentials.credential_id

--- a/tests/unit/operators/test_credentials.py
+++ b/tests/unit/operators/test_credentials.py
@@ -32,6 +32,18 @@ def test_operator_get_credential_not_found(mocker):
         )
 
 
+def test_operator_get_credential_not_found_in_datarobot(mock_airflow_connection_datarobot_jdbc):
+    operator = GetOrCreateCredentialOperator(task_id='get_credentials')
+    credential_id = operator.execute(
+        context={
+            "params": {
+                "datarobot_credentials_name": "datarobot_test_connection_jdbc_test",
+            },
+        }
+    )
+    assert credential_id == 'test-credentials-id'
+
+
 def test_operator_get_basic_credential_id(
     mocker, mock_airflow_connection_datarobot_basic_credentials
 ):


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale
