### PR TITLE
[DM-16784] Add a GetDataStoreOperator

### DIFF
--- a/.harness/cichecks.yaml
+++ b/.harness/cichecks.yaml
@@ -98,7 +98,7 @@ pipeline:
                           set -exuo pipefail
                           pip install apache-airflow
                           pip install -r requirements.txt
-                          pip install airflow-provider-datarobot
+                          pip install airflow-provider-datarobot freezegun
                           airflow db init
                           airflow db check
                           pytest -vv tests/unit/ --junit-xml=unit_test_report.xml

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@
 - Introduce `CreateWranglingRecipeOperator <datarobot_provider.operators.ai_catalog.CreateWranglingRecipeOperator>` 
 and `CreateDatasetFromRecipeOperator <datarobot_provider.operators.ai_catalog.CreateDatasetFromRecipeOperator>` 
 to create a wrangling recipe and publish it as a dataset into an existing use case.
+- Add `GetDataStoreOperator <datarobot_provider.operators.connections.GetDataStoreOperator>` to work directly with existing DataRobot data connections.
+- Make `CreateOrUpdateDataSourceOperator <datarobot_provider.operators.ai_catalog.CreateOrUpdateDataSourceOperator>` `dataset_name` parameter optional.
+- Make `CreateOrUpdateDataSourceOperator <datarobot_provider.operators.ai_catalog.CreateOrUpdateDataSourceOperator>` parameters use templates.
 
 ### Bugfixes
 

--- a/datarobot_provider/operators/ai_catalog.py
+++ b/datarobot_provider/operators/ai_catalog.py
@@ -434,7 +434,7 @@ class CreateDatasetVersionOperator(BaseOperator):
 class CreateOrUpdateDataSourceOperator(BaseOperator):
     """
     Get an existing data source by name and update it if any of *table_schema*, *table_name*, *query* are specified.
-    Create a new data source or update a data source and return data source ID.
+    Create a new data source if there is no existing one with the specified name.
 
     :param data_store_id: DataRobot data store ID
     :type data_store_id: str

--- a/datarobot_provider/operators/ai_catalog.py
+++ b/datarobot_provider/operators/ai_catalog.py
@@ -670,7 +670,9 @@ class CreateWranglingRecipeOperator(BaseOperator):
 
             self.log.info("Working with data_store_id=%s", self.data_store_id)
             data_store = dr.DataStore.get(self.data_store_id)
-            if not (data_store.type and data_store.type in dr.enums.DataWranglingDataSourceTypes):
+            if not (
+                data_store.type and data_store.type in iter(dr.enums.DataWranglingDataSourceTypes)
+            ):
                 raise AirflowException(f"Unexpected data store type: {data_store.type}")
 
             data_source_canonical_name = self._generate_data_source_canonical_name()

--- a/datarobot_provider/operators/ai_catalog.py
+++ b/datarobot_provider/operators/ai_catalog.py
@@ -603,12 +603,14 @@ class CreateWranglingRecipeOperator(BaseOperator):
             raise AirflowException("Specify either dataset_id or data_store_id to wrangle.")
 
         if self.dataset_id and self.data_store_id:
-            raise AirflowException("You have to specify either dataset_id or data_store_id. Not both.")
+            raise AirflowException(
+                "You have to specify either dataset_id or data_store_id. Not both."
+            )
 
         use_case = dr.UseCase.get(self.use_case_id)
 
         if self.dataset_id:
-            self.log.info('Working with dataset_id=%s', self.dataset_id)
+            self.log.info("Working with dataset_id=%s", self.dataset_id)
 
             dataset = dr.Dataset.get(self.dataset_id)
             recipe = dr.models.Recipe.from_dataset(
@@ -616,7 +618,7 @@ class CreateWranglingRecipeOperator(BaseOperator):
             )
 
         else:
-            self.log.info('Working with data_store_id=%s', self.data_store_id)
+            self.log.info("Working with data_store_id=%s", self.data_store_id)
             data_source_canonical_name = self._generate_data_source_canonical_name()
 
             data_store = dr.DataStore.get(self.data_store_id)
@@ -659,18 +661,18 @@ class CreateWranglingRecipeOperator(BaseOperator):
         if self.recipe_name or self.recipe_description:
             data = {"description": self.recipe_description}
             if self.recipe_name:
-                data['name'] = self.recipe_name
+                data["name"] = self.recipe_name
 
-            dr.client.get_client().patch(f"recipes/{recipe.id}/",json=data)
+            dr.client.get_client().patch(f"recipes/{recipe.id}/", json=data)
             logging.info("Recipe name/description set.")
 
         logging.info("Recipe id=%s is ready.", recipe.id)
         return recipe.id
 
     def _generate_data_source_canonical_name(self):
-        base_name = f'{self.table_name}-{datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S")}'
+        base_name = f"{self.table_name}-{datetime.datetime.now().strftime('%Y-%m-%dT%H:%M:%S')}"
 
         if self.table_schema:
-            base_name = f'{self.table_schema}-{base_name}'
+            base_name = f"{self.table_schema}-{base_name}"
 
-        return f'Airflow:{base_name}'
+        return f"Airflow:{base_name}"

--- a/datarobot_provider/operators/connections.py
+++ b/datarobot_provider/operators/connections.py
@@ -100,6 +100,6 @@ class GetDataStoreOperator(BaseOperator):
                 break
 
         else:
-            raise AirflowException(f'Connection {self.datarobot_connection_name} was not found.')
+            raise AirflowException(f"Connection {self.datarobot_connection_name} was not found.")
 
         return datastore.id

--- a/datarobot_provider/operators/connections.py
+++ b/datarobot_provider/operators/connections.py
@@ -20,6 +20,9 @@ from datarobot_provider.hooks.datarobot import DataRobotHook
 
 class GetOrCreateDataStoreOperator(BaseOperator):
     """
