### PR TITLE
[DM-16999] Migrate all operators to `BaseDatarobotOperator`

### DIFF
--- a/datarobot_provider/operators/model_insights.py
+++ b/datarobot_provider/operators/model_insights.py
@@ -37,8 +37,8 @@ class ComputeFeatureImpactOperator(BaseDatarobotOperator):
     def __init__(
         self,
         *,
-        project_id: Optional[str] = None,
-        model_id: Optional[str] = None,
+        project_id: str,
+        model_id: str,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -84,8 +84,8 @@ class ComputeFeatureEffectsOperator(BaseDatarobotOperator):
     def __init__(
         self,
         *,
-        project_id: Optional[str] = None,
-        model_id: Optional[str] = None,
+        project_id: str,
+        model_id: str,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)

--- a/datarobot_provider/operators/model_insights.py
+++ b/datarobot_provider/operators/model_insights.py
@@ -10,14 +10,12 @@ from typing import Any
 from typing import Optional
 
 import datarobot as dr
-from airflow.exceptions import AirflowException
-from airflow.models import BaseOperator
 from airflow.utils.context import Context
 
-from datarobot_provider.hooks.datarobot import DataRobotHook
+from datarobot_provider.operators.base_datarobot_operator import BaseDatarobotOperator
 
 
-class ComputeFeatureImpactOperator(BaseOperator):
+class ComputeFeatureImpactOperator(BaseDatarobotOperator):
     """
     Creates Feature Impact job in DataRobot.
     :param project_id: DataRobot project ID
@@ -35,37 +33,26 @@ class ComputeFeatureImpactOperator(BaseOperator):
         "project_id",
         "model_id",
     ]
-    template_fields_renderers: dict[str, str] = {}
-    template_ext: Sequence[str] = ()
-    ui_color = "#f4a460"
 
     def __init__(
         self,
         *,
         project_id: Optional[str] = None,
         model_id: Optional[str] = None,
-        datarobot_conn_id: str = "datarobot_default",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.project_id = project_id
         self.model_id = model_id
-        self.datarobot_conn_id = datarobot_conn_id
-        if kwargs.get("xcom_push") is not None:
-            raise AirflowException(
-                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
-            )
 
-    def execute(self, context: Context) -> str:
-        # Initialize DataRobot client
-        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
-
+    def validate(self):
         if self.project_id is None:
             raise ValueError("project_id is required to compute Feature Impact.")
 
         if self.model_id is None:
             raise ValueError("model_id is required to compute Feature Impact.")
 
+    def execute(self, context: Context) -> str:
         model = dr.models.Model.get(self.project_id, self.model_id)
 
         job = model.request_feature_impact()
@@ -75,7 +62,7 @@ class ComputeFeatureImpactOperator(BaseOperator):
         return job.id
 
 
-class ComputeFeatureEffectsOperator(BaseOperator):
+class ComputeFeatureEffectsOperator(BaseDatarobotOperator):
     """
     Submit request to compute Feature Effects for the model.
     :param project_id: DataRobot project ID
@@ -93,37 +80,26 @@ class ComputeFeatureEffectsOperator(BaseOperator):
         "project_id",
         "model_id",
     ]
