### PR TITLE
[CFX-1398] Adding opt-in Airflow ruff checking

### DIFF
--- a/datarobot_provider/example_dags/deprecated/datarobot_custom_model_pipeline_dag.py
+++ b/datarobot_provider/example_dags/deprecated/datarobot_custom_model_pipeline_dag.py
@@ -94,7 +94,7 @@ def create_custom_model_pipeline(
             return ["deploy_custom_model"]
         return ["custom_model_test_fail"]
 
-    branching = BranchPythonOperator(
+    if_tests_succeed = BranchPythonOperator(
         task_id="if_tests_succeed",
         python_callable=choose_branch,
         op_args=[custom_model_test_overall_status_op.output],
@@ -108,7 +108,7 @@ def create_custom_model_pipeline(
         importance=DEPLOYMENT_IMPORTANCE.LOW,
     )
 
-    custom_model_test_fail_case_op = EmptyOperator(
+    custom_model_test_fail = EmptyOperator(
         task_id="custom_model_test_fail",
     )
 
@@ -121,8 +121,8 @@ def create_custom_model_pipeline(
         >> test_dataset_uploading_op
         >> custom_model_test_op
         >> custom_model_test_overall_status_op
-        >> branching
-        >> [deploy_custom_model_op, custom_model_test_fail_case_op]
+        >> if_tests_succeed
+        >> [deploy_custom_model_op, custom_model_test_fail]
     )
 
 

--- a/datarobot_provider/example_dags/deprecated/datarobot_replace_custom_model_pipeline_dag.py
+++ b/datarobot_provider/example_dags/deprecated/datarobot_replace_custom_model_pipeline_dag.py
@@ -72,7 +72,7 @@ def update_custom_model_pipeline(
         else:
             return ["model_replacement_fail"]
 
-    branching = BranchPythonOperator(
+    if_tests_succeed = BranchPythonOperator(
         task_id="if_tests_succeed",
         python_callable=choose_branch,
         op_args=[
@@ -80,7 +80,7 @@ def update_custom_model_pipeline(
         ],
     )
 
-    handle_model_replacement_fail_op = EmptyOperator(
+    model_replacement_fail = EmptyOperator(
         task_id="model_replacement_fail",
     )
 
@@ -95,10 +95,10 @@ def update_custom_model_pipeline(
         create_custom_model_version_op
         >> custom_model_test_op
         >> custom_model_test_overall_status_op
-        >> branching
+        >> if_tests_succeed
         >> [
             replace_deployment_model_op,
-            handle_model_replacement_fail_op,
+            model_replacement_fail,
         ]
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ select = [
     "W",
     "B",
     "I",
+    "AIR",
 ]
 
 # Rules to ignore (corresponds to Flake8's ignore)


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Proposal to also use Ruff's Airflow rules - docs here:
https://docs.astral.sh/ruff/rules/#airflow-air

## Rationale

I think since we're using Ruff in this repo. and there were minimal errors it's a good opportunity to enable these checks

## Updates

- Added Airflow ruff config so we check those rules
- Updated code to get rid of errors => `AIR001 Task variable name should match the `task_id``