### PR TITLE
[DM-1903] Add CreateDatasetFromProjectOperator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@
 and `CreateDatasetFromRecipeOperator <datarobot_provider.operators.ai_catalog.CreateDatasetFromRecipeOperator>` 
 to create a wrangling recipe and publish it as a dataset into an existing use case.
 - Introduce `CreateDatasetFromProjectOperator <datarobot_provider.operators.ai_catalog.CreateDatasetFromProjectOperator>`
-to publish datasets from Feature Discovery recipes.
+to create datasets from project data.
 - Add `GetDataStoreOperator <datarobot_provider.operators.connections.GetDataStoreOperator>` to work directly with existing DataRobot data connections.
 - Make `CreateOrUpdateDataSourceOperator <datarobot_provider.operators.ai_catalog.CreateOrUpdateDataSourceOperator>` `dataset_name` parameter optional.
 - Make `CreateOrUpdateDataSourceOperator <datarobot_provider.operators.ai_catalog.CreateOrUpdateDataSourceOperator>` parameters use templates.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 - Introduce `CreateWranglingRecipeOperator <datarobot_provider.operators.ai_catalog.CreateWranglingRecipeOperator>` 
 and `CreateDatasetFromRecipeOperator <datarobot_provider.operators.ai_catalog.CreateDatasetFromRecipeOperator>` 
 to create a wrangling recipe and publish it as a dataset into an existing use case.
+- Introduce `CreateDatasetFromProjectOperator <datarobot_provider.operators.ai_catalog.CreateDatasetFromProjectOperator>`
+to publish datasets from Feature Discovery recipes.
 - Add `GetDataStoreOperator <datarobot_provider.operators.connections.GetDataStoreOperator>` to work directly with existing DataRobot data connections.
 - Make `CreateOrUpdateDataSourceOperator <datarobot_provider.operators.ai_catalog.CreateOrUpdateDataSourceOperator>` `dataset_name` parameter optional.
 - Make `CreateOrUpdateDataSourceOperator <datarobot_provider.operators.ai_catalog.CreateOrUpdateDataSourceOperator>` parameters use templates.

--- a/datarobot_provider/operators/ai_catalog.py
+++ b/datarobot_provider/operators/ai_catalog.py
@@ -15,10 +15,8 @@ from typing import Optional
 
 import datarobot as dr
 from airflow.exceptions import AirflowException
-from airflow.exceptions import AirflowFailException
 from airflow.models import BaseOperator
 from airflow.utils.context import Context
-from datarobot.utils.waiters import wait_for_async_resolution
 
 from datarobot_provider.hooks.connections import JDBCDataSourceHook
 from datarobot_provider.hooks.datarobot import DataRobotHook

--- a/datarobot_provider/operators/ai_catalog.py
+++ b/datarobot_provider/operators/ai_catalog.py
@@ -469,17 +469,9 @@ class CreateDatasetFromProjectOperator(BaseOperator):
     def execute(self, context: Context) -> str:
         # Initialize DataRobot client
         DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
-
-        dr_client = dr.client.get_client()
-        response = dr_client.post("/datasets/fromProject", json={"projectId": self.project_id})
-        if response.status_code != 202:
-            e_msg = "Server unexpectedly returned status code {}"
-            raise AirflowFailException(e_msg.format(response.status_code))
-        wait_for_async_resolution(dr_client, response.headers["Location"])
-
-        dataset_id = response.json()["catalogId"]
-        self.log.info(f"Dataset created: dataset_id={dataset_id}")
-        return dataset_id
+        dataset: dr.Dataset = dr.Dataset.create_from_project(project_id=self.project_id)
+        self.log.info(f"Dataset created: dataset_id={dataset.id}")
+        return dataset.id
 
 
 class CreateOrUpdateDataSourceOperator(BaseOperator):

--- a/datarobot_provider/operators/ai_catalog.py
+++ b/datarobot_provider/operators/ai_catalog.py
@@ -15,8 +15,10 @@ from typing import Optional
 
 import datarobot as dr
 from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowFailException
 from airflow.models import BaseOperator
 from airflow.utils.context import Context
+from datarobot.utils.waiters import wait_for_async_resolution
 
 from datarobot_provider.hooks.connections import JDBCDataSourceHook
 from datarobot_provider.hooks.datarobot import DataRobotHook
