### PR TITLE
[CFX-1399] Adding notebook Operators, Sensors and an E2E DAG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,9 +142,6 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
-# Jupyter notebooks
-notebooks/
-
 # Astro development environments
 astro-dev/
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,5 +10,6 @@
 /datarobot_provider/operators/monitoring_job.py          @datarobot/tracking-agent
 /datarobot_provider/operators/notebooks                  @datarobot/cfx
 /datarobot_provider/operators/prediction_explanations.py @datarobot/trust-explainable-ai
+/datarobot_provider/sensors/notebooks                    @datarobot/cfx
 /docs                                                    @datarobot/api-docs
 /tests/                                                  @datarobot/machine-learning-development

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,6 +8,7 @@
 /datarobot_provider/operators/model_predictions.py       @datarobot/predictions
 /datarobot_provider/operators/monitoring.py              @datarobot/model-management
 /datarobot_provider/operators/monitoring_job.py          @datarobot/tracking-agent
+/datarobot_provider/operators/notebooks                  @datarobot/cfx
 /datarobot_provider/operators/prediction_explanations.py @datarobot/trust-explainable-ai
 /docs                                                    @datarobot/api-docs
 /tests/                                                  @datarobot/machine-learning-development

--- a/datarobot_provider/example_dags/datarobot_run_notebook_e2e.py
+++ b/datarobot_provider/example_dags/datarobot_run_notebook_e2e.py
@@ -1,0 +1,70 @@
+# Copyright 2025 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+"""
+Config example for this dag:
+{
+    "notebook_id": "put_your_notebook_id_here",
+}
+"""
+
+from datetime import datetime
+
+from airflow.decorators import dag
+from airflow.models.param import Param
+
+from datarobot_provider.operators.notebooks.revision import NotebookRevisionCreateOperator
+from datarobot_provider.sensors.notebooks import NotebookExecutionCompleteSensor
+from datarobot_provider.sensors.notebooks import NotebookSessionRunningSensor
+
+
+@dag(
+    schedule=None,
+    start_date=datetime(2025, 1, 1),
+    tags=["example", "notebook"],
+    # Default json config example:
+    params={
+        "notebook_id": "put_your_notebook_id_here",
+        "notebook_parameters": Param(
+            {"data": [{"name": "foo", "value": "bar"}]}, type=["object", "null"]
+        ),
+    },
+)
+def datarobot_notebook_connect(notebook_id=None, notebook_parameters=None):
+    # Op - start notebook session
+
+    check_notebook_session_running = NotebookSessionRunningSensor(
+        task_id="check_notebook_session_running",
+        notebook_id=notebook_id,
+        poke_interval=15,  # status check each 15 sec
+        timeout=900,  # timeout after 15min (15*60sec = 900 sec)
+    )
+
+    # Op - execute notebook
+
+    check_notebook_execution_complete = NotebookExecutionCompleteSensor(
+        task_id="check_notebook_execution_complete",
+        notebook_id=notebook_id,
+        poke_interval=15,  # status check each 15 sec
+        # TODO: Update this timeout to something more like 24 hours
+        timeout=600,  # timeout after 10min (10*60sec = 600 sec)
+    )
+
+    notebook_create_revision = NotebookRevisionCreateOperator(
+        task_id="notebook_create_revision",
+        notebook_id=notebook_id,
+    )
+
+    # Op - stop notebook
+
+    check_notebook_session_running >> check_notebook_execution_complete >> notebook_create_revision
+
+
+datarobot_notebook_connection_dag = datarobot_notebook_connect()
+
+if __name__ == "__main__":
+    datarobot_notebook_connection_dag.test()

--- a/datarobot_provider/example_dags/datarobot_run_notebook_e2e.py
+++ b/datarobot_provider/example_dags/datarobot_run_notebook_e2e.py
@@ -9,6 +9,9 @@
 Config example for this dag:
 {
     "notebook_id": "put_your_notebook_id_here",
+    "notebook_parameters": {
+        "data": [{"name": "foo", "value": "bar"}]
+    }
 }
 """
 
@@ -17,9 +20,15 @@ from datetime import datetime
 from airflow.decorators import dag
 from airflow.models.param import Param
 
