### PR TITLE
[-] Tweaks to mypy config and ignore error code additions

### DIFF
--- a/datarobot_provider/hooks/credentials.py
+++ b/datarobot_provider/hooks/credentials.py
@@ -269,7 +269,7 @@ class GoogleCloudCredentialsHook(CredentialsBaseHook):
 
         self.log.info(f"Updating Google Cloud Credentials:{self.datarobot_credentials_conn_id}")
         try:
-            credential.update(**gcp_credentials)  # type: ignore
+            credential.update(**gcp_credentials)  # type: ignore[arg-type]
 
         except Exception as e:
             self.log.error(

--- a/datarobot_provider/operators/credentials.py
+++ b/datarobot_provider/operators/credentials.py
@@ -72,8 +72,8 @@ class GetOrCreateCredentialOperator(BaseOperator):
                 "Airflow connection with the same name"
             )
             hook = CredentialsBaseHook.get_hook(conn_id=credential_name)
-            if hook.conn_type == "datarobot.datasource.jdbc":  # type: ignore
-                credentials, _, _ = hook.run()  # type: ignore
+            if hook.conn_type == "datarobot.datasource.jdbc":  # type: ignore[attr-defined]
+                credentials, _, _ = hook.run()  # type: ignore[attr-defined]
             else:
-                credentials, _ = hook.run()  # type: ignore
+                credentials, _ = hook.run()  # type: ignore[attr-defined]
             return credentials.credential_id

--- a/datarobot_provider/operators/datarobot.py
+++ b/datarobot_provider/operators/datarobot.py
@@ -157,13 +157,13 @@ class DeployModelMixin:
         self, model_id: str, label: str, description: Optional[str] = None
     ) -> dr.Deployment:
         """Deploys the provided model to production."""
-        self.log.info(f"Deploying model_id={model_id} with label={label}")  # type: ignore
+        self.log.info(f"Deploying model_id={model_id} with label={label}")  # type: ignore[attr-defined]
         prediction_server = dr.PredictionServer.list()[0]
         deployment = dr.Deployment.create_from_learning_model(
             model_id, label, description, prediction_server.id
         )
-        self.log.info(f"Model deployed: deployment_id={deployment.id}")  # type: ignore
-        self.log.info("Enabling tracking for target drift and feature drift")  # type: ignore
+        self.log.info(f"Model deployed: deployment_id={deployment.id}")  # type: ignore[attr-defined]
+        self.log.info("Enabling tracking for target drift and feature drift")  # type: ignore[attr-defined]
         deployment.update_drift_tracking_settings(
             target_drift_enabled=True, feature_drift_enabled=True, max_wait=DATAROBOT_MAX_WAIT
         )

--- a/datarobot_provider/operators/feature_discovery.py
+++ b/datarobot_provider/operators/feature_discovery.py
@@ -287,7 +287,7 @@ class DatasetRelationshipOperator(BaseOperator):
             dataset2_identifier=self.dataset2_identifier,  # to transactions
             dataset1_keys=self.dataset1_keys,  # on CustomerID
             dataset2_keys=self.dataset2_keys,
-            feature_derivation_windows=self.feature_derivation_windows,  # type: ignore
+            feature_derivation_windows=self.feature_derivation_windows,  # type: ignore[arg-type]
             prediction_point_rounding=self.prediction_point_rounding,
             prediction_point_rounding_time_unit=self.prediction_point_rounding_time_unit,
             feature_derivation_window_start=self.feature_derivation_window_start,

--- a/datarobot_provider/operators/monitoring.py
+++ b/datarobot_provider/operators/monitoring.py
@@ -235,7 +235,7 @@ class UpdateMonitoringSettingsOperator(BaseOperator):
             )
 
         # Possibly a bug: deployment.get_association_id_settings returns str
-        current_association_id_settings: dict = deployment.get_association_id_settings()  # type: ignore
+        current_association_id_settings: dict = deployment.get_association_id_settings()  # type: ignore[assignment]
 
         association_id_column = context["params"].get(
             "association_id_column", current_association_id_settings["column_names"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,9 +85,14 @@ quote-style = "double"
 
 [tool.mypy]
 python_version = 3.12
+enable_error_code = "ignore-without-code"
 ignore_missing_imports = true
 follow_imports_for_stubs = true
+no_implicit_optional = true
+show_column_numbers = true
 warn_redundant_casts = true
+# warn_return_any = true  # TODO: Enable this check
+warn_unused_configs = true
 warn_unused_ignores = true
 show_error_codes = true
 pretty = true


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Tweak/alter the mypy config

## Rationale

By adding `enable_error_code = "ignore-without-code"` I believe this follows good practice to enforce contributors to ignore explicit errors if they are going to leverage the "ignore option"

I've then updated to add error codes to existing `ignore`'s

Also other updates to the mypy config I've found valuable.

I've added one config value commented out: `warn_return_any = true`
I believe it is a valuable addition however when running mypy _without_ it commented out we get:
`Found 23 errors in 13 files (checked 72 source files)`

<img width="1074" alt="Screenshot 2025-01-21 at 10 08 13 AM" src="https://github.com/user-attachments/assets/c9ce01e4-1061-4ac0-9305-d657fadd7d6b" />
