### PR TITLE
[MLDEV-1170] Prepare script to generate stuff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,3 +80,6 @@ build-astro-dev:
 
 copy-examples-astro-dev:
 	cp -r ./datarobot_provider/example_dags/* ./astro-dev/dags/
+
+autogen-operators:
+	python ./datarobot_provider/autogen/generate_operator.py --whitelist ./datarobot_provider/autogen/whitelist.yaml --output_folder ./datarobot_provider/operators/gen

--- a/datarobot_provider/autogen/generate_operator.py
+++ b/datarobot_provider/autogen/generate_operator.py
@@ -45,11 +45,11 @@ class GenerateOperators:
 
         Parameters
         ----------
-        module_key
+        module_key : str
             The module name.
-        module_obj_key
+        module_obj_key : str
             The object name within the module.
-        method
+        method : str
             The method name.
         method_docstring : NumpyDocString
             The docstring for the method.

--- a/datarobot_provider/autogen/generate_operator.py
+++ b/datarobot_provider/autogen/generate_operator.py
@@ -5,9 +5,13 @@
 # This is proprietary source code of DataRobot, Inc. and its affiliates.
 #
 # Released under the terms of DataRobot Tool and Utility Agreement.
+import argparse
 import importlib
+from collections import defaultdict
+from pathlib import Path
 
 import black
+import yaml
 from numpydoc.docscrape import NumpyDocString
 
 
@@ -41,26 +45,24 @@ class GenerateOperators:
 
         Parameters
         ----------
-        module_key : str
+        module_key
             The module name.
-        module_obj_key : str
+        module_obj_key
             The object name within the module.
-        method : str
+        method
             The method name.
         method_docstring : NumpyDocString
             The docstring for the method.
 
         Returns
         -------
-        str
-            The generated operator code.
+        The generated operator code.
         """
         print(f"Generating operator for {module_obj_key} {method}")
         doc = NumpyDocString(str(method_docstring))
         operator_name = f"{module_obj_key}{method.title()}Operator"
         op_python_code = (
-            f"from {module_key} import {module_obj_key}\n\n"
-            + f"class {operator_name}(BaseOperator):\n"
+            f"class {operator_name}(BaseOperator):\n"
             + cls.construct_operator_docstring(doc)
             + "\n\n"
             + cls.construct_operator_attibutes(doc)
@@ -70,8 +72,52 @@ class GenerateOperators:
             + cls.construct_operator_execute(doc, module_key, module_obj_key, method)
             + "\n"
         )
+        op_python_code = (
+            cls.construct_imports(op_python_code, module_key, module_obj_key)
+            + "\n\n"
+            + op_python_code
+        )
         op_python_code = cls.format_code_block_with_black(op_python_code)
         return op_python_code
+
+    @staticmethod
+    def construct_imports(code: str, module_key: str, module_obj_key: str) -> str:
+        """Construct the imports code for the operator.
+
+        Parameters
+        ----------
+        module_key : str
+            The module name.
+        module_obj_key : str
+            The object name within the module.
+
+        Returns
+        -------
+        The constructed imports code.
+        """
+        imports = [
+            ("Sequence", "from collections.abc import Sequence"),
+            ("Any", "from typing import Any"),
+            ("Optional", "from typing import Optional"),
+            ("",),
+            ("AirflowException", "from airflow.exceptions import AirflowException"),
+            ("BaseOperator", "from airflow.models import BaseOperator"),
+            ("Context", "from airflow.utils.context import Context"),
+            (f"from {module_key} import {module_obj_key}",),
+            ("",),
+            ("DataRobotHook", "from datarobot_provider.hooks.datarobot import DataRobotHook"),
+        ]
+        actual_imports = []
+        for imprt in imports:
+            # tuples with length one are required imports
+            if len(imprt) == 1:
+                actual_imports.append(imprt[0])
+            # others are optional imports
+            else:
+                if imprt[0] in code:
+                    actual_imports.append(imprt[1])
+
+        return "\n".join(actual_imports)
 
     @staticmethod
     def format_code_block_with_black(code_block: str) -> str:
@@ -142,7 +188,7 @@ class GenerateOperators:
         """
         op_init = "\tdef __init__(self,*,"
         for param in docstring["Parameters"]:
-            op_init += f"{param.name}: {param.type} = None,"
+            op_init += f"{param.name}: Optional[{param.type}] = None,"
         op_init += 'datarobot_conn_id: str = "datarobot_default",\n'
         op_init += "**kwargs: Any) -> None:\n"
         op_init += "\t\tsuper().__init__(**kwargs)\n"
@@ -185,9 +231,53 @@ class GenerateOperators:
                 f'\t\t\traise ValueError("{param.name} is required for {operator_name}.")\n'
             )
         op_execute += "\n"
-        op_execute += f"\t\tresult = {operator_module}.{operator_name}.{operator_method}(\n\t\t"
+        op_execute += f"\t\tresult = {operator_name}.{operator_method}(\n\t\t"
         for param in docstring["Parameters"]:
             op_execute += f"self.{param.name}, "
         op_execute += "\n\t)\n"
         op_execute += "\t\treturn result.id\n"
         return op_execute
+
+
+parser = argparse.ArgumentParser(description="Generate code for DataRobot provider")
+parser.add_argument("--whitelist", type=str, help="Whitelist file path")
+parser.add_argument("--output_folder", type=str, help="Output folder path")
+
+
+def to_snake_case(camel_case_str):
+    return "".join(["_" + i.lower() if i.isupper() else i for i in camel_case_str]).lstrip("_")
+
+
+def main(whitelist_path: Path, output_folder: Path):
+    # load whitelist yaml
+    with open(whitelist_path, "r") as f:
+        whitelist = yaml.safe_load(f)
+
+    # generate operators
+    generator = GenerateOperators(whitelist)
+    generated_code = generator.generate()
+    modules: dict[str, dict[str, str]] = defaultdict(dict)
+    for operator_key, code in generated_code.items():
+        _, module_name, operator_name = operator_key.split(".")
+        modules[module_name][operator_name] = code
+
+    # write generated code to files
+    for module_name, operators in modules.items():
+        module_folder = output_folder / module_name
+        module_folder.mkdir(parents=True, exist_ok=True)
+        for operator_name, code in operators.items():
+            # transform operator name from camel case to snake case
+            operator_file_name = to_snake_case(operator_name)
+            with open(module_folder / f"{operator_file_name}.py", "w") as f:
+                f.write(code)
+
+        # write init file, one line for each module
+        with open(module_folder / "__init__.py", "w") as f:
+            for operator_name in operators.keys():
+                operator_file_name = to_snake_case(operator_name)
+                f.write(f"from .{operator_file_name} import {operator_name} as {operator_name}\n")
+
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    main(Path(args.whitelist), Path(args.output_folder))

--- a/datarobot_provider/operators/gen/modeljob/__init__.py
+++ b/datarobot_provider/operators/gen/modeljob/__init__.py
@@ -1,0 +1,1 @@
+from .model_job_get_operator import ModelJobGetOperator as ModelJobGetOperator

--- a/datarobot_provider/operators/gen/modeljob/model_job_get_operator.py
+++ b/datarobot_provider/operators/gen/modeljob/model_job_get_operator.py
@@ -1,0 +1,54 @@
+from collections.abc import Sequence
+from typing import Any
+from typing import Optional
+
+from airflow.models import BaseOperator
+from airflow.utils.context import Context
+from datarobot.models.modeljob import ModelJob
+
+from datarobot_provider.hooks.datarobot import DataRobotHook
+
+
+class ModelJobGetOperator(BaseOperator):
+    """Fetches one ModelJob. If the job finished, raises PendingJobFinished exception.
+
+    :param project_id: The identifier of the project the model belongs to
+    :type project_id: str
+    :param model_job_id: The identifier of the model_job
+    :type model_job_id: str
+    :return: model_job
+    :rtype ModelJob
+    """
+
+    template_fields: Sequence[str] = ["project_id", "model_job_id"]
+    template_fields_renderers: dict[str, str] = {}
+    template_ext: Sequence[str] = ()
+    ui_color = "#f4a460"
+
+    def __init__(
+        self,
+        *,
+        project_id: Optional[str] = None,
+        model_job_id: Optional[str] = None,
+        datarobot_conn_id: str = "datarobot_default",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.project_id = project_id
+        self.model_job_id = model_job_id
+        self.datarobot_conn_id = datarobot_conn_id
+
+    def execute(self, context: Context) -> str:
+        # Initialize DataRobot client
+        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
+
+        if self.project_id is None:
+            raise ValueError("project_id is required for ModelJob.")
+        if self.model_job_id is None:
+            raise ValueError("model_job_id is required for ModelJob.")
+
+        result = ModelJob.get(
+            self.project_id,
+            self.model_job_id,
+        )
+        return result.id

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dev = [
     "sphinx-copybutton",
     "sphinx-markdown-builder",
     "myst-parser==4.0.0",
-    "black>=24.10.0",
+    "black==24.10.0",
     "pyyaml>=6.0.2",
     "types-PyYAML-6.0.12>=6.0.12",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dev = [
     "myst-parser==4.0.0",
     "black==24.10.0",
     "pyyaml>=6.0.2",
-    "types-PyYAML-6.0.12>=6.0.12",
+    "types-PyYAML>=6.0.12",
 ]
 
 [project.entry-points."apache_airflow_provider"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ dev = [
     "sphinx-copybutton",
     "sphinx-markdown-builder",
     "myst-parser==4.0.0",
+    "black>=24.10.0",
+    "pyyaml>=6.0.2",
+    "types-PyYAML-6.0.12>=6.0.12",
 ]
 
 [project.entry-points."apache_airflow_provider"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,6 @@ pyenchant==3.2.2
 sphinx-copybutton
 sphinx-markdown-builder
 myst-parser==3.0.1
-black==24.10.0
+black>=24.10.0
+pyyaml>=6.0.2
+types-PyYAML-6.0.12>=6.0.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,6 @@ pyenchant==3.2.2
 sphinx-copybutton
 sphinx-markdown-builder
 myst-parser==3.0.1
-black>=24.10.0
+black==24.10.0
 pyyaml>=6.0.2
 types-PyYAML-6.0.12>=6.0.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ sphinx-markdown-builder
 myst-parser==3.0.1
 black==24.10.0
 pyyaml>=6.0.2
-types-PyYAML-6.0.12>=6.0.12
+types-PyYAML>=6.0.12

--- a/tests/fixtures/whitelist_test_output.txt
+++ b/tests/fixtures/whitelist_test_output.txt
@@ -1,4 +1,12 @@
+from collections.abc import Sequence
+from typing import Any
+from typing import Optional
+
+from airflow.models import BaseOperator
+from airflow.utils.context import Context
 from datarobot.models.modeljob import ModelJob
+
+from datarobot_provider.hooks.datarobot import DataRobotHook
 
 
 class ModelJobGetOperator(BaseOperator):
@@ -20,8 +28,8 @@ class ModelJobGetOperator(BaseOperator):
     def __init__(
         self,
         *,
-        project_id: str = None,
-        model_job_id: str = None,
+        project_id: Optional[str] = None,
+        model_job_id: Optional[str] = None,
         datarobot_conn_id: str = "datarobot_default",
         **kwargs: Any
     ) -> None:
@@ -39,7 +47,7 @@ class ModelJobGetOperator(BaseOperator):
         if self.model_job_id is None:
             raise ValueError("model_job_id is required for ModelJob.")
 
-        result = datarobot.models.modeljob.ModelJob.get(
+        result = ModelJob.get(
             self.project_id,
             self.model_job_id,
         )


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

This:
1. Makes `generate_operator.py` into a script which can already be used to generate operators
2. Implements generation of imports
3. Adds POC generated operator to test the approach `datarobot_provider/operators/gen/modeljob/model_job_get_operator.py`

Problems:
Generated code gets minor fixes from `ruff`, I would prefer that we generate files which are always the same.
I have also added followups to https://datarobot.atlassian.net/browse/MLDEV-1169

## Rationale