-from datarobot_provider.operators.notebooks.revision import NotebookRevisionCreateOperator
+from datarobot_provider.operators.notebooks import NotebookExecuteOperator
+from datarobot_provider.operators.notebooks import NotebookRevisionCreateOperator
+from datarobot_provider.operators.notebooks import NotebookSessionStartOperator
+from datarobot_provider.operators.notebooks import NotebookSessionStopOperator
 from datarobot_provider.sensors.notebooks import NotebookExecutionCompleteSensor
 from datarobot_provider.sensors.notebooks import NotebookSessionRunningSensor
+
+# Default to 24 hours
+DEFAULT_NOTEBOOK_EXECUTION_TIMEOUT = 1440
 
 
 @dag(
@@ -34,34 +43,57 @@ from datarobot_provider.sensors.notebooks import NotebookSessionRunningSensor
         ),
     },
 )
-def datarobot_notebook_connect(notebook_id=None, notebook_parameters=None):
-    # Op - start notebook session
+def datarobot_notebook_connect(
+    notebook_id=None,
+    notebook_parameters=None,
+):
+    # Timeout waiting for complete notebook execution
+    execution_timeout = DEFAULT_NOTEBOOK_EXECUTION_TIMEOUT * 60
 
+    start_notebook_session = NotebookSessionStartOperator(
+        task_id="start_notebook_session",
+        notebook_id=notebook_id,
+        notebook_parameters=notebook_parameters,
+    )
+
+    poke_interval = 15  # Status check each 15 sec
+    session_timeout = 15 * 60  # Timeout after waiting 15 minutes for session to start
     check_notebook_session_running = NotebookSessionRunningSensor(
         task_id="check_notebook_session_running",
         notebook_id=notebook_id,
-        poke_interval=15,  # status check each 15 sec
-        timeout=900,  # timeout after 15min (15*60sec = 900 sec)
+        poke_interval=poke_interval,
+        timeout=session_timeout,
     )
 
-    # Op - execute notebook
+    execute_notebook = NotebookExecuteOperator(
+        task_id="execute_notebook",
+        notebook_id=notebook_id,
+    )
 
+    poke_interval = 15  # Status check each 15 sec
     check_notebook_execution_complete = NotebookExecutionCompleteSensor(
         task_id="check_notebook_execution_complete",
         notebook_id=notebook_id,
-        poke_interval=15,  # status check each 15 sec
-        # TODO: Update this timeout to something more like 24 hours
-        timeout=600,  # timeout after 10min (10*60sec = 600 sec)
+        poke_interval=poke_interval,
+        timeout=execution_timeout,
     )
 
     notebook_create_revision = NotebookRevisionCreateOperator(
-        task_id="notebook_create_revision",
-        notebook_id=notebook_id,
+        task_id="notebook_create_revision", notebook_id=notebook_id
     )
 
-    # Op - stop notebook
+    stop_notebook_session = NotebookSessionStopOperator(
+        task_id="stop_notebook_session", notebook_id=notebook_id
+    )
 
-    check_notebook_session_running >> check_notebook_execution_complete >> notebook_create_revision
+    (
+        start_notebook_session
+        >> check_notebook_session_running
+        >> execute_notebook
+        >> check_notebook_execution_complete
+        >> notebook_create_revision
+        >> stop_notebook_session
+    )
 
 
 datarobot_notebook_connection_dag = datarobot_notebook_connect()

--- a/datarobot_provider/operators/notebooks/__init__.py
+++ b/datarobot_provider/operators/notebooks/__init__.py
@@ -6,5 +6,13 @@
 #
 # Released under the terms of DataRobot Tool and Utility Agreement.
 from .revision import NotebookRevisionCreateOperator
+from .session import NotebookExecuteOperator
+from .session import NotebookSessionStartOperator
+from .session import NotebookSessionStopOperator
 
-__all__ = ("NotebookRevisionCreateOperator",)
+__all__ = (
+    "NotebookExecuteOperator",
+    "NotebookRevisionCreateOperator",
+    "NotebookSessionStartOperator",
+    "NotebookSessionStopOperator",
+)

--- a/datarobot_provider/operators/notebooks/__init__.py
+++ b/datarobot_provider/operators/notebooks/__init__.py
@@ -1,0 +1,10 @@
+# Copyright 2025 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+from .revision import NotebookRevisionCreateOperator
+
+__all__ = ("NotebookRevisionCreateOperator",)

