### PR TITLE
[CFX-1398] Misc airflow repo updates related to ruff linting

### DIFF
--- a/datarobot_provider/hooks/connections.py
+++ b/datarobot_provider/hooks/connections.py
@@ -162,7 +162,7 @@ class JDBCDataSourceHook(BasicCredentialsHook):
     def test_connection(self):
         """Test DataRobot connection to JDBC DataSource"""
         try:
-            credential, credential_data, data_store = self.run()
+            _, credential_data, data_store = self.run()
 
             test_result = data_store.test(
                 username=credential_data["user"], password=credential_data["password"]

--- a/datarobot_provider/hooks/credentials.py
+++ b/datarobot_provider/hooks/credentials.py
@@ -114,7 +114,7 @@ class CredentialsBaseHook(BaseHook):
     def test_connection(self):
         """Test that we can create DataRobot Credentials without errors"""
         try:
-            credential, credential_data = self.run()
+            credential, _ = self.run()
             credential = Credential.get(credential.credential_id)
             self.log.info(
                 f"Test credential {credential.name} id={credential.credential_id} created"

--- a/datarobot_provider/operators/ai_catalog.py
+++ b/datarobot_provider/operators/ai_catalog.py
@@ -196,7 +196,7 @@ class CreateDatasetFromDataStoreOperator(BaseOperator):
         DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
 
         # Fetch stored JDBC Connection with credentials
-        credential, credential_data, data_store = JDBCDataSourceHook(
+        _, credential_data, data_store = JDBCDataSourceHook(
             datarobot_credentials_conn_id=context["params"]["datarobot_jdbc_connection"]
         ).run()
 

--- a/datarobot_provider/operators/connections.py
+++ b/datarobot_provider/operators/connections.py
@@ -63,9 +63,7 @@ class GetOrCreateDataStoreOperator(BaseOperator):
         connection_name = context["params"][self.connection_param_name]
 
         # Fetch stored JDBC Connection with credentials
-        credential, credential_data, data_store = JDBCDataSourceHook(
-            datarobot_credentials_conn_id=connection_name
-        ).run()
+        _, _, data_store = JDBCDataSourceHook(datarobot_credentials_conn_id=connection_name).run()
 
         if data_store is not None:
             self.log.info(f"Found preconfigured jdbc connection: {connection_name}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ select = [
     "W",
     "B",
     "I",
+    "C90"
 ]
 
 # Rules to ignore (corresponds to Flake8's ignore)

--- a/tests/unit/hooks/credentials/test_aws_credentials.py
+++ b/tests/unit/hooks/credentials/test_aws_credentials.py
@@ -12,7 +12,7 @@ def test_datarobot_aws_credentials_conn(
     dr_aws_credentials_conn_details, mock_airflow_connection_datarobot_aws_credentials
 ):
     hook = AwsCredentialsHook(datarobot_credentials_conn_id="datarobot_aws_credentials_test")
-    credentials, credential_data = hook.get_conn()
+    _, credential_data = hook.get_conn()
 
     assert credential_data["awsAccessKeyId"] == dr_aws_credentials_conn_details["aws_access_key_id"]
     assert (

--- a/tests/unit/hooks/credentials/test_azure_credentials.py
+++ b/tests/unit/hooks/credentials/test_azure_credentials.py
@@ -14,7 +14,7 @@ def test_datarobot_azure_credentials_conn(
     hook = AzureStorageCredentialsHook(
         datarobot_credentials_conn_id="datarobot_azure_credentials_test"
     )
-    credentials, credential_data = hook.get_conn()
+    _, credential_data = hook.get_conn()
 
     assert (
         credential_data["azureConnectionString"]

--- a/tests/unit/hooks/credentials/test_basic_credentials.py
+++ b/tests/unit/hooks/credentials/test_basic_credentials.py
@@ -12,7 +12,7 @@ def test_datarobot_basic_credentials_conn(
     dr_basic_credentials_conn_details, mock_airflow_connection_datarobot_basic_credentials
 ):
     hook = BasicCredentialsHook(datarobot_credentials_conn_id="datarobot_basic_credentials_test")
-    credentials, credential_data = hook.get_conn()
+    _, credential_data = hook.get_conn()
 
     assert credential_data["user"] == dr_basic_credentials_conn_details["login"]
     assert credential_data["password"] == dr_basic_credentials_conn_details["password"]

--- a/tests/unit/hooks/credentials/test_gcp_credentials.py
+++ b/tests/unit/hooks/credentials/test_gcp_credentials.py
@@ -14,6 +14,6 @@ def test_datarobot_gcp_credentials_conn(
     hook = GoogleCloudCredentialsHook(
         datarobot_credentials_conn_id="datarobot_gcp_credentials_test"
     )
-    credentials, credential_data = hook.get_conn()
+    _, credential_data = hook.get_conn()
 
     assert credential_data["gcpKey"] == dr_gcp_credentials_conn_details["gcp_key"]

--- a/tests/unit/hooks/credentials/test_oauth_credentials.py
+++ b/tests/unit/hooks/credentials/test_oauth_credentials.py
@@ -12,7 +12,7 @@ def test_datarobot_oauth_credentials_conn(
     dr_oauth_credentials_conn_details, mock_airflow_connection_datarobot_oauth_credentials
 ):
     hook = OAuthCredentialsHook(datarobot_credentials_conn_id="datarobot_oauth_credentials_test")
-    credentials, credential_data = hook.get_conn()
+    _, credential_data = hook.get_conn()
 
     assert credential_data["oauthClientId"] == dr_oauth_credentials_conn_details["oauth_client_id"]
     assert credential_data["oauthClientSecret"] == dr_oauth_credentials_conn_details["token"]


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Added McCabe complexity rule (no issues):
https://docs.astral.sh/ruff/rules/#mccabe-c90

Then I found a handful of unused variables that ideally should be special `_` variable.
The way I discovered these was adding `preview = true` to the `[tool.ruff.lint]` section in pyproject.toml - I did _not_ commit that though but I can if we wish.

## Rationale

Putting lining rules in place while there's still very few violations to fix now.