@@ -429,6 +431,55 @@ class CreateDatasetVersionOperator(BaseOperator):
         )
 
         return ai_catalog_dataset.version_id
+
+
+class CreateDatasetFromProjectOperator(BaseOperator):
+    """
+    Create a new AI Catalog Dataset from existing project data.
+    :param project_id: DataRobot project ID
+    :type project_id: str
+    :param datasource_id: existing DataRobot datasource ID
+    :param datarobot_conn_id: Connection ID, defaults to `datarobot_default`
+    :type datarobot_conn_id: str, optional
+    :return: DataRobot AI Catalog dataset ID
+    :rtype: str
+    """
+
+    # Specify the arguments that are allowed to parse with jinja templating
+    template_fields: Sequence[str] = ["project_id"]
+    template_fields_renderers: dict[str, str] = {}
+    template_ext: Sequence[str] = ()
+    ui_color = "#f4a460"
+
+    def __init__(
+        self,
+        *,
+        project_id: str,
+        datarobot_conn_id: str = "datarobot_default",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.project_id = project_id
+        self.datarobot_conn_id = datarobot_conn_id
+        if kwargs.get("xcom_push") is not None:
+            raise AirflowException(
+                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
+            )
+
+    def execute(self, context: Context) -> str:
+        # Initialize DataRobot client
+        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
+
+        dr_client = dr.client.get_client()
+        response = dr_client.post("/datasets/fromProject", json={"projectId": self.project_id})
+        if response.status_code != 202:
+            e_msg = "Server unexpectedly returned status code {}"
+            raise AirflowFailException(e_msg.format(response.status_code))
+        wait_for_async_resolution(dr_client, response.headers["Location"])
+
+        dataset_id = response.json()["catalogId"]
+        self.log.info(f"Dataset created: dataset_id={dataset_id}")
+        return dataset_id
 
 
 class CreateOrUpdateDataSourceOperator(BaseOperator):

--- a/tests/unit/operators/test_ai_catalog.py
+++ b/tests/unit/operators/test_ai_catalog.py
@@ -280,13 +280,11 @@ def test_operator_create_dataset_from_recipe(
     get_recipe_mock.assert_called_once_with("test-recipe-id")
 
 
-@patch("datarobot_provider.operators.ai_catalog.wait_for_async_resolution")
-def test_operator_create_dataset_from_project(mock_wait_async, mocker):
-    mock_client_response = mocker.Mock(status_code=202, headers={"Location": "loc"})
-    mock_client_response.json.return_value = {"catalogId": "dataset-id"}
-    mock_client = mocker.Mock()
-    mock_client.post.return_value = mock_client_response
-    get_client_mock = mocker.patch.object(dr.client, "get_client", return_value=mock_client)
+def test_operator_create_dataset_from_project(mocker):
+    dataset_mock = mocker.Mock(id="dataset-id")
+    create_dataset_from_project_mock = mocker.patch.object(
+        dr.Dataset, "create_from_project", return_value=dataset_mock
+    )
 
     operator = CreateDatasetFromProjectOperator(
         task_id="create_project_from_project_id",
@@ -295,12 +293,8 @@ def test_operator_create_dataset_from_project(mock_wait_async, mocker):
 
     dataset_id = operator.execute(context={})
 
-    get_client_mock.assert_called_once()
-    mock_client.post.assert_called_once_with(
-        "/datasets/fromProject", json={"projectId": "project-id"}
-    )
-    mock_wait_async.assert_called_once()
     assert dataset_id == "dataset-id"
+    create_dataset_from_project_mock.assert_called_once_with(project_id="project-id")
 
 
 def test_operator_create_dataset_version(mocker):

--- a/tests/unit/operators/test_ai_catalog.py
+++ b/tests/unit/operators/test_ai_catalog.py
@@ -6,7 +6,6 @@
 #
 # Released under the terms of DataRobot Tool and Utility Agreement.
 from unittest.mock import ANY
-from unittest.mock import patch
 
 import datarobot as dr
 import freezegun


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.
We let users "publish" Feature Discovery datasets by creating new AI Catalog entries from their Feature Discovery project. So to allow users to publish, this PR updates to add `CreateDatasetFromProjectOperator`.

## Summary


## Rationale
