### PR TITLE
[DM-16787] Add `CreateWranglingRecipeOperator` 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,8 +3,9 @@
 ## Unreleased
 
 ### New features
-- Introduce `CreateDatasetFromRecipeOperator <datarobot_provider.operators.ai_catalog.CreateDatasetFromRecipeOperator>` 
-to publish a dataset based on existing wrangling recipe. 
+- Introduce `CreateWranglingRecipeOperator <datarobot_provider.operators.ai_catalog.CreateWranglingRecipeOperator>` 
+and `CreateDatasetFromRecipeOperator <datarobot_provider.operators.ai_catalog.CreateDatasetFromRecipeOperator>` 
+to create a wranglig recipe and publish it as a dataset into an existing experiment container. 
 
 ### Bugfixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 ### New features
 - Introduce `CreateWranglingRecipeOperator <datarobot_provider.operators.ai_catalog.CreateWranglingRecipeOperator>` 
 and `CreateDatasetFromRecipeOperator <datarobot_provider.operators.ai_catalog.CreateDatasetFromRecipeOperator>` 
-to create a wranglig recipe and publish it as a dataset into an existing experiment container. 
+to create a wrangling recipe and publish it as a dataset into an existing use case.
 
 ### Bugfixes
 

--- a/datarobot_provider/operators/ai_catalog.py
+++ b/datarobot_provider/operators/ai_catalog.py
@@ -250,8 +250,104 @@ class CreateDatasetFromDataStoreOperator(BaseOperator):
         return ai_catalog_dataset.id
 
 
-class CreateDatasetFromRecipeOperator(BaseOperator):
+class CreateRecipeOperator(BaseOperator):
+    """Create a Wrangling Recipe inside the Experiment Container
+    specified with *experiment_container_id* context parameter.
+
+    :param datarobot_conn_id: Connection ID, defaults to `datarobot_default`
+    :param dataset_id: The dataset to wrangle
+    :param dialect: SQL dialect to apply while wrangling.
+    :param downsampling_directive_param: Context parameter name to apply as a downsampling method.
+    :param downsampling_arguments_param: Context parameter name to apply as a downsampling arguments.
+    :param recipe_name: New recipe name.
+    :param recipe_description: New recipe description.
     """
