### PR TITLE
[MLDEV-1144] Add docs testing to main ci checks pipeline

### DIFF
--- a/.harness/cichecks.yaml
+++ b/.harness/cichecks.yaml
@@ -164,8 +164,5 @@ pipeline:
                       strategy:
                         matrix:
                           python_version:
-                            - "3.9"
-                            - "3.10"
-                            - "3.11"
                             - "3.12"
                           nodeName: <+matrix.python_version>

--- a/.harness/cichecks.yaml
+++ b/.harness/cichecks.yaml
@@ -147,8 +147,7 @@ pipeline:
                         command: |-
                           set -exuo pipefail
                           pip install apache-airflow
-                          pip install -r requirements.txt
-                          pip install airflow-provider-datarobot freezegun
+                          make req-dev
                           airflow db init
                           airflow db check
                           pytest -vv tests/unit/ --junit-xml=unit_test_report.xml

--- a/.harness/cichecks.yaml
+++ b/.harness/cichecks.yaml
@@ -136,8 +136,8 @@ pipeline:
                 steps:
                   - step:
                       type: Run
-                      name: run unit tests
-                      identifier: run_unit_tests
+                      name: run build docs test
+                      identifier: run_build_docs_tests
                       spec:
                         connectorRef: account.dockerhub_datarobot_read
                         image: python:<+matrix.python_version>

--- a/.harness/cichecks.yaml
+++ b/.harness/cichecks.yaml
@@ -96,12 +96,10 @@ pipeline:
                         shell: Bash
                         command: |-
                           set -exuo pipefail
-                          pip install apache-airflow
-                          pip install -r requirements.txt
-                          pip install airflow-provider-datarobot freezegun
+                          make req-dev
                           airflow db init
                           airflow db check
-                          pytest -vv tests/unit/ --junit-xml=unit_test_report.xml
+                          make test-harness
                         reports:
                           type: JUnit
                           spec:
@@ -146,11 +144,10 @@ pipeline:
                         shell: Bash
                         command: |-
                           set -exuo pipefail
-                          pip install apache-airflow
                           make req-dev
                           airflow db init
                           airflow db check
-                          pytest -vv tests/unit/ --junit-xml=unit_test_report.xml
+                          make test-docs-harness
                         reports:
                           type: JUnit
                           spec:

--- a/.harness/cichecks.yaml
+++ b/.harness/cichecks.yaml
@@ -119,3 +119,53 @@ pipeline:
                             - "3.11"
                             - "3.12"
                           nodeName: <+matrix.python_version>
+        - stage:
+            name: Docs tests
+            identifier: test_docs
+            description: ""
+            type: CI
+            spec:
+              cloneCodebase: true
+              infrastructure:
+                type: KubernetesDirect
+                spec:
+                  connectorRef: account.cigeneral
+                  namespace: harness-delegate-ng
+                  automountServiceAccountToken: true
+                  nodeSelector: {}
+                  os: Linux
+              execution:
+                steps:
+                  - step:
+                      type: Run
+                      name: run unit tests
+                      identifier: run_unit_tests
+                      spec:
+                        connectorRef: account.dockerhub_datarobot_read
+                        image: python:<+matrix.python_version>
+                        shell: Bash
+                        command: |-
+                          set -exuo pipefail
+                          pip install apache-airflow
+                          pip install -r requirements.txt
+                          pip install airflow-provider-datarobot freezegun
+                          airflow db init
+                          airflow db check
+                          pytest -vv tests/unit/ --junit-xml=unit_test_report.xml
+                        reports:
+                          type: JUnit
+                          spec:
+                            paths:
+                              - /harness/unit_test_report.xml
+                        resources:
+                          limits:
+                            memory: 1Gi
+                            cpu: "1.5"
+                      strategy:
+                        matrix:
+                          python_version:
+                            - "3.9"
+                            - "3.10"
+                            - "3.11"
+                            - "3.12"
+                          nodeName: <+matrix.python_version>

--- a/.harness/cichecks.yaml
+++ b/.harness/cichecks.yaml
@@ -14,7 +14,7 @@ pipeline:
     - parallel:
         - stage:
             name: Lint and MyPy
-            identifier: lint_and_mypy
+            identifier: lint
             description: ""
             type: CI
             spec:
@@ -68,7 +68,7 @@ pipeline:
                               make typecheck
         - stage:
             name: Unit tests
-            identifier: test_unit_tests
+            identifier: test_unit
             description: ""
             type: CI
             spec:

