### PR TITLE
Use 3.12 as primary dev version, support 3.9-3.13

### DIFF
--- a/.harness/build_and_publish_pipy.yaml
+++ b/.harness/build_and_publish_pipy.yaml
@@ -35,7 +35,7 @@ pipeline:
                       identifier: Run_build
                       spec:
                         connectorRef: account.dockerhub_datarobot_read
-                        image: python:3.11
+                        image: python:3.12-alpine
                         shell: Bash
                         command: |-
                           set -exuo pipefail
@@ -55,7 +55,7 @@ pipeline:
                         envVariables:
                           PYPI_TOKEN: <+secrets.getValue("PyPI_token_for_airflow-provider-datarobot")>
                         connectorRef: account.dockerhub_datarobot_read
-                        image: python:3.11
+                        image: python:3.12-alpine
                         shell: Bash
                         command: |-
                           set -exuo pipefail

--- a/.harness/cichecks.yaml
+++ b/.harness/cichecks.yaml
@@ -36,7 +36,7 @@ pipeline:
                         identifier: run_lint
                         spec:
                           connectorRef: account.dockerhub_datarobot_read
-                          image: python:3.11
+                          image: python:3.12-alpine
                           shell: Bash
                           command: |-
                             set -exuo pipefail
@@ -49,7 +49,7 @@ pipeline:
                         identifier: format_lint
                         spec:
                           connectorRef: account.dockerhub_datarobot_read
-                          image: python:3.11
+                          image: python:3.12-alpine
                           shell: Bash
                           command: |-
                             set -exuo pipefail
@@ -79,7 +79,7 @@ pipeline:
                       identifier: run_unit_tests
                       spec:
                         connectorRef: account.dockerhub_datarobot_read
-                        image: python:3.11
+                        image: python:3.12-alpine
                         shell: Bash
                         command: |-
                           set -exuo pipefail

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,17 +4,20 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "airflow-provider-datarobot"
-version = "0.0.10"
+version = "0.0.12"
 description = "DataRobot Airflow provider."
 readme = "README.md"
-requires-python = "~=3.11"
+requires-python = ">=3.9"
 license = {text = "DataRobot Tool and Utility Agreement"}
 authors = [
    {name = "DataRobot", email = "support@datarobot.com"}
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: Other/Proprietary License",
 ]
 dependencies = [
@@ -46,7 +49,7 @@ provider_info = "datarobot_provider.__init__:get_provider_info"
 [tool.ruff]
 # General settings
 line-length = 100
-target-version = "py311"
+target-version = "py312"
 
 # Extend default excludes (based on Flake8 configuration)
 exclude = [


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

We should aim to use 3.12 for development, but clients of this package may use older versions of Python, therefore we should test and support of them. This:
* set's python 3.12 as primary version for CI and local development 
* updates requirement to allow versions 3.9 and older
* implements matrix to run tests on all supported versions

## Rationale
