### PR TITLE
[CFX-1399] Use manual runs for E2E Notebook runs - Create Operator, Sensor and example DAG

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,12 +3,14 @@
 ## Unreleased
 
 ### New features
-- Introduce `CreateWranglingRecipeOperator <datarobot_provider.operators.ai_catalog.CreateWranglingRecipeOperator>` 
-and `CreateDatasetFromRecipeOperator <datarobot_provider.operators.ai_catalog.CreateDatasetFromRecipeOperator>` 
+- Introduce `CreateWranglingRecipeOperator <datarobot_provider.operators.ai_catalog.CreateWranglingRecipeOperator>`
+and `CreateDatasetFromRecipeOperator <datarobot_provider.operators.ai_catalog.CreateDatasetFromRecipeOperator>`
 to create a wrangling recipe and publish it as a dataset into an existing use case.
 - Add `GetDataStoreOperator <datarobot_provider.operators.connections.GetDataStoreOperator>` to work directly with existing DataRobot data connections.
 - Make `CreateOrUpdateDataSourceOperator <datarobot_provider.operators.ai_catalog.CreateOrUpdateDataSourceOperator>` `dataset_name` parameter optional.
 - Make `CreateOrUpdateDataSourceOperator <datarobot_provider.operators.ai_catalog.CreateOrUpdateDataSourceOperator>` parameters use templates.
+- Introduce `NotebookRunOperator <datarobot_provider.operators.notebook.NotebookRunOperator>`
+and `NotebookRunCompleteSensor <datarobot_provider.sensors.notebook.NotebookRunCompleteSensor>`
 
 ### Bugfixes
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,5 +10,6 @@
 /datarobot_provider/operators/monitoring_job.py          @datarobot/tracking-agent
 /datarobot_provider/operators/notebook.py                @datarobot/cfx
 /datarobot_provider/operators/prediction_explanations.py @datarobot/trust-explainable-ai
+/datarobot_provider/sensors/notebook.py                  @datarobot/cfx
 /docs                                                    @datarobot/api-docs
 /tests/                                                  @datarobot/machine-learning-development

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,6 +8,7 @@
 /datarobot_provider/operators/model_predictions.py       @datarobot/predictions
 /datarobot_provider/operators/monitoring.py              @datarobot/model-management
 /datarobot_provider/operators/monitoring_job.py          @datarobot/tracking-agent
+/datarobot_provider/operators/notebook.py                @datarobot/cfx
 /datarobot_provider/operators/prediction_explanations.py @datarobot/trust-explainable-ai
 /docs                                                    @datarobot/api-docs
 /tests/                                                  @datarobot/machine-learning-development