--- a/.harness/cichecks.yaml
+++ b/.harness/cichecks.yaml
@@ -14,10 +14,11 @@ pipeline:
     - parallel:
         - stage:
             name: Lint and MyPy
-            identifier: lint
+            identifier: lint_and_mypy
             description: ""
             type: CI
             spec:
+              cloneCodebase: true
               infrastructure:
                 type: KubernetesDirect
                 spec:
@@ -26,22 +27,20 @@ pipeline:
                   automountServiceAccountToken: true
                   nodeSelector: {}
                   os: Linux
-              cloneCodebase: true
               execution:
                 steps:
                   - parallel:
                       - step:
                           type: Run
                           name: lint check step
-                          identifier: run_lint
+                          identifier: run_lint_and_mypy
                           spec:
                             connectorRef: account.dockerhub_datarobot_read
                             image: python:3.12
                             shell: Bash
                             command: |-
                               set -exuo pipefail
-                              pip install -U pip
-                              pip install -r requirements.txt
+                              make req-dev
                               make lint
                       - step:
                           type: Run
@@ -53,8 +52,7 @@ pipeline:
                             shell: Bash
                             command: |-
                               set -exuo pipefail
-                              pip install -U pip
-                              pip install -r requirements.txt
+                              make req-dev
                               make format-no-fix
                       - step:
                           type: Run
@@ -66,12 +64,11 @@ pipeline:
                             shell: Bash
                             command: |-
                               set -exuo pipefail
-                              pip install -U pip
-                              pip install -r requirements.txt
+                              make req-dev
                               make typecheck
         - stage:
             name: Unit tests
-            identifier: test_unit
+            identifier: test_unit_tests
             description: ""
             type: CI
             spec:
@@ -118,8 +115,8 @@ pipeline:
                             - "3.12"
                           nodeName: <+matrix.python_version>
         - stage:
-            name: Docs tests
-            identifier: test_docs
+            name: Build docs tests
+            identifier: test_build_docs
             description: ""
             type: CI
             spec:
@@ -135,30 +132,28 @@ pipeline:
               execution:
                 steps:
                   - step:
+                      spec:
+                        connectorRef: account.dockerhub_datarobot_read
+                        image: python:3.12
+                        shell: Bash
+                        command: |-
+                          set -exuo pipefail
+                          pip install -U pip
+                          pip install -r requirements.txt
+                          make lint
+                  - step:
                       type: Run
                       name: run build docs test
                       identifier: run_build_docs_tests
                       spec:
                         connectorRef: account.dockerhub_datarobot_read
-                        image: python:<+matrix.python_version>
+                        image: python:3.12
                         shell: Bash
                         command: |-
                           set -exuo pipefail
                           make req-dev
-                          airflow db init
-                          airflow db check
                           make test-docs-harness
-                        reports:
-                          type: JUnit
-                          spec:
-                            paths:
-                              - /harness/unit_test_report.xml
                         resources:
                           limits:
                             memory: 1Gi
                             cpu: "1.5"
-                      strategy:
-                        matrix:
-                          python_version:
-                            - "3.12"
-                          nodeName: <+matrix.python_version>

--- a/.harness/cichecks.yaml
+++ b/.harness/cichecks.yaml
@@ -14,7 +14,7 @@ pipeline:
     - parallel:
         - stage:
             name: Lint and MyPy
-            identifier: lint
+            identifier: lint_and_mypy
             description: ""
             type: CI
             spec:
@@ -68,7 +68,7 @@ pipeline:
                               make typecheck
         - stage:
             name: Unit tests
-            identifier: test_unit
+            identifier: test_unit_tests
             description: ""
             type: CI
             spec:

--- a/.harness/cichecks.yaml
+++ b/.harness/cichecks.yaml
@@ -132,16 +132,6 @@ pipeline:
               execution:
                 steps:
                   - step:
-                      spec:
-                        connectorRef: account.dockerhub_datarobot_read
-                        image: python:3.12
-                        shell: Bash
-                        command: |-
-                          set -exuo pipefail
-                          pip install -U pip
-                          pip install -r requirements.txt
-                          make lint
-                  - step:
                       type: Run
                       name: run build docs test
                       identifier: run_build_docs_tests
@@ -151,7 +141,7 @@ pipeline:
                         shell: Bash
                         command: |-
                           set -exuo pipefail
-                          make req-dev
+                          make req-dev-docs
                           make test-docs-harness
                         resources:
                           limits:

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,9 @@ format:
 format-no-fix:
 	ruff format . --check
 
