### PR TITLE
[MLDEV-1124] Update codeowners to have a more domain-oriented review process

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,14 @@
-*       @elatt @alexromanyuk @andrius-senulis
+/                                                        @datarobot/core-backend
+/.harness                                                @datarobot/continuous-integration
+/datarobot_provider                                      @datarobot/machine-learning-development
+/datarobot_provider/operators/ai_catalog.py              @datarobot/mldata
+/datarobot_provider/operators/connections.py             @datarobot/mldata
+/datarobot_provider/operators/feature_discovery.py       @datarobot/trust-explainable-ai
+/datarobot_provider/operators/mlops.py                   @datarobot/model-management
+/datarobot_provider/operators/model_insights.py          @datarobot/trust-explainable-ai
+/datarobot_provider/operators/model_package.py           @datarobot/model-management
+/datarobot_provider/operators/model_predictions.py       @datarobot/predictions
+/datarobot_provider/operators/monitoring.py              @datarobot/model-management
+/datarobot_provider/operators/monitoring_job.py          @datarobot/model-management
+/datarobot_provider/operators/prediction_explanations.py @datarobot/trust-explainable-ai
+/tests/                                                  @datarobot/machine-learning-development

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-/                                                        @datarobot/machine-learning-development
+*                                                        @datarobot/machine-learning-development
 /.harness                                                @datarobot/continuous-integration
 /datarobot_provider                                      @datarobot/machine-learning-development
 /datarobot_provider/operators/ai_catalog.py              @datarobot/mldata

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-/                                                        @datarobot/core-backend
+/                                                        @datarobot/machine-learning-development
 /.harness                                                @datarobot/continuous-integration
 /datarobot_provider                                      @datarobot/machine-learning-development
 /datarobot_provider/operators/ai_catalog.py              @datarobot/mldata

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,12 +1,12 @@
 *                                                        @datarobot/machine-learning-development
 /datarobot_provider/operators/ai_catalog.py              @datarobot/mldata
 /datarobot_provider/operators/connections.py             @datarobot/mldata
-/datarobot_provider/operators/feature_discovery.py       @datarobot/trust-explainable-ai
+/datarobot_provider/operators/feature_discovery.py       @datarobot/mldata
 /datarobot_provider/operators/mlops.py                   @datarobot/model-management
 /datarobot_provider/operators/model_insights.py          @datarobot/trust-explainable-ai
 /datarobot_provider/operators/model_package.py           @datarobot/model-management
 /datarobot_provider/operators/model_predictions.py       @datarobot/predictions
 /datarobot_provider/operators/monitoring.py              @datarobot/model-management
-/datarobot_provider/operators/monitoring_job.py          @datarobot/model-management
+/datarobot_provider/operators/monitoring_job.py          @datarobot/tracking-agent
 /datarobot_provider/operators/prediction_explanations.py @datarobot/trust-explainable-ai
 /tests/                                                  @datarobot/machine-learning-development

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,4 @@
 *                                                        @datarobot/machine-learning-development
-/.harness                                                @datarobot/continuous-integration
-/datarobot_provider                                      @datarobot/machine-learning-development
 /datarobot_provider/operators/ai_catalog.py              @datarobot/mldata
 /datarobot_provider/operators/connections.py             @datarobot/mldata
 /datarobot_provider/operators/feature_discovery.py       @datarobot/trust-explainable-ai


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
This is a rough first draft at attempting to allocate the review into the appropriate slack channels so it doesn't always ping the 3 people listed in the codeowners file. It could be good to improve this by adding in some linter automation for the codeowners file (e.g. `code-owners format -i` as supported in the monolith) and some checks related to this. First I just want to at least get it where the reviews are being spread out to the domains/individuals working on things.

I think that `machine-learning-development` is probably an ok owner of the base files, and `continuous-integration` can be tagged on harness related changes. Actual test/dag changes and other areas, we'll need to sort of identify as this project progresses and we can dynamically improve on the codeowners file.


## Rationale
- Make codeowners point at domains
