### PR TITLE
[MLDEV-1174] Add use case create operator

### DIFF
--- a/datarobot_provider/operators/datarobot.py
+++ b/datarobot_provider/operators/datarobot.py
@@ -24,7 +24,7 @@ DATETIME_FORMAT = "%Y-%m-%d %H:%M:%s"
 
 class CreateUseCaseOperator(BaseOperator):
     """
-    Creates DataRobot project.
+    Creates a DataRobot Use Case.
 
     Parameters
     ----------
@@ -33,11 +33,11 @@ class CreateUseCaseOperator(BaseOperator):
 
     Returns
     -------
-    str: DataRobot project ID
+    str: DataRobot UseCase ID
     """
 
     # Specify the arguments that are allowed to parse with jinja templating
-    template_fields: Sequence[str] = ["dataset_id", "dataset_version_id", "credential_id"]
+    template_fields: Sequence[str] = ["credential_id"]
     template_fields_renderers: dict[str, str] = {}
     template_ext: Sequence[str] = ()
     ui_color = "#f4a460"

--- a/datarobot_provider/operators/datarobot.py
+++ b/datarobot_provider/operators/datarobot.py
@@ -22,6 +22,55 @@ DATAROBOT_AUTOPILOT_TIMEOUT = 86400
 DATETIME_FORMAT = "%Y-%m-%d %H:%M:%s"
 
 
+class CreateUseCaseOperator(BaseOperator):
+    """
+    Creates DataRobot project.
+
+    Parameters
+    ----------
+    datarobot_conn_id: str
+        Connection ID, defaults to `datarobot_default`
+
+    Returns
+    -------
+    str: DataRobot project ID
+    """
+
+    # Specify the arguments that are allowed to parse with jinja templating
+    template_fields: Sequence[str] = ["dataset_id", "dataset_version_id", "credential_id"]
+    template_fields_renderers: dict[str, str] = {}
+    template_ext: Sequence[str] = ()
+    ui_color = "#f4a460"
+
+    def __init__(
+        self,
+        *,
+        credential_id: Optional[str] = None,
+        datarobot_conn_id: str = "datarobot_default",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.datarobot_conn_id = datarobot_conn_id
+        self.credential_id = credential_id
+        if kwargs.get("xcom_push") is not None:
+            raise AirflowException(
+                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
+            )
+
+    def execute(self, context: Context) -> Optional[str]:
+        # Initialize DataRobot client
+        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
+
+        # Create DataRobot project
+        self.log.info("Creating DataRobot Use Case")
+        use_case: dr.UseCase = dr.UseCase.create(
+            name=context["params"].get("use_case_name"),
+            description=context["params"].get("use_case_description"),
+        )
+        self.log.info(f"Use case created: use_case_id={use_case.id} from local file")
+        return use_case.id
+
+
 class CreateProjectOperator(BaseOperator):
     """
     Creates DataRobot project.

--- a/docs/autodoc/operators_datarobot.md
+++ b/docs/autodoc/operators_datarobot.md
@@ -1,0 +1,8 @@
+(datarobot-modules)=
+
+# Datarobot Modules
+
+```{eval-rst}
+.. autoclass:: datarobot_provider.operators.datarobot.CreateUseCaseOperator
+   :members:
+```

--- a/tests/unit/operators/test_datarobot.py
+++ b/tests/unit/operators/test_datarobot.py
@@ -14,6 +14,7 @@ from datarobot.models.deployment.data_drift import FeatureDrift
 from datarobot.models.deployment.data_drift import TargetDrift
 
 from datarobot_provider.operators.datarobot import CreateProjectOperator
+from datarobot_provider.operators.datarobot import CreateUseCaseOperator
 from datarobot_provider.operators.datarobot import DeployModelOperator
 from datarobot_provider.operators.datarobot import DeployRecommendedModelOperator
 from datarobot_provider.operators.datarobot import GetFeatureDriftOperator
@@ -21,6 +22,37 @@ from datarobot_provider.operators.datarobot import GetTargetDriftOperator
 from datarobot_provider.operators.datarobot import ScorePredictionsOperator
 from datarobot_provider.operators.datarobot import TrainModelsOperator
 from datarobot_provider.operators.datarobot import _serialize_drift
+
+
+@pytest.mark.parametrize(
+    "name, description",
+    [
+        (None, None),
+        ("use-case-name", None),
+        (None, "use-case-description"),
+        ("use-case-name", "use-case-description"),
+    ],
+)
+def test_operator_create_use_case(mocker, name, description):
+    use_case_mock = mocker.Mock()
+    use_case_mock.id = "use-case-id"
+    create_use_case_mock = mocker.patch.object(dr.UseCase, "create", return_value=use_case_mock)
+
+    operator = CreateUseCaseOperator(task_id="create_project")
+    params = {}
+    if name:
+        params["use_case_name"] = name
+    if description:
+        params["use_case_description"] = description
+
+    use_case_id = operator.execute(
+        context={
+            "params": params,
+        }
+    )
+
+    assert use_case_id == "use-case-id"
+    create_use_case_mock.assert_called_with(name=name, description=description)
 
 
 def test_operator_create_project(mocker):


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
This was one of the remaining MLDEV operators blocking the P0 DAG. This allows a pipeline to create a use case. It's a pretty simple operator. Also the docstring has been moved to numpy now so that it works with the docs properly.


## Rationale
- Add a new create use case operator
- Add a simple test

Followup:
We probably need to investigate if we should have a more robust operator/dag test strategy in place. It feels like the existing flow heavily just relies on mocking out the core pySDK call, and this doesn't necessarily check that the upstream call hasn't changed in any way.