-    template_fields_renderers: dict[str, str] = {}
-    template_ext: Sequence[str] = ()
-    ui_color = "#f4a460"
 
     def __init__(
         self,
         *,
         project_id: Optional[str] = None,
         model_id: Optional[str] = None,
-        datarobot_conn_id: str = "datarobot_default",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.project_id = project_id
         self.model_id = model_id
-        self.datarobot_conn_id = datarobot_conn_id
-        if kwargs.get("xcom_push") is not None:
-            raise AirflowException(
-                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
-            )
 
-    def execute(self, context: Context) -> str:
-        # Initialize DataRobot client
-        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
-
+    def validate(self):
         if self.project_id is None:
             raise ValueError("project_id is required to compute Feature Effects.")
 
         if self.model_id is None:
             raise ValueError("model_id is required to compute Feature Effects.")
 
+    def execute(self, context: Context) -> str:
         model = dr.models.Model.get(self.project_id, self.model_id)
 
         job = model.request_feature_effect()
@@ -133,7 +109,7 @@ class ComputeFeatureEffectsOperator(BaseOperator):
         return job.id
 
 
-class ComputeShapOperator(BaseOperator):
+class ComputeShapOperator(BaseDatarobotOperator):
     """
     Creates SHAP impact job in DataRobot.
     :param project_id: DataRobot project ID
@@ -151,37 +127,26 @@ class ComputeShapOperator(BaseOperator):
         "project_id",
         "model_id",
     ]
-    template_fields_renderers: dict[str, str] = {}
-    template_ext: Sequence[str] = ()
-    ui_color = "#f4a460"
 
     def __init__(
         self,
         *,
         project_id: Optional[str] = None,
         model_id: Optional[str] = None,
-        datarobot_conn_id: str = "datarobot_default",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.project_id = project_id
         self.model_id = model_id
-        self.datarobot_conn_id = datarobot_conn_id
-        if kwargs.get("xcom_push") is not None:
-            raise AirflowException(
-                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
-            )
 
-    def execute(self, context: Context) -> str:
-        # Initialize DataRobot client
-        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
-
+    def validate(self):
         if self.project_id is None:
             raise ValueError("project_id is required to compute SHAP impact.")
 
         if self.model_id is None:
             raise ValueError("model_id is required to compute SHAP impact.")
 
+    def execute(self, context: Context) -> str:
         shap_impact_job = dr.ShapImpact.create(project_id=self.project_id, model_id=self.model_id)
 
         self.log.info(f"Compute SHAP impact Job submitted, job_id={shap_impact_job.id}")

--- a/datarobot_provider/operators/model_insights.py
+++ b/datarobot_provider/operators/model_insights.py
@@ -46,10 +46,10 @@ class ComputeFeatureImpactOperator(BaseDatarobotOperator):
         self.model_id = model_id
 
     def validate(self):
-        if self.project_id is None:
+        if not self.project_id:
             raise ValueError("project_id is required to compute Feature Impact.")
 
-        if self.model_id is None:
+        if not self.model_id:
             raise ValueError("model_id is required to compute Feature Impact.")
 
     def execute(self, context: Context) -> str:
@@ -93,10 +93,10 @@ class ComputeFeatureEffectsOperator(BaseDatarobotOperator):
         self.model_id = model_id
 
     def validate(self):
-        if self.project_id is None:
+        if not self.project_id:
             raise ValueError("project_id is required to compute Feature Effects.")
 
-        if self.model_id is None:
+        if not self.model_id:
             raise ValueError("model_id is required to compute Feature Effects.")
 
     def execute(self, context: Context) -> str:

--- a/datarobot_provider/operators/model_predictions.py
+++ b/datarobot_provider/operators/model_predictions.py
@@ -108,9 +108,9 @@ class RequestModelPredictionsOperator(BaseDatarobotOperator):
     def __init__(
         self,
         *,
-        project_id: Optional[str] = None,
-        model_id: Optional[str] = None,
-        external_dataset_id: Optional[str] = None,
+        project_id: str,
+        model_id: str,
+        external_dataset_id: str,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)

--- a/datarobot_provider/operators/model_predictions.py
+++ b/datarobot_provider/operators/model_predictions.py
@@ -10,16 +10,14 @@ from typing import Any
 from typing import Optional
 
 import datarobot as dr
-from airflow.exceptions import AirflowException
-from airflow.models import BaseOperator
 from airflow.utils.context import Context
 
-from datarobot_provider.hooks.datarobot import DataRobotHook
+from datarobot_provider.operators.base_datarobot_operator import BaseDatarobotOperator
 
 DEFAULT_MAX_WAIT_SEC = 600
 
 
-class AddExternalDatasetOperator(BaseOperator):
+class AddExternalDatasetOperator(BaseDatarobotOperator):
     """
     Upload a new dataset from a catalog dataset to make predictions for a model
     :param project_id: DataRobot project ID
@@ -43,9 +41,6 @@ class AddExternalDatasetOperator(BaseOperator):
         "credential_id",
         "dataset_version_id",
     ]
