### PR TITLE
[DM-16986] Introduce a `BaseDatarobotOperator`

### DIFF
--- a/datarobot_provider/operators/ai_catalog.py
+++ b/datarobot_provider/operators/ai_catalog.py
@@ -375,6 +375,7 @@ class CreateDatasetFromProjectOperator(BaseDatarobotOperator):
     """
 
     template_fields: Sequence[str] = ["project_id"]
+
     def __init__(
         self,
         *,
@@ -390,7 +391,7 @@ class CreateDatasetFromProjectOperator(BaseDatarobotOperator):
         return dataset.id
 
 
-class CreateOrUpdateDataSourceOperator(BaseOperator):
+class CreateOrUpdateDataSourceOperator(BaseDatarobotOperator):
     """
     Get an existing data source by name and update it if any of *table_schema*, *table_name*, *query* are specified.
     Create a new data source if there is no existing one with the specified name.

--- a/datarobot_provider/operators/ai_catalog.py
+++ b/datarobot_provider/operators/ai_catalog.py
@@ -20,7 +20,6 @@ from airflow.utils.context import Context
 from datarobot_provider.hooks.connections import JDBCDataSourceHook
 from datarobot_provider.operators.base_datarobot_operator import BaseDatarobotOperator
 
-
 # Time in seconds after which dataset uploading is considered unsuccessful.
 DATAROBOT_MAX_WAIT_SEC = 3600
 

--- a/datarobot_provider/operators/ai_catalog.py
+++ b/datarobot_provider/operators/ai_catalog.py
@@ -15,17 +15,17 @@ from typing import Optional
 
 import datarobot as dr
 from airflow.exceptions import AirflowException
-from airflow.models import BaseOperator
 from airflow.utils.context import Context
 
 from datarobot_provider.hooks.connections import JDBCDataSourceHook
-from datarobot_provider.hooks.datarobot import DataRobotHook
+from datarobot_provider.operators.base_datarobot_operator import BaseDatarobotOperator
+
 
 # Time in seconds after which dataset uploading is considered unsuccessful.
 DATAROBOT_MAX_WAIT_SEC = 3600
 
 
-class UploadDatasetOperator(BaseOperator):
+class UploadDatasetOperator(BaseDatarobotOperator):
     """
     Uploading local file to DataRobot AI Catalog and return Dataset ID.
     :param file_path: The path to the file.
@@ -39,35 +39,20 @@ class UploadDatasetOperator(BaseOperator):
     """
 
     # Specify the arguments that are allowed to parse with jinja templating