+    Deprected.
+    Please, manage database connections via DataRobot rather than Airflow and use *GetDataStoreOperator* instead.
+
     Fetching DataStore by connection name or creating if it does not exist
     and return DataStore ID.
 
@@ -73,6 +76,16 @@ class GetOrCreateDataStoreOperator(BaseOperator):
 
 
 class GetDataStoreOperator(BaseOperator):
+    """Get a DataRobot data store id by data connection name.
+    You have to create a DataRobot data connection in advance at /account/data-connections page.
+
+    :param datarobot_connection_name: unique, case sensitive data connection name.
+    You can set it either explicitly or via context parameters.
+    :type datarobot_connection_name: str
+    :return: Data store ID.
+    :rtype: str
+    """
+
     template_fields: Sequence[str] = ["datarobot_connection_name"]
     ui_color = "#f4a460"
 

--- a/datarobot_provider/operators/connections.py
+++ b/datarobot_provider/operators/connections.py
@@ -20,8 +20,7 @@ from datarobot_provider.hooks.datarobot import DataRobotHook
 
 class GetOrCreateDataStoreOperator(BaseOperator):
     """
-    Deprected.
-    Please, manage database connections via DataRobot rather than Airflow and use *GetDataStoreOperator* instead.
+    !! Please, manage database connections via DataRobot rather than Airflow and use *GetDataStoreOperator* instead. !!
 
     Fetching DataStore by connection name or creating if it does not exist
     and return DataStore ID.
@@ -79,26 +78,25 @@ class GetDataStoreOperator(BaseOperator):
     """Get a DataRobot data store id by data connection name.
     You have to create a DataRobot data connection in advance at /account/data-connections page.
 
