### PR TITLE
[MLDEV-1137] Add api docs as co-owner for docs in repo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,4 +9,5 @@
 /datarobot_provider/operators/monitoring.py              @datarobot/model-management
 /datarobot_provider/operators/monitoring_job.py          @datarobot/tracking-agent
 /datarobot_provider/operators/prediction_explanations.py @datarobot/trust-explainable-ai
+/docs                                                    @datarobot/api-docs
 /tests/                                                  @datarobot/machine-learning-development


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Add @datarobot/api-docs as the owner for the docs repo. Please let me know if this isn't the right team.