-    template_fields: Sequence[str] = [
-        "file_path",
-        "file_path_param",
-    ]
-    template_fields_renderers: dict[str, str] = {}
-    template_ext: Sequence[str] = ()
-    ui_color = "#f4a460"
+    template_fields: Sequence[str] = ["file_path", "file_path_param"]
 
     def __init__(
         self,
         *,
         file_path: Optional[str] = None,
         file_path_param: str = "dataset_file_path",
-        datarobot_conn_id: str = "datarobot_default",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.file_path = file_path
         self.file_path_param = file_path_param
-        self.datarobot_conn_id = datarobot_conn_id
-        if kwargs.get("xcom_push") is not None:
-            raise AirflowException(
-                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
-            )
 
     def execute(self, context: Context) -> str:
-        # Initialize DataRobot client
-        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
-
         # Upload Dataset to AI Catalog
         self.log.info("Upload Dataset to AI Catalog")
         if self.file_path is None:
@@ -82,7 +67,7 @@ class UploadDatasetOperator(BaseOperator):
         return ai_catalog_dataset.id
 
 
-class UpdateDatasetFromFileOperator(BaseOperator):
+class UpdateDatasetFromFileOperator(BaseDatarobotOperator):
     """
     Operator that creates a new Dataset version from a file.
     Returns when the new dataset version has been successfully uploaded.
@@ -108,9 +93,6 @@ class UpdateDatasetFromFileOperator(BaseOperator):
         "file_path",
         "file_path_param",
     ]
-    template_fields_renderers: dict[str, str] = {}
-    template_ext: Sequence[str] = ()
-    ui_color = "#f4a460"
 
     def __init__(
         self,
@@ -119,7 +101,6 @@ class UpdateDatasetFromFileOperator(BaseOperator):
         dataset_id_param: str = "training_dataset_id",
         file_path: Optional[str] = None,
         file_path_param: str = "dataset_file_path",
-        datarobot_conn_id: str = "datarobot_default",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -127,16 +108,8 @@ class UpdateDatasetFromFileOperator(BaseOperator):
         self.dataset_id_param = dataset_id_param
         self.file_path = file_path
         self.file_path_param = file_path_param
-        self.datarobot_conn_id = datarobot_conn_id
-        if kwargs.get("xcom_push") is not None:
-            raise AirflowException(
-                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
-            )
 
     def execute(self, context: Context) -> str:
-        # Initialize DataRobot client
-        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
-
         # If dataset_id not provided in constructor, then using dataset_id_param from json config
         dataset_id = (
             self.dataset_id
@@ -164,7 +137,7 @@ class UpdateDatasetFromFileOperator(BaseOperator):
         return ai_catalog_dataset.version_id
 
 
-class CreateDatasetFromDataStoreOperator(BaseOperator):
+class CreateDatasetFromDataStoreOperator(BaseDatarobotOperator):
     """
     Loading dataset from JDBC Connection to DataRobot AI Catalog and return Dataset ID.
 
@@ -176,27 +149,8 @@ class CreateDatasetFromDataStoreOperator(BaseOperator):
 
     # Specify the arguments that are allowed to parse with jinja templating
     template_fields: Sequence[str] = []
-    template_fields_renderers: dict[str, str] = {}
-    template_ext: Sequence[str] = ()
-    ui_color = "#f4a460"
-
-    def __init__(
-        self,
-        *,
-        datarobot_conn_id: str = "datarobot_default",
-        **kwargs: Any,
-    ) -> None:
-        super().__init__(**kwargs)
-        self.datarobot_conn_id = datarobot_conn_id
-        if kwargs.get("xcom_push") is not None:
-            raise AirflowException(
-                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
-            )
 
     def execute(self, context: Context) -> str:
-        # Initialize DataRobot client
-        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
-
         # Fetch stored JDBC Connection with credentials
         _, credential_data, data_store = JDBCDataSourceHook(
             datarobot_credentials_conn_id=context["params"]["datarobot_jdbc_connection"]
@@ -251,7 +205,7 @@ class CreateDatasetFromDataStoreOperator(BaseOperator):
         return ai_catalog_dataset.id
 
 
-class CreateDatasetFromRecipeOperator(BaseOperator):
+class CreateDatasetFromRecipeOperator(BaseDatarobotOperator):
     """Create a dataset based on a wrangling recipe.
     The dataset can be dynamic or a snapshot depending on the mandatory *do_snapshot* parameter.
     The dataset is added into the Use Case if use_case_id is specified
@@ -276,12 +230,10 @@ class CreateDatasetFromRecipeOperator(BaseOperator):
     """
 
     template_fields = ["recipe_id"]
-    ui_color = "#f4a460"
 
     def __init__(
         self,
         *,
-        datarobot_conn_id: str = "datarobot_default",
         recipe_id: str,
         do_snapshot: bool,
         dataset_name_param: str = "dataset_name",
@@ -291,7 +243,6 @@ class CreateDatasetFromRecipeOperator(BaseOperator):
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
-        self.datarobot_conn_id = datarobot_conn_id
         self.recipe_id = recipe_id
         self.do_snapshot = do_snapshot
 
@@ -299,11 +250,6 @@ class CreateDatasetFromRecipeOperator(BaseOperator):
         self.materialization_catalog_param = materialization_catalog_param
         self.materialization_schema_param = materialization_schema_param
         self.materialization_table_param = materialization_table_param
-
-        if kwargs.get("xcom_push") is not None:
-            raise AirflowException(
-                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
-            )
 
     def _get_materialization_destination(
         self, context: Context
@@ -327,9 +273,6 @@ class CreateDatasetFromRecipeOperator(BaseOperator):
         )
 
     def execute(self, context: Context) -> str:
-        # Initialize DataRobot client
-        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
-
         recipe = dr.models.Recipe.get(self.recipe_id)
         if recipe.dialect == dr.enums.DataWranglingDialect.SPARK and not self.do_snapshot:
             raise AirflowException(
@@ -365,7 +308,7 @@ class CreateDatasetFromRecipeOperator(BaseOperator):
         return dataset.id
 
 
-class CreateDatasetVersionOperator(BaseOperator):
+class CreateDatasetVersionOperator(BaseDatarobotOperator):
     """
     Creating new version of existing dataset in AI Catalog and return dataset version ID.
 
@@ -383,9 +326,6 @@ class CreateDatasetVersionOperator(BaseOperator):
 
     # Specify the arguments that are allowed to parse with jinja templating
     template_fields: Sequence[str] = ["dataset_id", "datasource_id", "credential_id"]
-    template_fields_renderers: dict[str, str] = {}
-    template_ext: Sequence[str] = ()
-    ui_color = "#f4a460"
 
     def __init__(
         self,
@@ -393,23 +333,14 @@ class CreateDatasetVersionOperator(BaseOperator):
         dataset_id: str,
         datasource_id: str,
         credential_id: str,
-        datarobot_conn_id: str = "datarobot_default",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.dataset_id = dataset_id
         self.datasource_id = datasource_id
         self.credential_id = credential_id
-        self.datarobot_conn_id = datarobot_conn_id
-        if kwargs.get("xcom_push") is not None:
-            raise AirflowException(
-                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
-            )
 
     def execute(self, context: Context) -> str:
-        # Initialize DataRobot client
-        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
-
         self.log.debug(
             f"Creation new version of dataset: dataset_id={self.dataset_id}, "
             f"using datasource: datasource_id={self.datasource_id}, "
@@ -431,7 +362,7 @@ class CreateDatasetVersionOperator(BaseOperator):
         return ai_catalog_dataset.version_id
 
 
-class CreateOrUpdateDataSourceOperator(BaseOperator):
+class CreateOrUpdateDataSourceOperator(BaseDatarobotOperator):
     """
     Get an existing data source by name and update it if any of *table_schema*, *table_name*, *query* are specified.
     Create a new data source if there is no existing one with the specified name.
@@ -461,13 +392,11 @@ class CreateOrUpdateDataSourceOperator(BaseOperator):
         "table_schema",
         "query",
     ]
-    ui_color = "#f4a460"
 
     def __init__(
         self,
         *,
         data_store_id: str,
-        datarobot_conn_id: str = "datarobot_default",
         dataset_name: Optional[str] = "{{ params.get('dataset_name', '') }}",
         table_schema: Optional[str] = "{{ params.get('table_schema', '') }}",
         table_name: Optional[str] = "{{ params.get('table_name', '') }}",
@@ -476,21 +405,12 @@ class CreateOrUpdateDataSourceOperator(BaseOperator):
     ) -> None:
         super().__init__(**kwargs)
         self.data_store_id = data_store_id
-        self.datarobot_conn_id = datarobot_conn_id
         self.dataset_name = dataset_name
         self.table_schema = table_schema
         self.table_name = table_name
         self.query = query
 
-        if kwargs.get("xcom_push") is not None:
-            raise AirflowException(
-                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
-            )
-
     def execute(self, context: Context) -> Optional[str]:
-        # Initialize DataRobot client
-        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
-
         self.log.debug(f"Trying to get existing DataStore by data_store_id={self.data_store_id}")
         data_store = dr.DataStore.get(data_store_id=self.data_store_id)
         self.log.debug(f"Found existing DataStore: {data_store.canonical_name}, id={data_store.id}")
@@ -557,7 +477,7 @@ class CreateOrUpdateDataSourceOperator(BaseOperator):
         return "-".join(parts)
 
 
-class CreateWranglingRecipeOperator(BaseOperator):
+class CreateWranglingRecipeOperator(BaseDatarobotOperator):
     """Create a Wrangling Recipe
 
     :param datarobot_conn_id: Connection ID, defaults to `datarobot_default`
@@ -598,12 +518,10 @@ class CreateWranglingRecipeOperator(BaseOperator):
         "downsampling_directive": "string",
         "downsampling_arguments": "json",
     }
-    ui_color = "#f4a460"
 
     def __init__(
         self,
         *,
-        datarobot_conn_id: str = "datarobot_default",
         use_case_id: str = '{{ params.get("use_case_id", "") }}',
         dataset_id: Optional[str] = None,
         data_store_id: Optional[str] = None,
@@ -618,7 +536,6 @@ class CreateWranglingRecipeOperator(BaseOperator):
         **kwargs,
     ):
         super().__init__(**kwargs)
-        self.datarobot_conn_id = datarobot_conn_id
         self.use_case_id = use_case_id
         self.dataset_id = dataset_id
         self.data_store_id = data_store_id
@@ -631,15 +548,7 @@ class CreateWranglingRecipeOperator(BaseOperator):
         self.downsampling_directive = downsampling_directive
         self.downsampling_arguments = downsampling_arguments
 
-        if kwargs.get("xcom_push") is not None:
-            raise AirflowException(
-                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
-            )
-
-    def execute(self, context: Context) -> str:
-        # Initialize DataRobot client
-        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
-
+    def validate(self):
         if not self.use_case_id:
             raise AirflowException(
                 "*use_case_id* is a mandatory parameter. "
@@ -651,6 +560,7 @@ class CreateWranglingRecipeOperator(BaseOperator):
                 "You have to specify either dataset_id or data_store_id. Not both."
             )
 
+    def execute(self, context: Context) -> str:
         use_case = dr.UseCase.get(self.use_case_id)
 
         if self.dataset_id:

--- a/datarobot_provider/operators/autopilot.py
+++ b/datarobot_provider/operators/autopilot.py
@@ -11,15 +11,15 @@ from typing import Optional
 
 import datarobot as dr
 from airflow.exceptions import AirflowException
-from airflow.models import BaseOperator
 from airflow.utils.context import Context
 
 from datarobot_provider.hooks.datarobot import DataRobotHook
+from datarobot_provider.operators.base_datarobot_operator import BaseDatarobotOperator
 
 DATAROBOT_MAX_WAIT = 600
 
 
-class StartAutopilotOperator(BaseOperator):
+class StartAutopilotOperator(BaseDatarobotOperator):
     """
     Triggers DataRobot Autopilot to train set of models.
 
@@ -46,9 +46,6 @@ class StartAutopilotOperator(BaseOperator):
         "relationships_configuration_id",
         "segmentation_task_id",
     ]
-    template_fields_renderers: dict[str, str] = {}
-    template_ext: Sequence[str] = ()
-    ui_color = "#f4a460"
 
     def __init__(
         self,
@@ -58,7 +55,6 @@ class StartAutopilotOperator(BaseOperator):
         relationships_configuration_id: Optional[str] = None,
         segmentation_task_id: Optional[str] = None,
         max_wait_sec: int = DATAROBOT_MAX_WAIT,
-        datarobot_conn_id: str = "datarobot_default",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -67,16 +63,8 @@ class StartAutopilotOperator(BaseOperator):
         self.relationships_configuration_id = relationships_configuration_id
         self.segmentation_task_id = segmentation_task_id
         self.max_wait_sec = max_wait_sec
-        self.datarobot_conn_id = datarobot_conn_id
-
-        if kwargs.get("xcom_push") is not None:
-            raise AirflowException(
-                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
-            )
 
     def execute(self, context: Context) -> None:
-        # Initialize DataRobot client
-        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
         # Train models
         project = dr.Project.get(self.project_id)
         if project.target:

--- a/datarobot_provider/operators/autopilot.py
+++ b/datarobot_provider/operators/autopilot.py
@@ -10,10 +10,8 @@ from typing import Any
 from typing import Optional
 
 import datarobot as dr
-from airflow.exceptions import AirflowException
 from airflow.utils.context import Context
 
-from datarobot_provider.hooks.datarobot import DataRobotHook
 from datarobot_provider.operators.base_datarobot_operator import BaseDatarobotOperator
 
 DATAROBOT_MAX_WAIT = 600

--- a/datarobot_provider/operators/base_datarobot_operator.py
+++ b/datarobot_provider/operators/base_datarobot_operator.py
@@ -6,7 +6,8 @@
 #
 # Released under the terms of DataRobot Tool and Utility Agreement.
 
-from typing import Optional, Any
+from typing import Any
+from typing import Optional
 
 import datarobot as dr
 from airflow.exceptions import AirflowException
@@ -33,14 +34,17 @@ class BaseDatarobotOperator(BaseOperator):
         self.validate()
 
     def check_dr_client_version(self):
-        if self.requires_early_access and not hasattr(dr, '_experimental'):
-            package_to_install = 'datarobot-early-access'
+        """Specific operators may require *datarobot-early-access*
+        or a specific *datarobot* client version.
+        Declare it with *requires_early_access* and/or *min_version* fields in your operator."""
+        if self.requires_early_access and not hasattr(dr, "_experimental"):
+            package_to_install = "datarobot-early-access"
             if self.min_version:
-                package_to_install = f'{package_to_install}>={self.min_version}'
+                package_to_install = f"{package_to_install}>={self.min_version}"
 
             raise AirflowException(
-                f'{self.__class__.__name__} requires datarobot-early-access package to run. '
-                f'Please install it with: pip install {package_to_install}'
+                f"{self.__class__.__name__} requires datarobot-early-access package to run. "
+                f"Please install it with: pip install {package_to_install}"
             )
 
         if self.min_version and Version(dr.__version__) < Version(self.min_version):

--- a/datarobot_provider/operators/base_datarobot_operator.py
+++ b/datarobot_provider/operators/base_datarobot_operator.py
@@ -11,6 +11,7 @@ from typing import Optional
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
+from airflow.utils.context import Context
 
 from datarobot_provider.hooks.datarobot import DataRobotHook
 
@@ -22,7 +23,7 @@ class BaseDatarobotOperator(BaseOperator):
     min_version: Optional[str] = None
     requires_early_access = False
 
-    def pre_execute(self, context: Any):
+    def pre_execute(self, context: Context):
         super().pre_execute(context)
 
         self.dr_hook = DataRobotHook(datarobot_conn_id=self.datarobot_conn_id)

--- a/datarobot_provider/operators/base_datarobot_operator.py
+++ b/datarobot_provider/operators/base_datarobot_operator.py
@@ -1,3 +1,11 @@
+# Copyright 2025 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+
 from typing import Optional, Any
 
 import datarobot as dr
@@ -8,7 +16,7 @@ from packaging.version import Version
 from datarobot_provider.hooks.datarobot import DataRobotHook
 
 
-class BaseDataRobotOperator(BaseOperator):
+class BaseDatarobotOperator(BaseOperator):
     ui_color = "#f4a460"
 
     dr_hook: DataRobotHook

--- a/datarobot_provider/operators/base_datarobot_operator.py
+++ b/datarobot_provider/operators/base_datarobot_operator.py
@@ -9,10 +9,8 @@
 from typing import Any
 from typing import Optional
 
-import datarobot as dr
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
-from packaging.version import Version
 
 from datarobot_provider.hooks.datarobot import DataRobotHook
 
@@ -27,31 +25,10 @@ class BaseDatarobotOperator(BaseOperator):
     def pre_execute(self, context: Any):
         super().pre_execute(context)
 
-        self.check_dr_client_version()
         self.dr_hook = DataRobotHook(datarobot_conn_id=self.datarobot_conn_id)
         self.dr_hook.run()
 
         self.validate()
-
-    def check_dr_client_version(self):
-        """Specific operators may require *datarobot-early-access*
-        or a specific *datarobot* client version.
-        Declare it with *requires_early_access* and/or *min_version* fields in your operator."""
-        if self.requires_early_access and not hasattr(dr, "_experimental"):
-            package_to_install = "datarobot-early-access"
-            if self.min_version:
-                package_to_install = f"{package_to_install}>={self.min_version}"
-
-            raise AirflowException(
-                f"{self.__class__.__name__} requires datarobot-early-access package to run. "
-                f"Please install it with: pip install {package_to_install}"
-            )
-
-        if self.min_version and Version(dr.__version__) < Version(self.min_version):
-            raise AirflowException(
-                f"{self.__class__.__name__} requires datarobot>={self.min_version} "
-                f"Please install it with: pip install datarobot>={self.min_version}"
-            )
 
     def validate(self):
         """Implement your validation of rendered operator fields here."""

--- a/datarobot_provider/operators/base_datarobot_operator.py
+++ b/datarobot_provider/operators/base_datarobot_operator.py
@@ -1,0 +1,53 @@
+from typing import Optional, Any
+
+import datarobot as dr
+from airflow.exceptions import AirflowException
+from airflow.models import BaseOperator
+from packaging.version import Version
+
+from datarobot_provider.hooks.datarobot import DataRobotHook
+
+
+class BaseDataRobotOperator(BaseOperator):
+    ui_color = "#f4a460"
+
+    dr_hook: DataRobotHook
+    min_version: Optional[str] = None
+    requires_early_access = False
+
+    def pre_execute(self, context: Any):
+        super().pre_execute(context)
+
+        self.check_dr_client_version()
+        self.dr_hook = DataRobotHook(datarobot_conn_id=self.datarobot_conn_id)
+        self.dr_hook.run()
+
+        self.validate()
+
+    def check_dr_client_version(self):
+        if self.requires_early_access and not hasattr(dr, '_experimental'):
+            package_to_install = 'datarobot-early-access'
+            if self.min_version:
+                package_to_install = f'{package_to_install}>={self.min_version}'
+
+            raise AirflowException(
+                f'{self.__class__.__name__} requires datarobot-early-access package to run. '
+                f'Please install it with: pip install {package_to_install}'
+            )
+
+        if self.min_version and Version(dr.__version__) < Version(self.min_version):
+            raise AirflowException(
+                f"{self.__class__.__name__} requires datarobot>={self.min_version} "
+                f"Please install it with: pip install datarobot>={self.min_version}"
+            )
+
+    def validate(self):
+        """Implement your validation of rendered operator fields here."""
+
+    def __init__(self, *, datarobot_conn_id: str = "datarobot_default", **kwargs: Any):
+        super().__init__(**kwargs)
+        self.datarobot_conn_id = datarobot_conn_id
+        if kwargs.get("xcom_push") is not None:
+            raise AirflowException(
+                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
+            )

--- a/datarobot_provider/operators/bias_and_fairness.py
+++ b/datarobot_provider/operators/bias_and_fairness.py
@@ -11,17 +11,15 @@ from typing import Any
 from typing import Optional
 
 import datarobot as dr
-from airflow.exceptions import AirflowException
-from airflow.models import BaseOperator
 from airflow.utils.context import Context
 
-from datarobot_provider.hooks.datarobot import DataRobotHook
+from datarobot_provider.operators.base_datarobot_operator import BaseDatarobotOperator
 
 if TYPE_CHECKING:
     from datarobot.models.deployment.deployment import BiasAndFairnessSettings
 
 
-class GetBiasAndFairnessSettingsOperator(BaseOperator):
+class GetBiasAndFairnessSettingsOperator(BaseDatarobotOperator):
     """
     Get Bias And Fairness settings for deployment.
 
@@ -33,29 +31,17 @@ class GetBiasAndFairnessSettingsOperator(BaseOperator):
 
     # Specify the arguments that are allowed to parse with jinja templating
     template_fields: Sequence[str] = ["deployment_id"]
-    template_fields_renderers: dict[str, str] = {}
-    template_ext: Sequence[str] = ()
-    ui_color = "#f4a460"
 
     def __init__(
         self,
         *,
         deployment_id: str,
-        datarobot_conn_id: str = "datarobot_default",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.deployment_id = deployment_id
-        self.datarobot_conn_id = datarobot_conn_id
-        if kwargs.get("xcom_push") is not None:
-            raise AirflowException(
-                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
-            )
 
     def execute(self, context: Context) -> Optional["BiasAndFairnessSettings"]:
-        # Initialize DataRobot client
-        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
-
         self.log.info(f"Get Deployment for deployment_id={self.deployment_id}")
         deployment = dr.Deployment.get(deployment_id=self.deployment_id)
 
@@ -64,7 +50,7 @@ class GetBiasAndFairnessSettingsOperator(BaseOperator):
         return bias_and_fairness_settings
 
 
-class UpdateBiasAndFairnessSettingsOperator(BaseOperator):
+class UpdateBiasAndFairnessSettingsOperator(BaseDatarobotOperator):
     """
     Update Bias And Fairness settings for deployment.
 
@@ -76,29 +62,17 @@ class UpdateBiasAndFairnessSettingsOperator(BaseOperator):
 
     # Specify the arguments that are allowed to parse with jinja templating
     template_fields: Sequence[str] = ["deployment_id"]
-    template_fields_renderers: dict[str, str] = {}
-    template_ext: Sequence[str] = ()
-    ui_color = "#f4a460"
 
     def __init__(
         self,
         *,
         deployment_id: str,
-        datarobot_conn_id: str = "datarobot_default",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.deployment_id = deployment_id
-        self.datarobot_conn_id = datarobot_conn_id
-        if kwargs.get("xcom_push") is not None:
-            raise AirflowException(
-                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
-            )
 
     def execute(self, context: Context) -> None:
-        # Initialize DataRobot client
-        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
-
         self.log.info(f"Getting Deployment for deployment_id={self.deployment_id}")
         deployment = dr.Deployment.get(deployment_id=self.deployment_id)
 

--- a/datarobot_provider/operators/connections.py
+++ b/datarobot_provider/operators/connections.py
@@ -14,7 +14,6 @@ from airflow.exceptions import AirflowNotFoundException
 from airflow.utils.context import Context
 
 from datarobot_provider.hooks.connections import JDBCDataSourceHook
-from datarobot_provider.hooks.datarobot import DataRobotHook
 from datarobot_provider.operators.base_datarobot_operator import BaseDatarobotOperator
 
 

--- a/datarobot_provider/operators/credentials.py
+++ b/datarobot_provider/operators/credentials.py
@@ -5,20 +5,17 @@
 # This is proprietary source code of DataRobot, Inc. and its affiliates.
 #
 # Released under the terms of DataRobot Tool and Utility Agreement.
-from collections.abc import Sequence
 from typing import Any
 from typing import Optional
 
-from airflow.exceptions import AirflowException
-from airflow.models import BaseOperator
 from airflow.utils.context import Context
 from datarobot import Credential
 
 from datarobot_provider.hooks.credentials import CredentialsBaseHook
-from datarobot_provider.hooks.datarobot import DataRobotHook
+from datarobot_provider.operators.base_datarobot_operator import BaseDatarobotOperator
 
 
-class GetOrCreateCredentialOperator(BaseOperator):
+class GetOrCreateCredentialOperator(BaseDatarobotOperator):
     """
     Fetching credentials by Credential name and return Credentials ID.
 
@@ -28,30 +25,16 @@ class GetOrCreateCredentialOperator(BaseOperator):
     :rtype: str
     """
 
-    # Specify the arguments that are allowed to parse with jinja templating
-    template_fields: Sequence[str] = []
-    template_fields_renderers: dict[str, str] = {}
-    template_ext: Sequence[str] = ()
-    ui_color = "#f4a460"
-
     def __init__(
         self,
         *,
         credentials_param_name: str = "datarobot_credentials_name",
-        datarobot_conn_id: str = "datarobot_default",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
-        self.datarobot_conn_id = datarobot_conn_id
         self.credentials_param_name = credentials_param_name
-        if kwargs.get("xcom_push") is not None:
-            raise AirflowException(
-                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
-            )
 
     def execute(self, context: Context) -> Optional[str]:
-        # Initialize DataRobot client
-        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
         credential_name = context["params"][self.credentials_param_name]
         # Trying to find a credential associated with provided credential name:
         for credential in Credential.list():

--- a/datarobot_provider/operators/custom_models.py
+++ b/datarobot_provider/operators/custom_models.py
@@ -298,13 +298,7 @@ class CreateCustomModelVersionOperator(BaseDatarobotOperator):
         self.create_from_previous = create_from_previous
         self.max_wait_sec = max_wait_sec
 
-    def execute(self, context: Context) -> str:
-        folder_path = (
-            context["params"].get("custom_model_folder", None)
-            if self.custom_model_folder is None
-            else self.custom_model_folder
-        )
-
+    def validate(self):
         if self.custom_model_id is None:
             raise ValueError(
                 "custom_model_id is required attribute for CreateCustomModelVersionOperator"
@@ -314,6 +308,13 @@ class CreateCustomModelVersionOperator(BaseDatarobotOperator):
             raise ValueError(
                 "base_environment_id is required attribute for CreateCustomModelVersionOperator"
             )
+
+    def execute(self, context: Context) -> str:
+        folder_path = (
+            context["params"].get("custom_model_folder", None)
+            if self.custom_model_folder is None
+            else self.custom_model_folder
+        )
 
         if self.create_from_previous:
             custom_model_version = dr.CustomModelVersion.create_from_previous(

--- a/datarobot_provider/operators/custom_models.py
+++ b/datarobot_provider/operators/custom_models.py
@@ -10,17 +10,15 @@ from typing import Any
 from typing import Optional
 
 import datarobot as dr
-from airflow.exceptions import AirflowException
-from airflow.models import BaseOperator
 from airflow.utils.context import Context
 from datarobot.models.execution_environment import RequiredMetadataKey
 
-from datarobot_provider.hooks.datarobot import DataRobotHook
+from datarobot_provider.operators.base_datarobot_operator import BaseDatarobotOperator
 
 DEFAULT_MAX_WAIT_SEC = 3600  # 1 hour timeout by default
 
 
-class CreateExecutionEnvironmentOperator(BaseOperator):
+class CreateExecutionEnvironmentOperator(BaseDatarobotOperator):
     """
     Create an execution environment.
     :param name: execution environment name
@@ -40,9 +38,6 @@ class CreateExecutionEnvironmentOperator(BaseOperator):
         "description",
         "programming_language",
     ]
-    template_fields_renderers: dict[str, str] = {}
-    template_ext: Sequence[str] = ()
-    ui_color = "#f4a460"
 
     def __init__(
         self,
@@ -50,23 +45,14 @@ class CreateExecutionEnvironmentOperator(BaseOperator):
         name: Optional[str] = None,
         description: Optional[str] = None,
         programming_language: Optional[str] = None,
-        datarobot_conn_id: str = "datarobot_default",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.name = name
         self.description = description
         self.programming_language = programming_language
-        self.datarobot_conn_id = datarobot_conn_id
-        if kwargs.get("xcom_push") is not None:
-            raise AirflowException(
-                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
-            )
 
     def execute(self, context: Context) -> str:
-        # Initialize DataRobot client
-        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
-
         required_metadata_keys = context["params"].get("required_metadata_keys", None)
         metadata_keys = []
         if required_metadata_keys:
@@ -105,7 +91,7 @@ class CreateExecutionEnvironmentOperator(BaseOperator):
         return execution_environment.id
 
 
-class CreateExecutionEnvironmentVersionOperator(BaseOperator):
+class CreateExecutionEnvironmentVersionOperator(BaseDatarobotOperator):
     """
     Create an execution environment version.
     :param execution_environment_id: the id of the execution environment
@@ -130,9 +116,6 @@ class CreateExecutionEnvironmentVersionOperator(BaseOperator):
         "environment_version_label",
         "environment_version_description",
     ]
-    template_fields_renderers: dict[str, str] = {}
-    template_ext: Sequence[str] = ()
-    ui_color = "#f4a460"
 
     def __init__(
         self,
@@ -142,7 +125,6 @@ class CreateExecutionEnvironmentVersionOperator(BaseOperator):
         environment_version_label: Optional[str] = None,
         environment_version_description: Optional[str] = None,
         max_wait_sec: int = DEFAULT_MAX_WAIT_SEC,
-        datarobot_conn_id: str = "datarobot_default",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -151,16 +133,8 @@ class CreateExecutionEnvironmentVersionOperator(BaseOperator):
         self.environment_version_label = environment_version_label
         self.environment_version_description = environment_version_description
         self.max_wait_sec = max_wait_sec
-        self.datarobot_conn_id = datarobot_conn_id
-        if kwargs.get("xcom_push") is not None:
-            raise AirflowException(
-                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
-            )
 
     def execute(self, context: Context) -> str:
-        # Initialize DataRobot client
-        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
-
         docker_context_path = (
             context["params"].get("docker_context_path", None)
             if self.docker_context_path is None
@@ -192,7 +166,7 @@ class CreateExecutionEnvironmentVersionOperator(BaseOperator):
         return environment_version.id
 
 
-class CreateCustomInferenceModelOperator(BaseOperator):
+class CreateCustomInferenceModelOperator(BaseDatarobotOperator):
     """
     Create a custom inference model.
     :param name: Name of the custom model.
@@ -208,31 +182,19 @@ class CreateCustomInferenceModelOperator(BaseOperator):
         "name",
         "description",
     ]
-    template_fields_renderers: dict[str, str] = {}
-    template_ext: Sequence[str] = ()
-    ui_color = "#f4a460"
 
     def __init__(
         self,
         *,
         name: Optional[str] = None,
         description: Optional[str] = None,
-        datarobot_conn_id: str = "datarobot_default",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.name = name
         self.description = description
-        self.datarobot_conn_id = datarobot_conn_id
-        if kwargs.get("xcom_push") is not None:
-            raise AirflowException(
-                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
-            )
 
     def execute(self, context: Context) -> str:
-        # Initialize DataRobot client
-        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
-
         custom_model_name = (
             context["params"].get("custom_model_name", None) if self.name is None else self.name
         )
@@ -279,7 +241,7 @@ class CreateCustomInferenceModelOperator(BaseOperator):
         return custom_model.id
 
 
-class CreateCustomModelVersionOperator(BaseOperator):
+class CreateCustomModelVersionOperator(BaseDatarobotOperator):
     """
     Create a custom model version.
 
@@ -314,9 +276,6 @@ class CreateCustomModelVersionOperator(BaseOperator):
         "custom_model_folder",
         "create_from_previous",
     ]
-    template_fields_renderers: dict[str, str] = {}
-    template_ext: Sequence[str] = ()
-    ui_color = "#f4a460"
 
     def __init__(
         self,
@@ -328,7 +287,6 @@ class CreateCustomModelVersionOperator(BaseOperator):
         custom_model_folder: Optional[str] = None,
         create_from_previous: bool = False,
         max_wait_sec: int = DEFAULT_MAX_WAIT_SEC,
-        datarobot_conn_id: str = "datarobot_default",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -339,16 +297,8 @@ class CreateCustomModelVersionOperator(BaseOperator):
         self.custom_model_folder = custom_model_folder
         self.create_from_previous = create_from_previous
         self.max_wait_sec = max_wait_sec
-        self.datarobot_conn_id = datarobot_conn_id
-        if kwargs.get("xcom_push") is not None:
-            raise AirflowException(
-                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
-            )
 
     def execute(self, context: Context) -> str:
-        # Initialize DataRobot client
-        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
-
         folder_path = (
             context["params"].get("custom_model_folder", None)
             if self.custom_model_folder is None
@@ -412,7 +362,7 @@ class CreateCustomModelVersionOperator(BaseOperator):
         return custom_model_version.id
 
 
-class CustomModelTestOperator(BaseOperator):
+class CustomModelTestOperator(BaseDatarobotOperator):
     """
     Create and start a custom model test.
 
@@ -431,9 +381,6 @@ class CustomModelTestOperator(BaseOperator):
 
     # Specify the arguments that are allowed to parse with jinja templating
     template_fields: Sequence[str] = ["custom_model_id", "custom_model_version_id", "dataset_id"]
-    template_fields_renderers: dict[str, str] = {}
-    template_ext: Sequence[str] = ()
-    ui_color = "#f4a460"
 
     def __init__(
         self,
@@ -442,7 +389,6 @@ class CustomModelTestOperator(BaseOperator):
         custom_model_version_id: str,
         dataset_id: Optional[str] = None,
         max_wait_sec: int = DEFAULT_MAX_WAIT_SEC,
-        datarobot_conn_id: str = "datarobot_default",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -450,22 +396,15 @@ class CustomModelTestOperator(BaseOperator):
         self.custom_model_version_id = custom_model_version_id
         self.dataset_id = dataset_id
         self.max_wait_sec = max_wait_sec
-        self.datarobot_conn_id = datarobot_conn_id
-        if kwargs.get("xcom_push") is not None:
-            raise AirflowException(
-                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
-            )
 
-    def execute(self, context: Context) -> str:
-        # Initialize DataRobot client
-        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
-
+    def validate(self):
         if self.custom_model_id is None:
             raise ValueError("custom_model_id is required attribute")
 
         if self.custom_model_version_id is None:
             raise ValueError("custom_model_version_id is required attribute")
 
+    def execute(self, context: Context) -> str:
         # Perform custom model tests
         custom_model_test = dr.CustomModelTest.create(
             custom_model_id=self.custom_model_id,
@@ -482,7 +421,7 @@ class CustomModelTestOperator(BaseOperator):
         return custom_model_test.id
 
 
-class GetCustomModelTestOverallStatusOperator(BaseOperator):
+class GetCustomModelTestOverallStatusOperator(BaseDatarobotOperator):
     """
     Get a custom model testing overall status.
 
@@ -494,32 +433,21 @@ class GetCustomModelTestOverallStatusOperator(BaseOperator):
 
     # Specify the arguments that are allowed to parse with jinja templating
     template_fields: Sequence[str] = ["custom_model_test_id"]
-    template_fields_renderers: dict[str, str] = {}
-    template_ext: Sequence[str] = ()
-    ui_color = "#f4a460"
 
     def __init__(
         self,
         *,
         custom_model_test_id: str,
-        datarobot_conn_id: str = "datarobot_default",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.custom_model_test_id = custom_model_test_id
-        self.datarobot_conn_id = datarobot_conn_id
-        if kwargs.get("xcom_push") is not None:
-            raise AirflowException(
-                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
-            )
 
-    def execute(self, context: Context) -> str:
-        # Initialize DataRobot client
-        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
-
+    def validate(self):
         if self.custom_model_test_id is None:
             raise ValueError("custom_model_test_id is required attribute")
 
+    def execute(self, context: Context) -> str:
         custom_model_test = dr.CustomModelTest.get(custom_model_test_id=self.custom_model_test_id)
 
         self.log.info(f"Overall testing status: {custom_model_test.overall_status}")
@@ -527,7 +455,7 @@ class GetCustomModelTestOverallStatusOperator(BaseOperator):
         return custom_model_test.overall_status
 
 
-class CreateCustomModelDeploymentOperator(BaseOperator):
+class CreateCustomModelDeploymentOperator(BaseDatarobotOperator):
     """
     Create a deployment from a DataRobot custom model image.
 
@@ -556,9 +484,6 @@ class CreateCustomModelDeploymentOperator(BaseOperator):
         "deployment_name",
         "prediction_server_id",
     ]
-    template_fields_renderers: dict[str, str] = {}
-    template_ext: Sequence[str] = ()
-    ui_color = "#f4a460"
 
     def __init__(
         self,
@@ -569,7 +494,6 @@ class CreateCustomModelDeploymentOperator(BaseOperator):
         description: Optional[str] = None,
         importance: Optional[str] = None,
         max_wait_sec: int = DEFAULT_MAX_WAIT_SEC,
-        datarobot_conn_id: str = "datarobot_default",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -579,22 +503,15 @@ class CreateCustomModelDeploymentOperator(BaseOperator):
         self.description = description
         self.importance = importance
         self.max_wait_sec = max_wait_sec
-        self.datarobot_conn_id = datarobot_conn_id
-        if kwargs.get("xcom_push") is not None:
-            raise AirflowException(
-                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
-            )
 
-    def execute(self, context: Context) -> str:
-        # Initialize DataRobot client
-        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
-
+    def validate(self):
         if self.custom_model_version_id is None:
             raise ValueError("Invalid or missing `custom_model_version_id` value")
 
         if self.deployment_name is None:
             raise ValueError("Invalid or missing `deployment_name` value")
 
+    def execute(self, context: Context) -> str:
         deployment = dr.Deployment.create_from_custom_model_version(
             custom_model_version_id=self.custom_model_version_id,
             label=self.deployment_name,

--- a/datarobot_provider/operators/datarobot.py
+++ b/datarobot_provider/operators/datarobot.py
@@ -95,11 +95,17 @@ class CreateProjectOperator(BaseDatarobotOperator):
         self.dataset_id = dataset_id
         self.dataset_version_id = dataset_version_id
         self.credential_id = credential_id
+        self.use_case_id = use_case_id
         self.recipe_id = recipe_id
 
     def execute(self, context: Context) -> Optional[str]:
         # Create DataRobot project
         self.log.info("Creating DataRobot project")
+
+        use_case = None
+
+        if self.use_case_id:
+            use_case = dr.models.UseCase.get(self.use_case_id)
 
         if self.dataset_id is None and "training_data" in context["params"]:
             # training_data may be a pre-signed URL to a file on S3 or a path to a local file

--- a/datarobot_provider/operators/datarobot.py
+++ b/datarobot_provider/operators/datarobot.py
@@ -99,13 +99,13 @@ class CreateProjectOperator(BaseDatarobotOperator):
         self.recipe_id = recipe_id
 
     def execute(self, context: Context) -> Optional[str]:
-        # Create DataRobot project
-        self.log.info("Creating DataRobot project")
-
         use_case = None
 
         if self.use_case_id:
             use_case = dr.models.UseCase.get(self.use_case_id)
+
+        # Create DataRobot project
+        self.log.info("Creating DataRobot project")
 
         if self.dataset_id is None and "training_data" in context["params"]:
             # training_data may be a pre-signed URL to a file on S3 or a path to a local file

--- a/datarobot_provider/operators/datarobot.py
+++ b/datarobot_provider/operators/datarobot.py
@@ -8,64 +8,16 @@
 from collections.abc import Sequence
 from typing import Any
 from typing import Optional
-from packaging.version import Version
 
 import datarobot as dr
-from airflow.exceptions import AirflowException
 from airflow.exceptions import AirflowFailException
-from airflow.models import BaseOperator
 from airflow.utils.context import Context
 
-from datarobot_provider.hooks.datarobot import DataRobotHook
+from datarobot_provider.operators.base_datarobot_operator import BaseDataRobotOperator
 
 DATAROBOT_MAX_WAIT = 3600
 DATAROBOT_AUTOPILOT_TIMEOUT = 86400
 DATETIME_FORMAT = "%Y-%m-%d %H:%M:%s"
-
-
-class BaseDataRobotOperator(BaseOperator):
-    ui_color = "#f4a460"
-
-    dr_hook: DataRobotHook
-    min_version: Optional[str] = None
-    requires_early_access = False
-
-    def pre_execute(self, context: Any):
-        super().pre_execute(context)
-
-        self.check_dr_client_version()
-        self.dr_hook = DataRobotHook(datarobot_conn_id=self.datarobot_conn_id)
-        self.dr_hook.run()
-
-        self.validate()
-
-    def check_dr_client_version(self):
-        if self.requires_early_access and not hasattr(dr, '_experimental'):
-            package_to_install = 'datarobot-early-access'
-            if self.min_version:
-                package_to_install = f'{package_to_install}>={self.min_version}'
-
-            raise AirflowException(
-                f'{self.__class__.__name__} requires datarobot-early-access package to run. '
-                f'Please install it with: pip install {package_to_install}'
-            )
-
-        if self.min_version and Version(dr.__version__) < Version(self.min_version):
-            raise AirflowException(
-                f"{self.__class__.__name__} requires datarobot>={self.min_version} "
-                f"Please install it with: pip install datarobot>={self.min_version}"
-            )
-
-    def validate(self):
-        """Implement your validation of rendered operator fields here."""
-
-    def __init__(self, *, datarobot_conn_id: str = "datarobot_default", **kwargs: Any):
-        super().__init__(**kwargs)
-        self.datarobot_conn_id = datarobot_conn_id
-        if kwargs.get("xcom_push") is not None:
-            raise AirflowException(
-                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
-            )
 
 
 class CreateUseCaseOperator(BaseDataRobotOperator):

--- a/datarobot_provider/operators/datarobot.py
+++ b/datarobot_provider/operators/datarobot.py
@@ -243,6 +243,7 @@ class DeployRecommendedModelOperator(BaseDatarobotOperator, DeployModelMixin):
 
     # Specify the arguments that are allowed to parse with jinja templating
     template_fields: Sequence[str] = ["project_id"]
+
     def __init__(
         self,
         *,

--- a/datarobot_provider/operators/datarobot.py
+++ b/datarobot_provider/operators/datarobot.py
@@ -13,14 +13,14 @@ import datarobot as dr
 from airflow.exceptions import AirflowFailException
 from airflow.utils.context import Context
 
-from datarobot_provider.operators.base_datarobot_operator import BaseDataRobotOperator
+from datarobot_provider.operators.base_datarobot_operator import BaseDatarobotOperator
 
 DATAROBOT_MAX_WAIT = 3600
 DATAROBOT_AUTOPILOT_TIMEOUT = 86400
 DATETIME_FORMAT = "%Y-%m-%d %H:%M:%s"
 
 
-class CreateUseCaseOperator(BaseDataRobotOperator):
+class CreateUseCaseOperator(BaseDatarobotOperator):
     """
     Creates a DataRobot Use Case.
 
@@ -58,7 +58,7 @@ class CreateUseCaseOperator(BaseDataRobotOperator):
         return use_case.id
 
 
-class CreateProjectOperator(BaseDataRobotOperator):
+class CreateProjectOperator(BaseDatarobotOperator):
     """
     Creates DataRobot project.
     :param dataset_id: DataRobot AI Catalog dataset ID
@@ -142,7 +142,7 @@ class CreateProjectOperator(BaseDataRobotOperator):
             )
 
 
-class TrainModelsOperator(BaseDataRobotOperator):
+class TrainModelsOperator(BaseDatarobotOperator):
     """
     Triggers DataRobot Autopilot to train models.
 
@@ -195,7 +195,7 @@ class DeployModelMixin:
         return deployment
 
 
-class DeployModelOperator(BaseDataRobotOperator, DeployModelMixin):
+class DeployModelOperator(BaseDatarobotOperator, DeployModelMixin):
     """
     Deploys the specified model to production.
 
@@ -229,7 +229,7 @@ class DeployModelOperator(BaseDataRobotOperator, DeployModelMixin):
         return deployment.id
 
 
-class DeployRecommendedModelOperator(BaseDataRobotOperator, DeployModelMixin):
+class DeployRecommendedModelOperator(BaseDatarobotOperator, DeployModelMixin):
     """
     Deploys a recommended model to production.
 
@@ -273,7 +273,7 @@ class DeployRecommendedModelOperator(BaseDataRobotOperator, DeployModelMixin):
         return deployment.id
 
 
-class ScorePredictionsOperator(BaseDataRobotOperator):
+class ScorePredictionsOperator(BaseDatarobotOperator):
     """
     Creates a batch prediction job in DataRobot, scores the data and saves prediction to the output.
     :param deployment_id: DataRobot deployment ID
@@ -372,7 +372,7 @@ class ScorePredictionsOperator(BaseDataRobotOperator):
         return job.id
 
 
-class GetTargetDriftOperator(BaseDataRobotOperator):
+class GetTargetDriftOperator(BaseDatarobotOperator):
     """
     Gets target drift measurements from a deployment.
 
@@ -404,7 +404,7 @@ class GetTargetDriftOperator(BaseDataRobotOperator):
         return _serialize_drift(drift)
 
 
-class GetFeatureDriftOperator(BaseDataRobotOperator):
+class GetFeatureDriftOperator(BaseDatarobotOperator):
     """
     Gets feature drift measurements from a deployment.
 

--- a/tests/unit/operators/test_custom_models.py
+++ b/tests/unit/operators/test_custom_models.py
@@ -233,7 +233,7 @@ def test_operator_create_custom_model_version_no_custom_model_id_op(mocker, cust
     )
 
     with pytest.raises(ValueError):
-        operator.execute(context={"params": custom_model_params})
+        operator.validate()
 
 
 def test_operator_create_custom_model_test_op(mocker, custom_model_params):
@@ -288,7 +288,7 @@ def test_operator_create_custom_model_test_no_custom_model_id_op():
     )
 
     with pytest.raises(ValueError):
-        operator.execute(context={"params": custom_model_params})
+        operator.validate()
 
 
 def test_operator_create_custom_model_test_no_custom_model_version_id_op():
@@ -306,7 +306,7 @@ def test_operator_create_custom_model_test_no_custom_model_version_id_op():
     )
 
     with pytest.raises(ValueError):
-        operator.execute(context={"params": custom_model_params})
+        operator.validate()
 
 
 def test_operator_create_custom_model_test_status_op(mocker, custom_model_params):


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Introduce a base class for all Datarobot operators. Apply it to operators modules from `a...` to `f...`. More updates to do in a subsequent PR.

## Rationale

There is quite a lot of repeatable codebase in the repo. Move it into the base class.