--- a/datarobot_provider/example_dags/datarobot_run_notebook_e2e.py
+++ b/datarobot_provider/example_dags/datarobot_run_notebook_e2e.py
@@ -1,0 +1,75 @@
+# Copyright 2025 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+"""
+Config example for this dag:
+{
+    "notebook_id": "6798e158cc74377e3ceb4868",
+    "notebook_path": "/home/notebooks/storage/test.py"
+    "notebook_parameters": {
+        "data": [{"name": "foo", "value": "bar"}]
+    }
+}
+"""
+
+from datetime import datetime
+
+from airflow.decorators import dag
+from airflow.models.param import Param
+
+from datarobot_provider.operators.notebook import NotebookRunOperator
+from datarobot_provider.sensors.notebook import NotebookRunCompleteSensor
+
+# Default to 24 hours
+DEFAULT_NOTEBOOK_EXECUTION_TIMEOUT = 1440
+
+
+@dag(
+    schedule=None,
+    start_date=datetime(2025, 1, 1),
+    tags=["example", "notebook"],
+    # Default json config example:
+    params={
+        "notebook_id": "put_your_notebook_id_here",
+        "notebook_path": "put_notebook_path_here_if_codespace",
+        "notebook_parameters": Param(
+            {"data": [{"name": "foo", "value": "bar"}]}, type=["object", "null"]
+        ),
+    },
+)
+def datarobot_notebook_run(
+    notebook_id=None,
+    notebook_path=None,
+    notebook_parameters=None,
+):
+    # Timeout waiting for complete notebook execution
+    execution_timeout = DEFAULT_NOTEBOOK_EXECUTION_TIMEOUT * 60
+
+    run_notebook = NotebookRunOperator(
+        task_id="run_notebook",
+        notebook_id=notebook_id,
+        notebook_path=notebook_path,
+        notebook_parameters=notebook_parameters,
+    )
+
+    # Status check each 15 sec
+    poke_interval = 15
+    check_notebook_run_complete = NotebookRunCompleteSensor(
+        task_id="check_notebook_run_complete",
+        notebook_id=notebook_id,
+        job_id=run_notebook.output,
+        poke_interval=poke_interval,
+        timeout=execution_timeout,
+    )
+
+    run_notebook >> check_notebook_run_complete
+
+
+datarobot_notebook_run_dag = datarobot_notebook_run()
+
+if __name__ == "__main__":
+    datarobot_notebook_run_dag.test()

--- a/datarobot_provider/operators/notebook.py
+++ b/datarobot_provider/operators/notebook.py
@@ -1,0 +1,86 @@
+# Copyright 2025 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+from collections.abc import Sequence
+from typing import Any
+from typing import Optional
+from typing import TypedDict
+
+from airflow.exceptions import AirflowException
+from airflow.models import BaseOperator
+from airflow.utils.context import Context
+from datarobot._experimental.models.notebooks import Notebook
+from datarobot._experimental.models.notebooks.session import StartSessionParameters
+
+from datarobot_provider.hooks.datarobot import DataRobotHook
+
+
+class NotebookParametersData(TypedDict):
+    data: list[StartSessionParameters]
+
+
+class NotebookRunOperator(BaseOperator):
+    """
+    Runs a DataRobot Notebook.
+
+    :param notebook_id: DataRobot notebook ID
+    :type notebook_id: str
+    :param notebook_path: Path to the notebook file. Must be provided if the notebook is part of a Codespace.
+    :type notebook_path: str
+    :param notebook_parameters: Parameters to be set as environment variables in the notebook session. Must be in the
+        form of `{"name": "FOO", "value": "MyValue"}`
+    :type notebook_parameters: dict, optional
+    :param datarobot_conn_id: Connection ID, defaults to `datarobot_default`
+    :type datarobot_conn_id: str, optional
+    :return: The ID of the triggered notebook run.
+    :rtype: str
+    """
+
+    # Specify the arguments that are allowed to parse with jinja templating
+    template_fields: Sequence[str] = [
+        "notebook_id",
+        "notebook_path",
+        "notebook_parameters",
+    ]
+
+    def __init__(
+        self,
+        *,
+        notebook_id: str,
+        notebook_path: Optional[str],
+        notebook_parameters: Optional[NotebookParametersData] = None,
+        datarobot_conn_id: str = "datarobot_default",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.notebook_id = notebook_id
+        self.notebook_path = notebook_path
+        self.notebook_parameters = notebook_parameters
+        self.datarobot_conn_id = datarobot_conn_id
+        if kwargs.get("xcom_push") is not None:
+            raise AirflowException(
+                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
+            )
+
+    def execute(self, context: Context) -> str:
+        # Initialize DataRobot client
+        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
+
+        # DAGs using Airflow's `Param` model can't seem to take an array/list - it needs to be an object/dict
+        parameters = self.notebook_parameters.get("data") if self.notebook_parameters else None
+
+        # Fetch the notebook
+        notebook = Notebook.get(notebook_id=self.notebook_id)
+
+        # Run the notebook
+        manual_run = notebook.run(
+            notebook_path=self.notebook_path,
+            parameters=parameters,
+        )
+        self.log.info(f"Notebook triggered. Manual run ID: {manual_run.id}")
+
+        return manual_run.id

--- a/datarobot_provider/operators/notebook.py
+++ b/datarobot_provider/operators/notebook.py
@@ -76,6 +76,9 @@ class NotebookRunOperator(BaseOperator):
         # Fetch the notebook
         notebook = Notebook.get(notebook_id=self.notebook_id)
 
+        if not notebook.use_case_id:
+            raise AirflowException("Notebook should have use_case_id")
+
         # Run the notebook
         manual_run = notebook.run(
             notebook_path=self.notebook_path,

--- a/datarobot_provider/sensors/notebook.py
+++ b/datarobot_provider/sensors/notebook.py
@@ -1,0 +1,77 @@
+# Copyright 2025 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+from typing import Any
+
+from airflow.exceptions import AirflowException
+from airflow.sensors.base import BaseSensorOperator
+from airflow.utils.context import Context
+from datarobot._experimental.models.notebooks.enums import ScheduledRunStatus
+from datarobot._experimental.models.notebooks.notebook import Notebook
+from datarobot._experimental.models.notebooks.scheduled_job import NotebookScheduledJob
+
+from datarobot_provider.hooks.datarobot import DataRobotHook
+
+
+class NotebookRunCompleteSensor(BaseSensorOperator):
+    """
+    Checks if the notebook run is complete.
+
+    :param notebook_id: Notebook ID
+    :type notebook_id: str
+    :param job_id: Job ID
+    :type job_id: str
+    :param datarobot_conn_id: Connection ID, defaults to `datarobot_default`
+    :type datarobot_conn_id: str, optional
+    :return: False if not yet completed
+    :rtype: bool
+    """
+
+    # Specify the arguments that are allowed to parse with jinja templating
+    template_fields = [
+        "notebook_id",
+        "job_id",
+    ]
+
+    def __init__(
+        self,
+        *,
+        notebook_id: str,
+        job_id: str,
+        datarobot_conn_id: str = "datarobot_default",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.notebook_id = notebook_id
+        self.job_id = job_id
+        self.datarobot_conn_id = datarobot_conn_id
+
+        self.hook = DataRobotHook(datarobot_conn_id)
+
+    def poke(self, context: Context) -> bool:
+        # Initialize DataRobot client
+        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
+
+        self.log.info("Checking if notebook execution is complete.")
+        notebook = Notebook.get(self.notebook_id)
+
+        # This should not happen but to keep mypy happy as well as remain very defensive we'll check
+        if not notebook.use_case_id:
+            raise AirflowException("Notebook should have use_case_id")
+
+        notebook_scheduled_job = NotebookScheduledJob.get(
+            use_case_id=notebook.use_case_id, scheduled_job_id=self.job_id
+        )
+        manual_run = notebook_scheduled_job.get_most_recent_run()
+
+        if manual_run and manual_run.status in ScheduledRunStatus.terminal_statuses():
+            self.log.info(f"Notebook job no longer running - status: {manual_run.status}")
+            return True
+
+        status_message = f" - status: {manual_run.status}" if manual_run else ""
+        self.log.info(f"Notebook job still running{status_message}")
+        return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 dependencies = [
     "apache-airflow>=2.3.0",
-    "datarobot>=3.3.1"
+    "datarobot>=3.7.0b0"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ classifiers = [
 ]
 dependencies = [
     "apache-airflow>=2.3.0",
-    "datarobot>=3.7.0b0"
+    "datarobot>=3.7.0b0",  # TODO: Use early access version below? Currently iterating on PySDK additions relying on artifactory versions
+    # "datarobot-early-access>=3.7.0.2025.1.28"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

We're creating a single Operator and Sensor for use with Notebooks (Standalone, non-Classic) and Codepsace notebooks.

This is a Draft PR in part because I'm waiting on a blocking decision/approach on how to leverage the experimental DR Python client methods (all the DR Notebook methods & classes are in experimental)

## Rationale

We want to be able to execute notebooks easily in Airflow pipelines.

## Changes

- Update codeowners file
- Update DR Python client dep. to what's needed for new, experimental methods (only available using private Artifactory)
- Add `NotebookRunOperator`
- Add `NotebookRunCompleteSensor`
- Add Example DAG for running a notebook end to end

## Screenshots

<img width="1370" alt="Screenshot 2025-01-28 at 7 05 32 PM" src="https://github.com/user-attachments/assets/a8938af6-150e-4725-ba22-90836d9a2b3c" />

<img width="1203" alt="Screenshot 2025-01-28 at 7 05 50 PM" src="https://github.com/user-attachments/assets/a0e756f2-77ed-4a31-aaf1-ce915619b86d" />