-    :param datarobot_connection_name: unique, case sensitive data connection name.
-    You can set it either explicitly or via context parameters.
-    :type datarobot_connection_name: str
+    :param data_connection: unique, case-sensitive data connection name as you can see it at DataRobot.
+    :type data_connection: str
     :return: Data store ID.
     :rtype: str
     """
 
-    template_fields: Sequence[str] = ["datarobot_connection_name"]
+    template_fields: Sequence[str] = ["data_connection"]
     ui_color = "#f4a460"
 
     def __init__(
         self,
         *,
-        datarobot_connection_name: str = "{{ params.datarobot_connection_name }}",
+        data_connection: str = "{{ params.data_connection }}",
         datarobot_conn_id: str = "datarobot_default",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.datarobot_conn_id = datarobot_conn_id
-        self.datarobot_connection_name = datarobot_connection_name
+        self.data_connection = data_connection
         if kwargs.get("xcom_push") is not None:
             raise AirflowException(
                 "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
@@ -108,11 +106,11 @@ class GetDataStoreOperator(BaseOperator):
         # Initialize DataRobot client
         DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
 
-        for datastore in dr.DataStore.list(name=self.datarobot_connection_name):
-            if datastore.canonical_name == self.datarobot_connection_name:
+        for datastore in dr.DataStore.list(name=self.data_connection):
+            if datastore.canonical_name == self.data_connection:
                 break
 
         else:
-            raise AirflowException(f"Connection {self.datarobot_connection_name} was not found.")
+            raise AirflowException(f"Connection {self.data_connection} was not found.")
 
         return datastore.id

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "black==24.10.0",
     "pyyaml>=6.0.2",
     "types-PyYAML>=6.0.12",
+    "freezegun>=1.5.1",
 ]
 
 [project.entry-points."apache_airflow_provider"]

--- a/tests/unit/operators/test_ai_catalog.py
+++ b/tests/unit/operators/test_ai_catalog.py
@@ -299,7 +299,7 @@ def test_operator_create_datasource_operator(mocker):
 def test_operator_update_datasource_operator(mocker):
     data_store_id = "test-data-store-id"
     new_query = 'SELECT * FROM "integration_demo"."test_table22"'
-    canonical_name = 'Airflow-test-data-store-id-q-fcd91844f7cf2132d6a98e7692d0dae808f77d800880870963be31ec00ac8ba8'
+    canonical_name = "Airflow-test-data-store-id-q-fcd91844f7cf2132d6a98e7692d0dae808f77d800880870963be31ec00ac8ba8"
 
     context = {"params": {"db_query": new_query}}
 
@@ -318,9 +318,7 @@ def test_operator_update_datasource_operator(mocker):
     create_datasource_mock = mocker.patch.object(dr.DataSource, "create")
 
     operator = CreateOrUpdateDataSourceOperator(
-        task_id="create_dataset_version",
-        data_store_id=data_store_id,
-        query='{{ params.db_query }}'
+        task_id="create_dataset_version", data_store_id=data_store_id, query="{{ params.db_query }}"
     )
     operator.render_template_fields(context)
     data_source_id = operator.execute(context)
@@ -330,6 +328,6 @@ def test_operator_update_datasource_operator(mocker):
 
     datasource_mock.update.assert_called_once_with(
         canonical_name=canonical_name,
-        params=dr.DataSourceParameters(data_store_id=data_store_id, query=new_query)
+        params=dr.DataSourceParameters(data_store_id=data_store_id, query=new_query),
     )
     create_datasource_mock.assert_not_called()

--- a/tests/unit/operators/test_connections.py
+++ b/tests/unit/operators/test_connections.py
@@ -6,11 +6,12 @@
 #
 # Released under the terms of DataRobot Tool and Utility Agreement.
 
+import datarobot as dr
 import pytest
 from airflow.exceptions import AirflowNotFoundException
 
-import datarobot as dr
-from datarobot_provider.operators.connections import GetOrCreateDataStoreOperator, GetDataStoreOperator
+from datarobot_provider.operators.connections import GetDataStoreOperator
+from datarobot_provider.operators.connections import GetOrCreateDataStoreOperator
 
 
 def test_operator_get_or_create_dataset(mock_airflow_connection_datarobot_jdbc):
@@ -52,16 +53,15 @@ def test_operator_get_or_create_dataset_not_found(mock_airflow_connection_dataro
 def test_operator_get_data_store(mocker):
     mocker.patch.object(
         dr.DataStore,
-        'list',
+        "list",
         return_value=[
-            dr.DataStore(data_store_id='0', canonical_name='the connection'),
-            dr.DataStore(data_store_id='1', canonical_name='The connection'),
-            dr.DataStore(data_store_id='2', canonical_name='The connection.'),
+            dr.DataStore(data_store_id="0", canonical_name="the connection"),
+            dr.DataStore(data_store_id="1", canonical_name="The connection"),
+            dr.DataStore(data_store_id="2", canonical_name="The connection."),
         ],
-
     )
 
-    operator = GetDataStoreOperator(task_id='test', data_connection='The connection')
+    operator = GetDataStoreOperator(task_id="test", data_connection="The connection")
     data_store_id = operator.execute({})
 
-    assert data_store_id == '1'
+    assert data_store_id == "1"

--- a/tests/unit/operators/test_connections.py
+++ b/tests/unit/operators/test_connections.py
@@ -9,7 +9,8 @@
 import pytest
 from airflow.exceptions import AirflowNotFoundException
 
-from datarobot_provider.operators.connections import GetOrCreateDataStoreOperator
+import datarobot as dr
+from datarobot_provider.operators.connections import GetOrCreateDataStoreOperator, GetDataStoreOperator
 
 
 def test_operator_get_or_create_dataset(mock_airflow_connection_datarobot_jdbc):
@@ -46,3 +47,21 @@ def test_operator_get_or_create_dataset_not_found(mock_airflow_connection_dataro
                 },
             }
         )
+
+
+def test_operator_get_data_store(mocker):
+    mocker.patch.object(
+        dr.DataStore,
+        'list',
+        return_value=[
+            dr.DataStore(data_store_id='0', canonical_name='the connection'),
+            dr.DataStore(data_store_id='1', canonical_name='The connection'),
+            dr.DataStore(data_store_id='2', canonical_name='The connection.'),
+        ],
+
+    )
+
+    operator = GetDataStoreOperator(task_id='test', data_connection='The connection')
+    data_store_id = operator.execute({})
+
+    assert data_store_id == '1'


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

* Get a `data_store_id` based on the connection name.
* Make `CreateOrUpdateDataSourceOperator` more flexible:
  * `dataset_name` parameter is now optional
  * All parameters are templates now.
* Create a wrangling recipe from a db table. No intermediate dataset needed. 

## Rationale

* Datarobot relies on default credentials heavily in UXR. New API endpoints don't expect plain credentials anymore. So, users have to **prefer Datarobot over Airflow connections management**.

* We're going to build an example DAG with database wrangling. The PR prepares existing operators for this.