+    ui_color = "#f4a460"
+
+    def __init__(
+        self,
+        *,
+        datarobot_conn_id: str = "datarobot_default",
+        dataset_id: str,
+        dialect: dr.enums.DataWranglingDialect,
+        operations_param: str = "operations",
+        downsampling_directive_param: str = "downsampling_directive",
+        downsampling_arguments_param: str = "downsampling_arguments",
+        recipe_name: Optional[str] = None,
+        recipe_description: Optional[str] = "Created with Apache-Airflow",
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.datarobot_conn_id = datarobot_conn_id
+        self.dataset_id = dataset_id
+        self.dialect = dialect
+
+        self.operations_param = operations_param
+        self.downsampling_directive_param = downsampling_directive_param
+        self.downsampling_arguments_param = downsampling_arguments_param
+        self.recipe_name = recipe_name
+        self.recipe_description = recipe_description
+
+        if kwargs.get("xcom_push") is not None:
+            raise AirflowException(
+                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
+            )
+
+    def execute(self, context: Context) -> str:
+        # Initialize DataRobot client
+        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
+
+        operations = downsampling = None
+
+        if context["params"].get(self.operations_param):
+            if isinstance(context["params"][self.operations_param], str):
+                raw_operations = json.loads(context["params"][self.operations_param])
+
+            else:
+                raw_operations = context["params"][self.operations_param]
+
+            operations = [
+                dr.models.recipe.WranglingOperation.from_data(x) for x in raw_operations
+            ]
+
+        if context["params"].get(self.downsampling_directive_param):
+            downsampling = dr.models.recipe.DownsamplingOperation(
+                directive=context["params"][self.downsampling_directive_param],
+                arguments=context["params"][self.downsampling_arguments_param],
+            )
+
+        experiment_container = dr.UseCase.get(context["params"]["experiment_container_id"])
+        dataset = dr.Dataset.get(self.dataset_id)
+
+        recipe = dr.models.Recipe.from_dataset(
+            experiment_container, dataset, dialect=dr.enums.DataWranglingDialect(self.dialect)
+        )
+        logging.info('%s recipe id=%s created. Configuring...', self.dialect, recipe.id)
+
+        if operations is not None:
+            dr.models.Recipe.set_operations(recipe.id, operations)
+            logging.info('%d operations set.', len(operations))
+
+        if downsampling is not None:
+            dr.models.Recipe.update_downsampling(recipe.id, downsampling)
+            logging.info('%s dowsnsampling set.', downsampling.directive)
+
+        if self.recipe_name or self.recipe_description:
+            dr.client.get_client().patch(
+                f'recipes/{recipe.id}/',
+                json={'name': self.recipe_name, 'description': self.recipe_description},
+            )
+            logging.info('Recipe name/description set.')
+
+        logging.info('The recipe is ready.')
+        return recipe.id
+
+
+class CreateDatasetFromRecipeOperator(BaseOperator):
+    """ Create a dataset based on a wrangling recipe.
+    The dataset can be dynamic or a snapshot depending on the mandatory *do_snapshot* parameter.
+    The dataset is added into the Experiment Container if experiment_container_id is specified
+    in the context parameters.
 
     :param datarobot_conn_id: Connection ID, defaults to `datarobot_default`
     :type datarobot_conn_id: str, optional
@@ -445,10 +541,6 @@ class CreateOrUpdateDataSourceOperator(BaseOperator):
     :rtype: str
     """
 
-    # Specify the arguments that are allowed to parse with jinja templating
-    template_fields: Sequence[str] = ["data_store_id"]
-    template_fields_renderers: dict[str, str] = {}
-    template_ext: Sequence[str] = ()
     ui_color = "#f4a460"
 
     def __init__(
@@ -511,91 +603,3 @@ class CreateOrUpdateDataSourceOperator(BaseOperator):
             self.log.info(f"DataSource:{dataset_name} successfully created, id={data_source.id}")
 
         return data_source.id
-
-
-class CreateRecipeOperator(BaseOperator):
-    # Specify the arguments that are allowed to parse with jinja templating
-    template_fields: Sequence[str] = []
-    template_fields_renderers: dict[str, str] = {}
-    template_ext: Sequence[str] = ()
-    ui_color = "#f4a460"
-
-    def __init__(
-        self,
-        *,
-        datarobot_conn_id: str = "datarobot_default",
-        dataset_id: str,
-        dialect: dr.enums.DataWranglingDialect,
-        operations_param: str = "operations",
-        downsampling_directive_param: str = "downsampling_directive",
-        downsampling_arguments_param: str = "downsampling_arguments",
-        recipe_name: Optional[str] = None,
-        recipe_description: Optional[str] = "Created with Apache-Airflow",
-        **kwargs,
-    ):
-        super().__init__(**kwargs)
-        self.datarobot_conn_id = datarobot_conn_id
-        self.dataset_id = dataset_id
-        self.dialect = dialect
-
-        self.operations_param = operations_param
-        self.downsampling_directive_param = downsampling_directive_param
-        self.downsampling_arguments_param = downsampling_arguments_param
-        self.recipe_name = recipe_name
-        self.recipe_description = recipe_description
-
-        if kwargs.get("xcom_push") is not None:
-            raise AirflowException(
-                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
-            )
-
-    def execute(self, context: Context) -> str:
-        # Initialize DataRobot client
-        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
-
-        operations = downsampling = None
-
-        if context["params"].get(self.operations_param):
-            if isinstance(context["params"][self.operations_param], str):
-                raw_operations = json.loads(context["params"][self.operations_param])
-
-            else:
-                raw_operations = context["params"][self.operations_param]
-
-            logging.info(raw_operations)
-
-            operations = [
-                dr.models.recipe.WranglingOperation.from_data(x) for x in raw_operations
-            ]
-
-        if context["params"].get(self.downsampling_directive_param):
-            downsampling = dr.models.recipe.DownsamplingOperation(
-                directive=context["params"][self.downsampling_directive_param],
-                arguments=context["params"][self.downsampling_arguments_param],
-            )
-
-        experiment_container = dr.UseCase.get(context["params"]["experiment_container_id"])
-        dataset = dr.Dataset.get(self.dataset_id)
-
-        recipe = dr.models.Recipe.from_dataset(
-            experiment_container, dataset, dialect=dr.enums.DataWranglingDialect(self.dialect)
-        )
-        logging.info('%s recipe id=%s created. Configuring...', self.dialect, recipe.id)
-
-        if operations is not None:
-            dr.models.Recipe.set_operations(recipe.id, operations)
-            logging.info('%d operations set.', len(operations))
-
-        if downsampling is not None:
-            dr.models.Recipe.update_downsampling(recipe.id, downsampling)
-            logging.info('%s dowsnsampling set.', downsampling.directive)
-
-        if self.recipe_name or self.recipe_description:
-            dr.client.get_client().patch(
-                f'recipes/{recipe.id}/',
-                json={'name': self.recipe_name, 'description': self.recipe_description},
-            )
-            logging.info('Recipe name/description set.')
-
-        logging.info('The recipe is ready.')
-        return recipe.id

--- a/datarobot_provider/operators/ai_catalog.py
+++ b/datarobot_provider/operators/ai_catalog.py
@@ -5,11 +5,11 @@
 # This is proprietary source code of DataRobot, Inc. and its affiliates.
 #
 # Released under the terms of DataRobot Tool and Utility Agreement.
-import json
 import logging
 from collections.abc import Sequence
-from typing import Any, List
+from typing import Any
 from typing import Dict
+from typing import List
 from typing import Optional
 
 import datarobot as dr
@@ -513,8 +513,8 @@ class CreateOrUpdateDataSourceOperator(BaseOperator):
 
 
 class CreateRecipeOperator(BaseOperator):
-    """Create a Wrangling Recipe inside the Experiment Container
-    specified with *experiment_container_id* context parameter.
+    """Create a Wrangling Recipe inside an Experiment Container
+    specified by *experiment_container_id* context parameter.
 
     :param datarobot_conn_id: Connection ID, defaults to `datarobot_default`
     :param dataset_id: The dataset to wrangle
@@ -531,8 +531,12 @@ class CreateRecipeOperator(BaseOperator):
     ]
     template_fields_renderers: dict[str, str] = {
         "dataset_id": "string",
-        "dialect": "string", "recipe_name": "string", "recipe_description": "string", "operations": "json",
-        "downsampling_directive": "string", "downsampling_arguments": "json"
+        "dialect": "string",
+        "recipe_name": "string",
+        "recipe_description": "string",
+        "operations": "json",
+        "downsampling_directive": "string",
+        "downsampling_arguments": "json",
     }
     ui_color = "#f4a460"
 

--- a/datarobot_provider/operators/ai_catalog.py
+++ b/datarobot_provider/operators/ai_catalog.py
@@ -8,7 +8,6 @@
 import logging
 from collections.abc import Sequence
 from typing import Any
-from typing import Dict
 from typing import List
 from typing import Optional
 

--- a/datarobot_provider/operators/ai_catalog.py
+++ b/datarobot_provider/operators/ai_catalog.py
@@ -512,7 +512,7 @@ class CreateOrUpdateDataSourceOperator(BaseOperator):
         return data_source.id
 
 
-class CreateRecipeOperator(BaseOperator):
+class CreateWranglingRecipeOperator(BaseOperator):
     """Create a Wrangling Recipe inside an Experiment Container
     specified by *experiment_container_id* context parameter.
 

--- a/datarobot_provider/operators/ai_catalog.py
+++ b/datarobot_provider/operators/ai_catalog.py
@@ -251,7 +251,7 @@ class CreateDatasetFromDataStoreOperator(BaseOperator):
 
 
 class CreateDatasetFromRecipeOperator(BaseOperator):
-    """ Create a dataset based on a wrangling recipe.
+    """Create a dataset based on a wrangling recipe.
     The dataset can be dynamic or a snapshot depending on the mandatory *do_snapshot* parameter.
     The dataset is added into the Experiment Container if experiment_container_id is specified
     in the context parameters.
@@ -526,8 +526,15 @@ class CreateWranglingRecipeOperator(BaseOperator):
     :param downsampling_arguments_param: Downsampling arguments.
 
     """
+
     template_fields: Sequence[str] = [
-        "dataset_id", "dialect", "recipe_name", "recipe_description", "operations", "downsampling_directive", "downsampling_arguments"
+        "dataset_id",
+        "dialect",
+        "recipe_name",
+        "recipe_description",
+        "operations",
+        "downsampling_directive",
+        "downsampling_arguments",
     ]
     template_fields_renderers: dict[str, str] = {
         "dataset_id": "string",
@@ -578,29 +585,29 @@ class CreateWranglingRecipeOperator(BaseOperator):
         recipe = dr.models.Recipe.from_dataset(
             experiment_container, dataset, dialect=dr.enums.DataWranglingDialect(self.dialect)
         )
-        logging.info('%s recipe id=%s created. Configuring...', self.dialect, recipe.id)
+        logging.info("%s recipe id=%s created. Configuring...", self.dialect, recipe.id)
 
         if self.operations:
             client_operations = [
                 dr.models.recipe.WranglingOperation.from_data(x) for x in self.operations
             ]
             dr.models.Recipe.set_operations(recipe.id, client_operations)
-            logging.info('%d operations set.', len(client_operations))
+            logging.info("%d operations set.", len(client_operations))
 
         if self.downsampling_directive is not None:
             client_downsampling = dr.models.recipe.DownsamplingOperation(
-                directive= dr.enums.DownsamplingOperations(self.downsampling_directive),
+                directive=dr.enums.DownsamplingOperations(self.downsampling_directive),
                 arguments=self.downsampling_arguments,
             )
             dr.models.Recipe.update_downsampling(recipe.id, client_downsampling)
-            logging.info('%s dowsnsampling set.', self.downsampling_directive)
+            logging.info("%s dowsnsampling set.", self.downsampling_directive)
 
         if self.recipe_name or self.recipe_description:
             dr.client.get_client().patch(
-                f'recipes/{recipe.id}/',
-                json={'name': self.recipe_name, 'description': self.recipe_description},
+                f"recipes/{recipe.id}/",
+                json={"name": self.recipe_name, "description": self.recipe_description},
             )
-            logging.info('Recipe name/description set.')
+            logging.info("Recipe name/description set.")
 
-        logging.info('Recipe id=%s is ready.', recipe.id)
+        logging.info("Recipe id=%s is ready.", recipe.id)
         return recipe.id

--- a/datarobot_provider/operators/ai_catalog.py
+++ b/datarobot_provider/operators/ai_catalog.py
@@ -252,7 +252,7 @@ class CreateDatasetFromDataStoreOperator(BaseOperator):
 class CreateDatasetFromRecipeOperator(BaseOperator):
     """Create a dataset based on a wrangling recipe.
     The dataset can be dynamic or a snapshot depending on the mandatory *do_snapshot* parameter.
-    The dataset is added into the Experiment Container if experiment_container_id is specified
+    The dataset is added into the Use Case if use_case_id is specified
     in the context parameters.
 
     :param datarobot_conn_id: Connection ID, defaults to `datarobot_default`
@@ -352,16 +352,13 @@ class CreateDatasetFromRecipeOperator(BaseOperator):
             dataset.name,
         )
 
-        if context["params"].get("experiment_container_id"):
-            dr.UseCase.get(use_case_id=context["params"]["experiment_container_id"]).add(dataset)
-
-            logging.info(
-                "The dataset is added into experiment container %s.",
-                context["params"]["experiment_container_id"],
-            )
+        if context["params"].get("use_case_id"):
+            use_case = dr.UseCase.get(use_case_id=context["params"]["use_case_id"])
+            use_case.add(dataset)
+            logging.info('The dataset is added into use case "%s".', use_case.name)
 
         else:
-            logging.info("New Dataset won't belong to any experiment container.")
+            logging.info("New Dataset won't belong to any use case.")
 
         return dataset.id
 
@@ -585,8 +582,8 @@ class CreateWranglingRecipeOperator(BaseOperator):
 
         if not self.use_case_id:
             raise AirflowException(
-                '*use_case_id* is a mandatory parameter. '
-                'You can set it either explicitly or via the context variable *use_case_id*'
+                "*use_case_id* is a mandatory parameter. "
+                "You can set it either explicitly or via the context variable *use_case_id*"
             )
 
         use_case = dr.UseCase.get(self.use_case_id)

--- a/datarobot_provider/operators/ai_catalog.py
+++ b/datarobot_provider/operators/ai_catalog.py
@@ -274,10 +274,6 @@ class CreateDatasetFromRecipeOperator(BaseOperator):
     :rtype: str
     """
 
-    # Specify the arguments that are allowed to parse with jinja templating
-    template_fields: Sequence[str] = []
-    template_fields_renderers: Dict[str, str] = {}
-    template_ext: Sequence[str] = ()
     ui_color = "#f4a460"
 
     def __init__(
@@ -448,6 +444,10 @@ class CreateOrUpdateDataSourceOperator(BaseOperator):
     :rtype: str
     """
 
+    # Specify the arguments that are allowed to parse with jinja templating
+    template_fields: Sequence[str] = ["data_store_id"]
+    template_fields_renderers: dict[str, str] = {}
+    template_ext: Sequence[str] = ()
     ui_color = "#f4a460"
 
     def __init__(

--- a/datarobot_provider/operators/ai_catalog.py
+++ b/datarobot_provider/operators/ai_catalog.py
@@ -266,13 +266,14 @@ class CreateDatasetFromRecipeOperator(BaseOperator):
     :param materialization_catalog_param: Name of the parameter in the configuration to use as materialization_catalog
     :type materialization_catalog_param: str
     :param materialization_schema_param: Name of the parameter in the configuration to use as materialization_schema
-    :type materialization_schema: str
+    :type materialization_schema_param: str
     :param materialization_table_param: Name of the parameter in the configuration to use as materialization_table
-    :type materialization_table: str
+    :type materialization_table_param: str
     :return: DataRobot AI Catalog dataset ID
     :rtype: str
     """
 
+    template_fields = ["recipe_id"]
     ui_color = "#f4a460"
 
     def __init__(

--- a/tests/unit/operators/test_ai_catalog.py
+++ b/tests/unit/operators/test_ai_catalog.py
@@ -120,6 +120,7 @@ def test_operator_create_wrangling_recipe(mocker):
     ).return_value
     recipe_mock = mocker.patch("datarobot_provider.operators.ai_catalog.dr.models.Recipe")
     recipe_mock.from_dataset.return_value.id = "test-recipe-id"
+    context = {"params": {"use_case_id": "test-use-case-id"}}
 
     operator = CreateWranglingRecipeOperator(
         task_id="create_recipe",
@@ -135,11 +136,13 @@ def test_operator_create_wrangling_recipe(mocker):
         downsampling_directive=dr.enums.DownsamplingOperations.RANDOM_SAMPLE,
         downsampling_arguments={"value": 100, "seed": 25},
     )
-    recipe_id = operator.execute(context={"params": {"experiment_container_id": "test-exp-con-id"}})
+    operator.render_template_fields(context)
+
+    recipe_id = operator.execute(context=context)
 
     assert recipe_id == "test-recipe-id"
     get_dataset_mock.assert_called_once_with("test-dataset-id")
-    get_exp_container_mock.assert_called_once_with("test-exp-con-id")
+    get_exp_container_mock.assert_called_once_with("test-use-case-id")
     client_mock.patch.assert_called_once_with(
         "recipes/test-recipe-id/",
         json={"name": "Test name", "description": "Created with Apache-Airflow"},

--- a/tests/unit/operators/test_ai_catalog.py
+++ b/tests/unit/operators/test_ai_catalog.py
@@ -12,8 +12,8 @@ import pytest
 from datarobot_provider.operators.ai_catalog import CreateDatasetFromDataStoreOperator
 from datarobot_provider.operators.ai_catalog import CreateDatasetFromRecipeOperator
 from datarobot_provider.operators.ai_catalog import CreateDatasetVersionOperator
-from datarobot_provider.operators.ai_catalog import CreateRecipeOperator
 from datarobot_provider.operators.ai_catalog import CreateOrUpdateDataSourceOperator
+from datarobot_provider.operators.ai_catalog import CreateRecipeOperator
 from datarobot_provider.operators.ai_catalog import UpdateDatasetFromFileOperator
 from datarobot_provider.operators.ai_catalog import UploadDatasetOperator
 

--- a/tests/unit/operators/test_ai_catalog.py
+++ b/tests/unit/operators/test_ai_catalog.py
@@ -115,32 +115,34 @@ def test_operator_create_dataset_from_jdbc(mocker, mock_airflow_connection_datar
 def test_operator_create_wrangling_recipe(mocker):
     get_dataset_mock = mocker.patch.object(dr.Dataset, "get")
     get_exp_container_mock = mocker.patch.object(dr.UseCase, "get")
-    client_mock = mocker.patch('datarobot_provider.operators.ai_catalog.dr.client.get_client').return_value
-    recipe_mock = mocker.patch('datarobot_provider.operators.ai_catalog.dr.models.Recipe')
-    recipe_mock.from_dataset.return_value.id = 'test-recipe-id'
+    client_mock = mocker.patch(
+        "datarobot_provider.operators.ai_catalog.dr.client.get_client"
+    ).return_value
+    recipe_mock = mocker.patch("datarobot_provider.operators.ai_catalog.dr.models.Recipe")
+    recipe_mock.from_dataset.return_value.id = "test-recipe-id"
 
     operator = CreateWranglingRecipeOperator(
         task_id="create_recipe",
         recipe_name="Test name",
-        dataset_id='test-dataset-id',
+        dataset_id="test-dataset-id",
         dialect=dr.enums.DataWranglingDialect.SNOWFLAKE,
         operations=[
             {
-              "directive": "drop-columns",
-              "arguments": {"columns": ["test-feature-1", "test-feature-2"]}
+                "directive": "drop-columns",
+                "arguments": {"columns": ["test-feature-1", "test-feature-2"]},
             }
         ],
         downsampling_directive=dr.enums.DownsamplingOperations.RANDOM_SAMPLE,
-        downsampling_arguments={'value': 100, 'seed': 25},
+        downsampling_arguments={"value": 100, "seed": 25},
     )
     recipe_id = operator.execute(context={"params": {"experiment_container_id": "test-exp-con-id"}})
 
-    assert recipe_id == 'test-recipe-id'
-    get_dataset_mock.assert_called_once_with('test-dataset-id')
+    assert recipe_id == "test-recipe-id"
+    get_dataset_mock.assert_called_once_with("test-dataset-id")
     get_exp_container_mock.assert_called_once_with("test-exp-con-id")
     client_mock.patch.assert_called_once_with(
-        'recipes/test-recipe-id/',
-        json={'name': "Test name", 'description': 'Created with Apache-Airflow'},
+        "recipes/test-recipe-id/",
+        json={"name": "Test name", "description": "Created with Apache-Airflow"},
     )
     recipe_mock.from_dataset.assert_called_once_with(
         get_exp_container_mock.return_value,
@@ -153,9 +155,11 @@ def test_operator_create_wrangling_recipe(mocker):
     )
 
     recipe_mock.update_downsampling.assert_called_once()
-    assert recipe_mock.update_downsampling.call_args.args[1].directive == dr.enums.DownsamplingOperations.RANDOM_SAMPLE
-    assert recipe_mock.update_downsampling.call_args.args[
-               1].arguments == {'value': 100, 'seed': 25}
+    assert (
+        recipe_mock.update_downsampling.call_args.args[1].directive
+        == dr.enums.DownsamplingOperations.RANDOM_SAMPLE
+    )
+    assert recipe_mock.update_downsampling.call_args.args[1].arguments == {"value": 100, "seed": 25}
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/operators/test_ai_catalog.py
+++ b/tests/unit/operators/test_ai_catalog.py
@@ -13,7 +13,7 @@ from datarobot_provider.operators.ai_catalog import CreateDatasetFromDataStoreOp
 from datarobot_provider.operators.ai_catalog import CreateDatasetFromRecipeOperator
 from datarobot_provider.operators.ai_catalog import CreateDatasetVersionOperator
 from datarobot_provider.operators.ai_catalog import CreateOrUpdateDataSourceOperator
-from datarobot_provider.operators.ai_catalog import CreateRecipeOperator
+from datarobot_provider.operators.ai_catalog import CreateWranglingRecipeOperator
 from datarobot_provider.operators.ai_catalog import UpdateDatasetFromFileOperator
 from datarobot_provider.operators.ai_catalog import UploadDatasetOperator
 
@@ -112,14 +112,14 @@ def test_operator_create_dataset_from_jdbc(mocker, mock_airflow_connection_datar
     )
 
 
-def test_operator_create_recipe(mocker):
+def test_operator_create_wrangling_recipe(mocker):
     get_dataset_mock = mocker.patch.object(dr.Dataset, "get")
     get_exp_container_mock = mocker.patch.object(dr.UseCase, "get")
     client_mock = mocker.patch('datarobot_provider.operators.ai_catalog.dr.client.get_client').return_value
     recipe_mock = mocker.patch('datarobot_provider.operators.ai_catalog.dr.models.Recipe')
     recipe_mock.from_dataset.return_value.id = 'test-recipe-id'
 
-    operator = CreateRecipeOperator(
+    operator = CreateWranglingRecipeOperator(
         task_id="create_recipe",
         recipe_name="Test name",
         dataset_id='test-dataset-id',

--- a/tests/unit/operators/test_ai_catalog.py
+++ b/tests/unit/operators/test_ai_catalog.py
@@ -12,6 +12,7 @@ import pytest
 from datarobot_provider.operators.ai_catalog import CreateDatasetFromDataStoreOperator
 from datarobot_provider.operators.ai_catalog import CreateDatasetFromRecipeOperator
 from datarobot_provider.operators.ai_catalog import CreateDatasetVersionOperator
+from datarobot_provider.operators.ai_catalog import CreateRecipeOperator
 from datarobot_provider.operators.ai_catalog import CreateOrUpdateDataSourceOperator
 from datarobot_provider.operators.ai_catalog import UpdateDatasetFromFileOperator
 from datarobot_provider.operators.ai_catalog import UploadDatasetOperator
@@ -109,6 +110,52 @@ def test_operator_create_dataset_from_jdbc(mocker, mock_airflow_connection_datar
         do_snapshot=test_params["do_snapshot"],
         max_wait=3600,
     )
+
+
+def test_operator_create_recipe(mocker):
+    get_dataset_mock = mocker.patch.object(dr.Dataset, "get")
+    get_exp_container_mock = mocker.patch.object(dr.UseCase, "get")
+    client_mock = mocker.patch('datarobot_provider.operators.ai_catalog.dr.client.get_client').return_value
+    recipe_mock = mocker.patch('datarobot_provider.operators.ai_catalog.dr.models.Recipe')
+    recipe_mock.from_dataset.return_value.id = 'test-recipe-id'
+
+    operator = CreateRecipeOperator(
+        task_id="create_recipe",
+        recipe_name="Test name",
+        dataset_id='test-dataset-id',
+        dialect=dr.enums.DataWranglingDialect.SNOWFLAKE,
+        operations=[
+            {
+              "directive": "drop-columns",
+              "arguments": {"columns": ["test-feature-1", "test-feature-2"]}
+            }
+        ],
+        downsampling_directive=dr.enums.DownsamplingOperations.RANDOM_SAMPLE,
+        downsampling_arguments={'value': 100, 'seed': 25},
+    )
+    recipe_id = operator.execute(context={"params": {"experiment_container_id": "test-exp-con-id"}})
+
+    assert recipe_id == 'test-recipe-id'
+    get_dataset_mock.assert_called_once_with('test-dataset-id')
+    get_exp_container_mock.assert_called_once_with("test-exp-con-id")
+    client_mock.patch.assert_called_once_with(
+        'recipes/test-recipe-id/',
+        json={'name': "Test name", 'description': 'Created with Apache-Airflow'},
+    )
+    recipe_mock.from_dataset.assert_called_once_with(
+        get_exp_container_mock.return_value,
+        get_dataset_mock.return_value,
+        dialect=dr.enums.DataWranglingDialect.SNOWFLAKE,
+    )
+    recipe_mock.set_operations.assert_called_once()
+    assert isinstance(
+        recipe_mock.set_operations.call_args.args[1][0], dr.models.recipe.WranglingOperation
+    )
+
+    recipe_mock.update_downsampling.assert_called_once()
+    assert recipe_mock.update_downsampling.call_args.args[1].directive == dr.enums.DownsamplingOperations.RANDOM_SAMPLE
+    assert recipe_mock.update_downsampling.call_args.args[
+               1].arguments == {'value': 100, 'seed': 25}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Add a new operator: `CreateWranglingRecipeOperator`


## Rationale

Users should be able to create a recipe and use it in a recently added `CreateDatasetFromRecipeOperator`
