### PR TITLE
[MLDEV-1126] Improve makefile commands for astro dev environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,6 @@ cython_debug/
 
 # Jupyter notebooks
 notebooks/
+
+# Astro development environments
+astro-dev/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,18 @@
 SHELL := bash
 
+# Determine the operating system
+# "darwin" or "linux"
+OS_NAME := $(shell uname -s | tr A-Z a-z)
+ifeq ($(OS_NAME), darwin)
+	ASTRO_CMD=brew install astro
+else
+	ASTRO_CMD=curl -sSL install.astronomer.io | sudo bash -s
+endif
+
 .PHONY: black isort lint typecheck check-licenses fix-licenses unit-tests
+
+req:
+	pip install -r requirements.txt
 
 lint:
 	flake8
@@ -24,3 +36,34 @@ fix-licenses:
 
 check-licenses:
 	docker run  --rm -v $(CURDIR):/github/workspace ghcr.io/apache/skywalking-eyes/license-eye:785bb7f3810572d6912666b4f64bad28e4360799 -v info -c .licenserc.yaml header check
+
+install-astro:
+	$(ASTRO_CMD)
+
+create-astro-dev:
+	mkdir astro-dev
+	cd astro-dev && astro dev init
+	echo "RUN pip install -r \"/usr/local/airflow/requirements_dev.txt\"" >> ./astro-dev/Dockerfile
+
+reset-astro-dev:
+	rm -rf astro-dev
+	$(MAKE) install-astro
+	$(MAKE) create-astro-dev
+
+start-astro-dev:
+	cd astro-dev && astro dev start
+
+stop-astro-dev:
+	cd astro-dev && astro dev stop
+
+build-astro-dev:
+	echo "For testing remember to bump datarobot_provider/__init__.py and setup.py versions"
+	cd astro-dev && astro dev stop
+	pip install --upgrade build
+	python -m build
+	cp -r ./datarobot_provider/example_dags/* ./astro-dev/dags/
+	cp -p "`ls -dtr1 ./dist/*.whl | sort -n | tail -1`" "./astro-dev/"
+	echo "/usr/local/airflow/`find ./dist/*.whl -exec basename {} \; | sort -n | tail -1`" > \
+ 		./astro-dev/requirements_dev.txt
+	cd astro-dev && astro dev start
+

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ stop-astro-dev:
 build-astro-dev:
 	echo "For testing remember to bump datarobot_provider/__init__.py and setup.py versions"
 	cd astro-dev && astro dev stop
+	rm -rf ./dist
 	pip install --upgrade build
 	python -m build
 	cp -r ./datarobot_provider/example_dags/* ./astro-dev/dags/

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,6 @@ stop-astro-dev:
 	cd astro-dev && astro dev stop
 
 build-astro-dev:
-	echo "For testing remember to bump datarobot_provider/__init__.py and setup.py versions"
 	$(MAKE) stop-astro-dev
 	cd astro-dev && astro dev stop
 	rm -rf ./dist

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,6 @@ create-astro-dev:
 
 reset-astro-dev:
 	rm -rf astro-dev
-	$(MAKE) install-astro
 	$(MAKE) create-astro-dev
 
 start-astro-dev:

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ create-astro-dev:
 	echo "RUN pip install -r \"/usr/local/airflow/requirements_dev.txt\"" >> ./astro-dev/Dockerfile
 
 clean-astro-dev:
+	$(MAKE) stop-astro-dev
 	rm -rf astro-dev
 	$(MAKE) create-astro-dev
 
@@ -58,7 +59,6 @@ stop-astro-dev:
 
 build-astro-dev:
 	$(MAKE) stop-astro-dev
-	cd astro-dev && astro dev stop
 	rm -rf ./dist
 	pip install --upgrade build
 	python -m build

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ stop-astro-dev:
 
 build-astro-dev:
 	echo "For testing remember to bump datarobot_provider/__init__.py and setup.py versions"
+	$(MAKE) stop-astro-dev
 	cd astro-dev && astro dev stop
 	rm -rf ./dist
 	pip install --upgrade build
@@ -65,5 +66,4 @@ build-astro-dev:
 	cp -p "`ls -dtr1 ./dist/*.whl | sort -n | tail -1`" "./astro-dev/"
 	echo "/usr/local/airflow/`find ./dist/*.whl -exec basename {} \; | sort -n | tail -1`" > \
  		./astro-dev/requirements_dev.txt
-	cd astro-dev && astro dev start
-
+	$(MAKE) start-astro-dev

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ install-astro:
 create-astro-dev:
 	mkdir astro-dev
 	cd astro-dev && astro dev init
+	grep -qF -- 'RUN pip install -r \"/usr/local/airflow/requirements_dev.txt\"' ./astro-dev/Dockerfile || \
 	echo "RUN pip install -r \"/usr/local/airflow/requirements_dev.txt\"" >> ./astro-dev/Dockerfile
 
 reset-astro-dev:

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ create-astro-dev:
 	grep -qF -- 'RUN pip install -r \"/usr/local/airflow/requirements_dev.txt\"' ./astro-dev/Dockerfile || \
 	echo "RUN pip install -r \"/usr/local/airflow/requirements_dev.txt\"" >> ./astro-dev/Dockerfile
 
-reset-astro-dev:
+clean-astro-dev:
 	rm -rf astro-dev
 	$(MAKE) create-astro-dev
 

--- a/README.md
+++ b/README.md
@@ -1586,25 +1586,17 @@ operators and DAGs. The following steps will construct the two environments need
 _Note: The default username and password will both be `admin` in the astro project._
 
 ### Updating Operators in the Dev Environment
-1. Build the python package in the `airflow-provider-datarobot` repo.
+- Test, compile, and run new or updated operators on the development package with:
     ```bash
-        pip install --upgrade build
-        python -m build
+        make build-astro-dev
     ```
-2. The resulting wheel will be present in the `airflow-provider-datarobot/dist/` folder.
-3. Copy the wheel to the `airflow-dev` project.
+- Manually start the airflow dev environment without rebuilding the package with:
     ```bash
-        cp ~/workspace/airflow-provider-datarobot/dist/*.whl ~/workspace/airflow-dev/
+        make start-astro-dev
     ```
-4. Add the new wheel to the `requirements.txt` file in the `airflow-dev` project. You
-may want to update this version when testing. Make sure `X.Y.Z` is the version built in
-step 1.
+- Manually stop the airflow dev environment without rebuilding the package with:
     ```bash
-        echo "airflow-provider-datarobot==X.Y.Z" >> requirements.txt
-    ```
-6. Start the new environment and wait for the packages to be resolved and the environment to be built.
-    ```bash
-        astro dev start
+        make stop-astro-dev
     ```
 
 ## Issues

--- a/README.md
+++ b/README.md
@@ -1575,7 +1575,7 @@ operators and DAGs. The following steps will construct the two environments need
     ```
 2. Build an astro development environment with the following command:
     ```bash
-        make reset-astro-dev
+        make create-astro-dev
     ```
 3. A new `./astro-dev` folder will be constructed for you to use as a development and test environment.
 4. Compile and run airflow on the development package with:
@@ -1597,6 +1597,10 @@ _Note: The default username and password will both be `admin` in the astro proje
 - Manually stop the airflow dev environment without rebuilding the package with:
     ```bash
         make stop-astro-dev
+    ```
+- If there are problems with the airflow environment you can reset it to a clean state with:
+    ```bash
+        make clean-astro-dev
     ```
 
 ## Issues

--- a/README.md
+++ b/README.md
@@ -1583,7 +1583,8 @@ operators and DAGs. The following steps will construct the two environments need
         make build-astro-dev
     ```
 
-_Note: The default username and password will both be `admin` in the astro project._
+_Note: All credentials and logins will be printed in the terminal after running
+the `build-astro-dev` command._
 
 ### Updating Operators in the Dev Environment
 - Test, compile, and run new or updated operators on the development package with:

--- a/README.md
+++ b/README.md
@@ -1567,12 +1567,20 @@ operators and DAGs. The following steps will construct the two environments need
         pyenv local airflow-provider-datarobot
         pip install -r requirements.txt
     ```
-3. Create a new astro project
+
+### Astro Setup
+1. (OPTIONAL) Install astro with the following command or manually from the links above:
     ```bash
-        cd ~/workspace
-        mkdir airflow-dev
-        cd airflow-dev/
-        astro dev init
+        make install-astro
+    ```
+2. Build an astro development environment with the following command:
+    ```bash
+        make reset-astro-dev
+    ```
+3. A new `./astro-dev` folder will be constructed for you to use as a development and test environment.
+4. Compile and run airflow on the development package with:
+    ```bash
+        make build-astro-dev
     ```
 
 _Note: The default username and password will both be `admin` in the astro project._


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
This PR reworks some of the `Makefile` to make the development flow much smoother and quicker. We don't include the `airflow_provider_datarobot` as a package directly anymore and just point at a second `requirements_dev.txt` that is used after the initial image is built, but before the airflow environment is started. The `Makefile` will take care of adjusting the `Dockerfile` and `requirements_dev.txt` files during rebuilds.

The reason for using this slightly offset approach is that the `Docker` environment inside astro runs a few different commands, and the files are not present inside the container at the stage where the `requirements.txt` is read and executed. We need to wait until the initial container is constructed and execute a second `pip install` command between the initial build, and the airflow environment actually executing.

The makefile basically shortens the build flow by:
- Stop running airflow environments in astro
- Cleaning out the `dist` folder
- Building the current package to a wheel
- Updating the `requirements_dev.txt` with the wheel location directly (we don't use a `==` here because we just want to directly install whatever is in the wheel. This avoids having to bump/change versions during development)
- Restarting and rebuilding the astro environment

_This process takes ~10-30 seconds from start to finish, so it's pretty fast to keep dev times easy_

I also added helper files with OS detection for:
- Installing astro
- Creating a dev environment
- Starting/stopping astro
- Rebuilding the environment