+test-harness:
+	pytest -vv tests/unit/ --junit-xml=unit_test_report.xml
+
 unit-tests:
 	pytest -vv tests/unit/
 
@@ -39,6 +42,9 @@ typecheck:
 
 test-docs:
 	cd docs && $(MAKE) doctest
+
+test-docs-harness:
+	$(MAKE) test-docs
 
 # Copyright Notices are handled by the next two targets
 # See .licenserc.yaml for configuration

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ req-dev:
 	pip install --upgrade pip setuptools
 	pip install -e ".[dev]"
 
+req-dev-docs:
+	pip install --upgrade pip setuptools
+	pip install -e ".[dev,docs]"
+
 lint:
 	ruff check .
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dev = [
     "pyenchant==3.2.2",
     "sphinx-copybutton",
     "sphinx-markdown-builder",
-    "myst-parser==4.0.0",
+    "myst-parser==3.0.1",
     "black==24.10.0",
     "pyyaml>=6.0.2",
     "types-PyYAML>=6.0.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,12 @@ dev = [
     "pytest>=7.0.0",
     "pytest-mock>=3.7.0",
     "pytest-helpers-namespace>=2021.12.29",
+    "black==24.10.0",
+    "pyyaml>=6.0.2",
+    "types-PyYAML>=6.0.12",
+    "freezegun>=1.5.1",
+]
+docs = [
     "Sphinx>=7.4.7",
     "sphinx_rtd_theme>=3.0",
     "numpydoc>=1.7.0,<1.8.0",
@@ -41,10 +47,6 @@ dev = [
     "sphinx-copybutton",
     "sphinx-markdown-builder",
     "myst-parser==3.0.1",
-    "black==24.10.0",
-    "pyyaml>=6.0.2",
-    "types-PyYAML>=6.0.12",
-    "freezegun>=1.5.1",
 ]
 
 [project.entry-points."apache_airflow_provider"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,13 +40,13 @@ dev = [
     "freezegun>=1.5.1",
 ]
 docs = [
-    "Sphinx>=7.4.7",
+    "Sphinx>=8.1.3",
     "sphinx_rtd_theme>=3.0",
     "sphinx-autodoc-typehints>=2",
     "pyenchant==3.2.2",
     "sphinx-copybutton",
     "sphinx-markdown-builder",
-    "myst-parser==3.0.1",
+    "myst-parser==4.0.0",
 ]
 
 [project.entry-points."apache_airflow_provider"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
     "pytest>=7.0.0",
     "pytest-mock>=3.7.0",
     "pytest-helpers-namespace>=2021.12.29",
+    "numpydoc>=1.7.0,<1.8.0",
     "black==24.10.0",
     "pyyaml>=6.0.2",
     "types-PyYAML>=6.0.12",
@@ -41,7 +42,6 @@ dev = [
 docs = [
     "Sphinx>=7.4.7",
     "sphinx_rtd_theme>=3.0",
-    "numpydoc>=1.7.0,<1.8.0",
     "sphinx-autodoc-typehints>=2",
     "pyenchant==3.2.2",
     "sphinx-copybutton",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dev = [
     "pytest>=7.0.0",
     "pytest-mock>=3.7.0",
     "pytest-helpers-namespace>=2021.12.29",
-    "Sphinx>=8.1.3",
+    "Sphinx>=7.4.7",
     "sphinx_rtd_theme>=3.0",
     "numpydoc>=1.7.0,<1.8.0",
     "sphinx-autodoc-typehints>=2",
@@ -46,6 +46,7 @@ dev = [
     "types-PyYAML>=6.0.12",
     "freezegun>=1.5.1",
 ]
+docs = []
 
 [project.entry-points."apache_airflow_provider"]
 provider_info = "datarobot_provider.__init__:get_provider_info"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ dev = [
     "types-PyYAML>=6.0.12",
     "freezegun>=1.5.1",
 ]
-docs = []
 
 [project.entry-points."apache_airflow_provider"]
 provider_info = "datarobot_provider.__init__:get_provider_info"


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
This PR adds doc testing to the main `ci_checks` pipeline. It also unifies up some of the wording, and removes the manual `pip` commands and dependency on the `requirements.txt`. Instead everything now defers to the `make` commands which makes it more simple to update the pipelines.

Docs test is currently passing on this build.

I also split apart the `dev` and `docs` requirements so that these aren't needed in the regression matrix unit testing. This allows us to always use the latest docs versions for everything. A followup to this will formally remove the `requirements.txt` file now that the pipelines should not depend on it anymore.