-    template_fields_renderers: dict[str, str] = {}
-    template_ext: Sequence[str] = ()
-    ui_color = "#f4a460"
 
     def __init__(
         self,
@@ -55,7 +50,6 @@ class AddExternalDatasetOperator(BaseOperator):
         credential_id: Optional[str] = None,
         dataset_version_id: Optional[str] = None,
         max_wait_sec: int = DEFAULT_MAX_WAIT_SEC,
-        datarobot_conn_id: str = "datarobot_default",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -64,22 +58,15 @@ class AddExternalDatasetOperator(BaseOperator):
         self.credential_id = credential_id
         self.dataset_version_id = dataset_version_id
         self.max_wait_sec = max_wait_sec
-        self.datarobot_conn_id = datarobot_conn_id
-        if kwargs.get("xcom_push") is not None:
-            raise AirflowException(
-                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
-            )
 
-    def execute(self, context: Context) -> str:
-        # Initialize DataRobot client
-        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
-
+    def validate(self):
         if self.project_id is None:
             raise ValueError("project_id is required to add external dataset.")
 
         if self.dataset_id is None:
             raise ValueError("dataset_id is required to add external dataset.")
 
+    def execute(self, context: Context) -> str:
         project = dr.Project.get(self.project_id)
 
         external_dataset = project.upload_dataset_from_catalog(
@@ -96,7 +83,7 @@ class AddExternalDatasetOperator(BaseOperator):
         return external_dataset.id
 
 
-class RequestModelPredictionsOperator(BaseOperator):
+class RequestModelPredictionsOperator(BaseDatarobotOperator):
     """
     Requests predictions against a previously uploaded dataset.
     :param project_id: DataRobot project ID
@@ -117,9 +104,6 @@ class RequestModelPredictionsOperator(BaseOperator):
         "model_id",
         "external_dataset_id",
     ]
-    template_fields_renderers: dict[str, str] = {}
-    template_ext: Sequence[str] = ()
-    ui_color = "#f4a460"
 
     def __init__(
         self,
@@ -127,23 +111,14 @@ class RequestModelPredictionsOperator(BaseOperator):
         project_id: Optional[str] = None,
         model_id: Optional[str] = None,
         external_dataset_id: Optional[str] = None,
-        datarobot_conn_id: str = "datarobot_default",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.project_id = project_id
         self.model_id = model_id
         self.external_dataset_id = external_dataset_id
-        self.datarobot_conn_id = datarobot_conn_id
-        if kwargs.get("xcom_push") is not None:
-            raise AirflowException(
-                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
-            )
 
-    def execute(self, context: Context) -> str:
-        # Initialize DataRobot client
-        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
-
+    def validate(self):
         if self.project_id is None:
             raise ValueError("project_id is required to compute model predictions.")
 
@@ -153,6 +128,7 @@ class RequestModelPredictionsOperator(BaseOperator):
         if self.external_dataset_id is None:
             raise ValueError("external_dataset_id is required to compute model predictions.")
 
+    def execute(self, context: Context) -> str:
         model = dr.models.Model.get(self.project_id, self.model_id)
 
         predict_job = model.request_predictions(dataset_id=self.external_dataset_id)

--- a/datarobot_provider/operators/model_training.py
+++ b/datarobot_provider/operators/model_training.py
@@ -46,8 +46,8 @@ class TrainModelOperator(BaseDatarobotOperator):
     def __init__(
         self,
         *,
-        project_id: Optional[str] = None,
-        blueprint_id: Optional[str] = None,
+        project_id: str,
+        blueprint_id: str,
         featurelist_id: Optional[str] = None,
         source_project_id: Optional[str] = None,
         **kwargs: Any,
@@ -110,8 +110,8 @@ class RetrainModelOperator(BaseDatarobotOperator):
     def __init__(
         self,
         *,
-        project_id: Optional[str] = None,
-        model_id: Optional[str] = None,
+        project_id: str,
+        model_id: str,
         featurelist_id: Optional[str] = None,
         **kwargs: Any,
     ) -> None:

--- a/datarobot_provider/operators/monitoring.py
+++ b/datarobot_provider/operators/monitoring.py
@@ -10,16 +10,14 @@ from typing import Any
 from typing import Optional
 
 import datarobot as dr
-from airflow.exceptions import AirflowException
-from airflow.models import BaseOperator
 from airflow.utils.context import Context
 
-from datarobot_provider.hooks.datarobot import DataRobotHook
+from datarobot_provider.operators.base_datarobot_operator import BaseDatarobotOperator
 
 DATETIME_FORMAT = "%Y-%m-%d %H:%M:%s"
 
 
-class GetServiceStatsOperator(BaseOperator):
+class GetServiceStatsOperator(BaseDatarobotOperator):
     """
     Gets service stats measurements from a deployment.
 
@@ -33,29 +31,17 @@ class GetServiceStatsOperator(BaseOperator):
 
     # Specify the arguments that are allowed to parse with jinja templating
     template_fields: Sequence[str] = ["deployment_id"]
-    template_fields_renderers: dict[str, str] = {}
-    template_ext: Sequence[str] = ()
-    ui_color = "#f4a460"
 
     def __init__(
         self,
         *,
         deployment_id: str,
-        datarobot_conn_id: str = "datarobot_default",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.deployment_id = deployment_id
-        self.datarobot_conn_id = datarobot_conn_id
-        if kwargs.get("xcom_push") is not None:
-            raise AirflowException(
-                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
-            )
 
     def execute(self, context: Context) -> list[dict]:
-        # Initialize DataRobot client
-        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
-
         self.log.info(f"Getting service stats for deployment_id={self.deployment_id}")
         deployment = dr.Deployment.get(self.deployment_id)
         service_stats_params = context["params"].get("service_stats", {})
@@ -72,7 +58,7 @@ def _serialize_metrics(service_stats_obj, date_format=DATETIME_FORMAT):
     return service_stats_dict
 
 
-class GetAccuracyOperator(BaseOperator):
+class GetAccuracyOperator(BaseDatarobotOperator):
     """
     Gets the accuracy of a deployment’s predictions.
 
@@ -86,29 +72,17 @@ class GetAccuracyOperator(BaseOperator):
 
     # Specify the arguments that are allowed to parse with jinja templating
     template_fields: Sequence[str] = ["deployment_id"]
-    template_fields_renderers: dict[str, str] = {}
-    template_ext: Sequence[str] = ()
-    ui_color = "#f4a460"
 
     def __init__(
         self,
         *,
         deployment_id: str,
-        datarobot_conn_id: str = "datarobot_default",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.deployment_id = deployment_id
-        self.datarobot_conn_id = datarobot_conn_id
-        if kwargs.get("xcom_push") is not None:
-            raise AirflowException(
-                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
-            )
 
     def execute(self, context: Context) -> list[dict]:
-        # Initialize DataRobot client
-        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
-
         self.log.info(f"Getting service stats for deployment_id={self.deployment_id}")
         deployment = dr.Deployment.get(self.deployment_id)
         accuracy_params = context["params"].get("accuracy", {})
@@ -116,7 +90,7 @@ class GetAccuracyOperator(BaseOperator):
         return _serialize_metrics(accuracy)
 
 
-class GetMonitoringSettingsOperator(BaseOperator):
+class GetMonitoringSettingsOperator(BaseDatarobotOperator):
     """
     Get monitoring settings for deployment.
 
@@ -128,29 +102,17 @@ class GetMonitoringSettingsOperator(BaseOperator):
 
     # Specify the arguments that are allowed to parse with jinja templating
     template_fields: Sequence[str] = ["deployment_id"]
-    template_fields_renderers: dict[str, str] = {}
-    template_ext: Sequence[str] = ()
-    ui_color = "#f4a460"
 
     def __init__(
         self,
         *,
         deployment_id: str,
-        datarobot_conn_id: str = "datarobot_default",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.deployment_id = deployment_id
-        self.datarobot_conn_id = datarobot_conn_id
-        if kwargs.get("xcom_push") is not None:
-            raise AirflowException(
-                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
-            )
 
     def execute(self, context: Context) -> dict:
-        # Initialize DataRobot client
-        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
-
         self.log.info(f"Get Deployment for deployment_id={self.deployment_id}")
         deployment = dr.Deployment.get(deployment_id=self.deployment_id)
 
@@ -167,7 +129,7 @@ class GetMonitoringSettingsOperator(BaseOperator):
         return monitoring_settings
 
 
-class UpdateMonitoringSettingsOperator(BaseOperator):
+class UpdateMonitoringSettingsOperator(BaseDatarobotOperator):
     """
     Updates monitoring settings for a deployment.
 
@@ -179,31 +141,19 @@ class UpdateMonitoringSettingsOperator(BaseOperator):
 
     # Specify the arguments that are allowed to parse with jinja templating
     template_fields: Sequence[str] = ["deployment_id"]
-    template_fields_renderers: dict[str, str] = {}
-    template_ext: Sequence[str] = ()
-    ui_color = "#f4a460"
 
     def __init__(
         self,
         *,
         deployment_id: str,
         monitoring_settings: Optional[dict] = None,
-        datarobot_conn_id: str = "datarobot_default",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.deployment_id = deployment_id
         self.monitoring_settings = monitoring_settings
-        self.datarobot_conn_id = datarobot_conn_id
-        if kwargs.get("xcom_push") is not None:
-            raise AirflowException(
-                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
-            )
 
     def execute(self, context: Context) -> None:
-        # Initialize DataRobot client
-        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
-
         self.log.info(f"Getting Deployment for deployment_id={self.deployment_id}")
         deployment = dr.Deployment.get(deployment_id=self.deployment_id)
 

--- a/datarobot_provider/operators/monitoring_job.py
+++ b/datarobot_provider/operators/monitoring_job.py
@@ -10,15 +10,13 @@ from typing import Any
 from typing import Optional
 
 import datarobot as dr
-from airflow.exceptions import AirflowException
-from airflow.models import BaseOperator
 from airflow.utils.context import Context
 from datarobot import BatchMonitoringJob
 
-from datarobot_provider.hooks.datarobot import DataRobotHook
+from datarobot_provider.operators.base_datarobot_operator import BaseDatarobotOperator
 
 
-class BatchMonitoringOperator(BaseOperator):
+class BatchMonitoringOperator(BaseDatarobotOperator):
     """
     Creates a batch monitoring job in DataRobot.
     :param deployment_id: DataRobot deployment ID
@@ -39,9 +37,6 @@ class BatchMonitoringOperator(BaseOperator):
         "datastore_id",
         "credential_id",
     ]
-    template_fields_renderers: dict[str, str] = {}
-    template_ext: Sequence[str] = ()
-    ui_color = "#f4a460"
 
     def __init__(
         self,
@@ -49,23 +44,14 @@ class BatchMonitoringOperator(BaseOperator):
         deployment_id: Optional[str] = None,
         datastore_id: Optional[str] = None,
         credential_id: Optional[str] = None,
-        datarobot_conn_id: str = "datarobot_default",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.deployment_id = deployment_id
         self.datastore_id = datastore_id
         self.credential_id = credential_id
-        self.datarobot_conn_id = datarobot_conn_id
-        if kwargs.get("xcom_push") is not None:
-            raise AirflowException(
-                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
-            )
 
     def execute(self, context: Context) -> str:
-        # Initialize DataRobot client
-        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
-
         monitoring_job_settings = context["params"]["monitoring_settings"]
 
         # in case of deployment_id was not set from operator argument:

--- a/datarobot_provider/operators/segment_analysis.py
+++ b/datarobot_provider/operators/segment_analysis.py
@@ -10,17 +10,15 @@ from typing import TYPE_CHECKING
 from typing import Any
 
 import datarobot as dr
-from airflow.exceptions import AirflowException
-from airflow.models import BaseOperator
 from airflow.utils.context import Context
 
-from datarobot_provider.hooks.datarobot import DataRobotHook
+from datarobot_provider.operators.base_datarobot_operator import BaseDatarobotOperator
 
 if TYPE_CHECKING:
     from datarobot.models.deployment.deployment import SegmentAnalysisSettings
 
 
-class GetSegmentAnalysisSettingsOperator(BaseOperator):
+class GetSegmentAnalysisSettingsOperator(BaseDatarobotOperator):
     """
     Get segment analysis settings for a deployment.
 
@@ -32,29 +30,17 @@ class GetSegmentAnalysisSettingsOperator(BaseOperator):
 
     # Specify the arguments that are allowed to parse with jinja templating
     template_fields: Sequence[str] = ["deployment_id"]
-    template_fields_renderers: dict[str, str] = {}
-    template_ext: Sequence[str] = ()
-    ui_color = "#f4a460"
 
     def __init__(
         self,
         *,
         deployment_id: str,
-        datarobot_conn_id: str = "datarobot_default",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.deployment_id = deployment_id
-        self.datarobot_conn_id = datarobot_conn_id
-        if kwargs.get("xcom_push") is not None:
-            raise AirflowException(
-                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
-            )
 
     def execute(self, context: Context) -> "SegmentAnalysisSettings":
-        # Initialize DataRobot client
-        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
-
         self.log.info(f"Get Deployment for deployment_id={self.deployment_id}")
         deployment = dr.Deployment.get(deployment_id=self.deployment_id)
 
@@ -63,7 +49,7 @@ class GetSegmentAnalysisSettingsOperator(BaseOperator):
         return segment_analysis_settings
 
 
-class UpdateSegmentAnalysisSettingsOperator(BaseOperator):
+class UpdateSegmentAnalysisSettingsOperator(BaseDatarobotOperator):
     """
     Updates segment analysis settings for a deployment.
 
@@ -75,29 +61,17 @@ class UpdateSegmentAnalysisSettingsOperator(BaseOperator):
 
     # Specify the arguments that are allowed to parse with jinja templating
     template_fields: Sequence[str] = ["deployment_id"]
-    template_fields_renderers: dict[str, str] = {}
-    template_ext: Sequence[str] = ()
-    ui_color = "#f4a460"
 
     def __init__(
         self,
         *,
         deployment_id: str,
-        datarobot_conn_id: str = "datarobot_default",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.deployment_id = deployment_id
-        self.datarobot_conn_id = datarobot_conn_id
-        if kwargs.get("xcom_push") is not None:
-            raise AirflowException(
-                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
-            )
 
     def execute(self, context: Context) -> None:
-        # Initialize DataRobot client
-        DataRobotHook(datarobot_conn_id=self.datarobot_conn_id).run()
-
         self.log.info(f"Getting Deployment for deployment_id={self.deployment_id}")
         deployment = dr.Deployment.get(deployment_id=self.deployment_id)
 

--- a/tests/unit/operators/test_mlops.py
+++ b/tests/unit/operators/test_mlops.py
@@ -69,17 +69,14 @@ def test_operator_submit_actuals_deployment_is_none(mocker, submit_actuals_from_
         return_value=StatusCheckJob(job_id=status_check_job_id),
     )
 
+    operator = SubmitActualsFromCatalogOperator(
+        task_id="submit_actuals_form_catalog",
+        deployment_id=deployment_id,
+        dataset_id=dataset_id,
+    )
+
     with pytest.raises(ValueError):
-        operator = SubmitActualsFromCatalogOperator(
-            task_id="submit_actuals_form_catalog",
-            deployment_id=deployment_id,
-            dataset_id=dataset_id,
-        )
-        operator.execute(
-            context={
-                "params": submit_actuals_from_catalog_settings,
-            }
-        )
+        operator.validate()
 
 
 def test_operator_submit_actuals_dataset_is_none(mocker, submit_actuals_from_catalog_settings):
@@ -93,14 +90,11 @@ def test_operator_submit_actuals_dataset_is_none(mocker, submit_actuals_from_cat
         return_value=StatusCheckJob(job_id=status_check_job_id),
     )
 
+    operator = SubmitActualsFromCatalogOperator(
+        task_id="submit_actuals_form_catalog",
+        deployment_id=deployment_id,
+        dataset_id=dataset_id,
+    )
+
     with pytest.raises(ValueError):
-        operator = SubmitActualsFromCatalogOperator(
-            task_id="submit_actuals_form_catalog",
-            deployment_id=deployment_id,
-            dataset_id=dataset_id,
-        )
-        operator.execute(
-            context={
-                "params": submit_actuals_from_catalog_settings,
-            }
-        )
+        operator.validate()

--- a/tests/unit/operators/test_model_insights_job.py
+++ b/tests/unit/operators/test_model_insights_job.py
@@ -51,10 +51,12 @@ def test_operator_compute_feature_impact_no_project_id(mocker):
     model_mock.id = model_id
     model_mock.project_id = project_id
 
-    operator = ComputeFeatureImpactOperator(task_id="compute_feature_impact", model_id=model_id)
+    operator = ComputeFeatureImpactOperator(
+        task_id="compute_feature_impact", model_id=model_id, project_id=""
+    )
 
     with pytest.raises(ValueError):
-        operator.execute(context={"params": {}})
+        operator.validate()
 
 
 def test_operator_compute_feature_impact_no_model_id(mocker):
@@ -65,10 +67,12 @@ def test_operator_compute_feature_impact_no_model_id(mocker):
     model_mock.id = model_id
     model_mock.project_id = project_id
 
-    operator = ComputeFeatureImpactOperator(task_id="compute_feature_impact", project_id=project_id)
+    operator = ComputeFeatureImpactOperator(
+        task_id="compute_feature_impact", model_id="", project_id=project_id
+    )
 
     with pytest.raises(ValueError):
-        operator.execute(context={"params": {}})
+        operator.validate()
 
 
 def test_operator_compute_feature_effects(mocker):
@@ -108,10 +112,12 @@ def test_operator_compute_feature_effects_no_project_id(mocker):
     model_mock.id = model_id
     model_mock.project_id = project_id
 
-    operator = ComputeFeatureEffectsOperator(task_id="compute_feature_effects", model_id=model_id)
+    operator = ComputeFeatureEffectsOperator(
+        task_id="compute_feature_effects", project_id="", model_id=model_id
+    )
 
     with pytest.raises(ValueError):
-        operator.execute(context={"params": {}})
+        operator.validate()
 
 
 def test_operator_compute_feature_effects_no_model_id(mocker):
@@ -123,11 +129,11 @@ def test_operator_compute_feature_effects_no_model_id(mocker):
     model_mock.project_id = project_id
 
     operator = ComputeFeatureEffectsOperator(
-        task_id="compute_feature_effects", project_id=project_id
+        task_id="compute_feature_effects", project_id=project_id, model_id=""
     )
 
     with pytest.raises(ValueError):
-        operator.execute(context={"params": {}})
+        operator.validate()
 
 
 def test_operator_compute_shap(mocker):


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

That's a followup for https://github.com/datarobot/airflow-provider-datarobot/pull/131 Use `BaseDatarobotOperator` as the base class in all DataRobot operators.

## Rationale

Remove duplicate code and separate validation from execution.