--- a/datarobot_provider/operators/notebooks/revision.py
+++ b/datarobot_provider/operators/notebooks/revision.py
@@ -1,0 +1,85 @@
+# Copyright 2025 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+from collections.abc import Sequence
+from typing import Any
+from typing import Optional
+
+from airflow.exceptions import AirflowException
+from airflow.models import BaseOperator
+from airflow.utils.context import Context
+from datarobot._experimental.models.notebooks.notebook import Notebook
+
+from datarobot_provider.hooks.datarobot import DataRobotHook
+
+
+class NotebookRevisionCreateOperator(BaseOperator):
+    """
+    Runs a DataRobot Notebook.
+    :param notebook_id: DataRobot notebook ID
+    :type notebook_id: str
+    :param name: Name for notebook revision.
+    :type name: str, optional
+    :param notebook_path: Path to notebook file. Required for Codespace notebooks.
+    :type notebook_path: str, optional
+    :param is_auto: Signifies if the revision was created from interactive user action. Defaults to `True`.
+    :type is_auto: bool, optional
+    :param datarobot_conn_id: Connection ID, defaults to `datarobot_default`
+    :type datarobot_conn_id: str, optional
+    :return: The notebook revision's ID.
+    :rtype: str
+    """
+
+    # Specify the arguments that are allowed to parse with jinja templating
+    template_fields: Sequence[str] = [
+        "notebook_id",
+        "name",
+        "notebook_path",
+        "is_auto",
+    ]
+
+    def __init__(
+        self,
+        *,
+        notebook_id: str,
+        name: Optional[str] = None,
+        notebook_path: Optional[str] = None,
+        is_auto: bool = True,
+        datarobot_conn_id: str = "datarobot_default",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.notebook_id = notebook_id
+        self.name = name
+        self.notebook_path = notebook_path
+        self.is_auto = is_auto
+        self.datarobot_conn_id = datarobot_conn_id
+        if kwargs.get("xcom_push") is not None:
+            raise AirflowException(
+                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
+            )
+
+    def execute(self, context: Context) -> str:
+        # Initialize DataRobot client
+        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
+
+        self.log.info(f"Fetching notebook w/ ID: {self.notebook_id}")
+        notebook = Notebook.get(self.notebook_id)
+        if notebook.is_codespace and not self.notebook_path:
+            raise AirflowException(
+                "Creating a notebook revision for a Codespace requires `notebook_path`."
+            )
+
+        self.log.info("Creating revision.")
+        revision = notebook.create_revision(
+            name=self.name,
+            notebook_path=self.notebook_path,
+            is_auto=self.is_auto,
+        )
+        self.log.info(f"Revision created: {revision}")
+
+        return revision.revision_id

--- a/datarobot_provider/operators/notebooks/session.py
+++ b/datarobot_provider/operators/notebooks/session.py
@@ -1,0 +1,164 @@
+# Copyright 2025 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+from collections.abc import Sequence
+from typing import Any
+from typing import List
+from typing import Optional
+from typing import TypedDict
+
+from airflow.exceptions import AirflowException
+from airflow.models import BaseOperator
+from airflow.utils.context import Context
+from datarobot._experimental.models.notebooks.notebook import Notebook
+from datarobot._experimental.models.notebooks.session import StartSessionParameters
+
+from datarobot_provider.hooks.datarobot import DataRobotHook
+
+
+class NotebookParametersData(TypedDict):
+    data: List[StartSessionParameters]
+
+
+class NotebookSessionStartOperator(BaseOperator):
+    """
+    Starts a DataRobot Notebook session.
+    :param notebook_id: DataRobot notebook ID
+    :type notebook_id: str
+    :param notebook_parameters: Parameters to be set as environment variables in the notebook session. Must be in the
+        form of `{"name": "FOO", "value": "MyValue"}`
+    :type notebook_parameters: dict, optional
+    :param datarobot_conn_id: Connection ID, defaults to `datarobot_default`
+    :type datarobot_conn_id: str, optional
+    :return: The notebook session's ID.
+    :rtype: str
+    """
+
+    # Specify the arguments that are allowed to parse with jinja templating
+    template_fields: Sequence[str] = [
+        "notebook_id",
+        "notebook_parameters",
+    ]
+
+    def __init__(
+        self,
+        *,
+        notebook_id: str,
+        notebook_parameters: Optional[NotebookParametersData] = None,
+        datarobot_conn_id: str = "datarobot_default",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.notebook_id = notebook_id
+        self.notebook_parameters = notebook_parameters
+        self.datarobot_conn_id = datarobot_conn_id
+        if kwargs.get("xcom_push") is not None:
+            raise AirflowException(
+                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
+            )
+
+    def execute(self, context: Context) -> str:
+        # Initialize DataRobot client
+        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
+
+        self.log.info(f"Fetching notebook w/ ID: {self.notebook_id}")
+        notebook = Notebook.get(self.notebook_id)
+
+        self.log.info("Starting session.")
+        # DAGs using Airflow's `Param` model can't seem to take an array/list but it needs to be an object/dict
+        parameters = self.notebook_parameters.get("data") if self.notebook_parameters else None
+        session = notebook.start_session(is_triggered_run=True, parameters=parameters)
+
+        return session.session_id
+
+
+class NotebookExecuteOperator(BaseOperator):
+    """
+    Stops a DataRobot Notebook session.
+    :param notebook_id: DataRobot notebook ID
+    :type notebook_id: str
+    :param datarobot_conn_id: Connection ID, defaults to `datarobot_default`
+    :type datarobot_conn_id: str, optional
+    :return: The notebook's ID.
+    :rtype: str
+    """
+
+    # Specify the arguments that are allowed to parse with jinja templating
+    template_fields: Sequence[str] = [
+        "notebook_id",
+    ]
+
+    def __init__(
+        self,
+        *,
+        notebook_id: str,
+        datarobot_conn_id: str = "datarobot_default",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.notebook_id = notebook_id
+        self.datarobot_conn_id = datarobot_conn_id
+        if kwargs.get("xcom_push") is not None:
+            raise AirflowException(
+                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
+            )
+
+    def execute(self, context: Context) -> str:
+        # Initialize DataRobot client
+        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
+
+        self.log.info(f"Fetching notebook w/ ID: {self.notebook_id}")
+        notebook = Notebook.get(self.notebook_id)
+
+        self.log.info("Executing notebook.")
+        notebook.execute()
+
+        return self.notebook_id
+
+
+class NotebookSessionStopOperator(BaseOperator):
+    """
+    Stops a DataRobot Notebook session.
+    :param notebook_id: DataRobot notebook ID
+    :type notebook_id: str
+    :param datarobot_conn_id: Connection ID, defaults to `datarobot_default`
+    :type datarobot_conn_id: str, optional
+    :return: The notebook session's ID.
+    :rtype: str
+    """
+
+    # Specify the arguments that are allowed to parse with jinja templating
+    template_fields: Sequence[str] = [
+        "notebook_id",
+    ]
+
+    def __init__(
+        self,
+        *,
+        notebook_id: str,
+        datarobot_conn_id: str = "datarobot_default",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.notebook_id = notebook_id
+        self.datarobot_conn_id = datarobot_conn_id
+        if kwargs.get("xcom_push") is not None:
+            raise AirflowException(
+                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
+            )
+
+    def execute(self, context: Context) -> str:
+        # Initialize DataRobot client
+        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
+
+        self.log.info(f"Fetching notebook w/ ID: {self.notebook_id}")
+        notebook = Notebook.get(self.notebook_id)
+
+        self.log.info("Stopping session.")
+        session = notebook.stop_session()
+
+        return session.session_id

--- a/datarobot_provider/sensors/notebooks/__init__.py
+++ b/datarobot_provider/sensors/notebooks/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2025 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+from .execution_complete import NotebookExecutionCompleteSensor
+from .session_running import NotebookSessionRunningSensor
+
+__all__ = (
+    "NotebookExecutionCompleteSensor",
+    "NotebookSessionRunningSensor",
+)

--- a/datarobot_provider/sensors/notebooks/execution_complete.py
+++ b/datarobot_provider/sensors/notebooks/execution_complete.py
@@ -1,0 +1,51 @@
+# Copyright 2025 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+from typing import Any
+
+from airflow.sensors.base import BaseSensorOperator
+from airflow.utils.context import Context
+from datarobot._experimental.models.notebooks.notebook import Notebook
+
+from datarobot_provider.hooks.datarobot import DataRobotHook
+
+
+class NotebookExecutionCompleteSensor(BaseSensorOperator):
+    """
+    Checks if the notebook execution is complete.
+
+    :param notebook_id: Notebook ID
+    :type notebook_id: str
+    :param datarobot_conn_id: Connection ID, defaults to `datarobot_default`
+    :type datarobot_conn_id: str, optional
+    :return: False if not yet completed
+    :rtype: bool
+    """
+
+    # Specify the arguments that are allowed to parse with jinja templating
+    template_fields = ["notebook_id"]
+
+    def __init__(
+        self,
+        *,
+        notebook_id: str,
+        datarobot_conn_id: str = "datarobot_default",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.notebook_id = notebook_id
+        self.datarobot_conn_id = datarobot_conn_id
+
+        self.hook = DataRobotHook(datarobot_conn_id)
+
+    def poke(self, context: Context) -> bool:
+        # Initialize DataRobot client
+        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
+
+        notebook = Notebook.get(self.notebook_id)
+        self.log.info("Checking if notebook execution is complete.")
+        return notebook.is_finished_executing()

--- a/datarobot_provider/sensors/notebooks/session_running.py
+++ b/datarobot_provider/sensors/notebooks/session_running.py
@@ -1,0 +1,51 @@
+# Copyright 2025 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+from typing import Any
+
+from airflow.sensors.base import BaseSensorOperator
+from airflow.utils.context import Context
+from datarobot._experimental.models.notebooks.notebook import Notebook
+
+from datarobot_provider.hooks.datarobot import DataRobotHook
+
+
+class NotebookSessionRunningSensor(BaseSensorOperator):
+    """
+    Checks if the notebook session is running.
+
+    :param notebook_id: Notebook ID
+    :type notebook_id: str
+    :param datarobot_conn_id: Connection ID, defaults to `datarobot_default`
+    :type datarobot_conn_id: str, optional
+    :return: False if not yet completed
+    :rtype: bool
+    """
+
+    # Specify the arguments that are allowed to parse with jinja templating
+    template_fields = ["notebook_id"]
+
+    def __init__(
+        self,
+        *,
+        notebook_id: str,
+        datarobot_conn_id: str = "datarobot_default",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.notebook_id = notebook_id
+        self.datarobot_conn_id = datarobot_conn_id
+
+        self.hook = DataRobotHook(datarobot_conn_id)
+
+    def poke(self, context: Context) -> bool:
+        # Initialize DataRobot client
+        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
+
+        notebook = Notebook.get(self.notebook_id)
+        self.log.info("Checking if notebook session is running.")
+        return notebook.is_running()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 dependencies = [
     "apache-airflow>=2.3.0",
-    "datarobot>=3.3.1"
+    "datarobot>=3.7.0b0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Currently a DRAFT PR however I believe this can be close to production ready.

Adding Operators and Sensors for DR Notebooks and also making some needed code alterations like .gitignore for example.

## Rationale

This is the approach I'm most in favor of where we use granular steps/Operators in our notebook execution flow and leverage Airflow Sensors to handle the two needed polling states.

## TODOs

_Maybe_ parametrize the timeout used with the `NotebookExecutionCompleteSensor` in the example DAG since in DR scheduling we give an upper limit of 24 hours - in the code I've written so far I've set the timeout to 10 minutes - so for _sure_ we should make it longer than that by default.

## Screenshots

**Successful end-to-end run:**

<img width="1789" alt="Screenshot 2025-01-27 at 3 21 27 PM" src="https://github.com/user-attachments/assets/1c656910-8a26-4c35-b0ba-49196bcf288d" />

<hr>

**Example passing notebook params in DAG:**

<img width="985" alt="Screenshot 2025-01-27 at 3 42 31 PM" src="https://github.com/user-attachments/assets/90dcbcba-c034-4bed-a51d-3dda81f53392" />

<hr>

**Example of Airflow Sensor checking/polling to see if notebook session is running:**

<img width="1137" alt="Screenshot 2025-01-27 at 4 43 33 PM" src="https://github.com/user-attachments/assets/ec2da546-fc52-4bb8-bc2d-3d258a7c6405" />
