### PR TITLE
[MLDEV-1207] New early access test release pipeline

### DIFF
--- a/.harness/build_and_publish_early_access_pypi.yaml
+++ b/.harness/build_and_publish_early_access_pypi.yaml
@@ -17,4 +17,4 @@ pipeline:
               - name: BUILD_TYPE
                 type: String
                 default: test
-                value: <+input>.default(test).allowedValues(test,early-access,pypi)
+                value: test

--- a/.harness/build_and_publish_early_access_pypi.yaml
+++ b/.harness/build_and_publish_early_access_pypi.yaml
@@ -11,3 +11,10 @@ pipeline:
         template:
           templateRef: publish_early_access_to_pypi_or_testpypi
           versionLabel: "1"
+          templateInputs:
+            type: CI
+            variables:
+              - name: BUILD_TYPE
+                type: String
+                default: test
+                value: <+input>.default(test).allowedValues(test,early-access,pypi)

--- a/.harness/build_and_publish_early_access_pypi.yaml
+++ b/.harness/build_and_publish_early_access_pypi.yaml
@@ -6,6 +6,39 @@ pipeline:
   tags: {}
   stages:
     - stage:
+        name: Lint
+        identifier: Lint
+        description: ""
+        type: CI
+        spec:
+          cloneCodebase: true
+          caching:
+            enabled: true
+          buildIntelligence:
+            enabled: true
+          infrastructure:
+            type: KubernetesDirect
+            spec:
+              connectorRef: account.cigeneral
+              namespace: harness-delegate-ng
+              automountServiceAccountToken: true
+              nodeSelector: {}
+              os: Linux
+          execution:
+            steps:
+              - step:
+                  type: Run
+                  name: lint check step
+                  identifier: lint_check_step
+                  spec:
+                    connectorRef: account.dockerhub_datarobot_read
+                    image: python:3.12
+                    shell: Bash
+                    command: |-
+                      set -exuo pipefail
+                      make req-dev
+                      make lint
+    - stage:
         name: Publish to TestPypi
         identifier: Publish_to_TestPypi
         template:
@@ -18,3 +51,9 @@ pipeline:
                 type: String
                 default: test
                 value: test
+  properties:
+    ci:
+      codebase:
+        connectorRef: account.svc_harness_git1
+        repoName: airflow-provider-datarobot
+        build: <+input>

--- a/.harness/build_and_publish_early_access_pypi.yaml
+++ b/.harness/build_and_publish_early_access_pypi.yaml
@@ -1,5 +1,5 @@
 pipeline:
-  name: test_build_and_publish_early_access_pypi
+  name: test-release-early-access-pypi
   identifier: test_build_and_publish_early_access_pypi
   projectIdentifier: airflowproviderdatarobot
   orgIdentifier: AGENTS

--- a/.harness/build_and_publish_early_access_pypi.yaml
+++ b/.harness/build_and_publish_early_access_pypi.yaml
@@ -1,0 +1,13 @@
+pipeline:
+  name: test_build_and_publish_early_access_pypi
+  identifier: test_build_and_publish_early_access_pypi
+  projectIdentifier: airflowproviderdatarobot
+  orgIdentifier: AGENTS
+  tags: {}
+  stages:
+    - stage:
+        name: Publish to TestPypi
+        identifier: Publish_to_TestPypi
+        template:
+          templateRef: publish_early_access_to_pypi_or_testpypi
+          versionLabel: "1"

--- a/.harness/input_sets/test_release_early_access_pypi.yaml
+++ b/.harness/input_sets/test_release_early_access_pypi.yaml
@@ -1,0 +1,14 @@
+inputSet:
+  name: test-release-early-access-pypi-input-set
+  identifier: testreleaseearlyaccesspypiinputset
+  orgIdentifier: AGENTS
+  projectIdentifier: airflowproviderdatarobot
+  pipeline:
+    identifier: test_build_and_publish_early_access_pypi
+    properties:
+      ci:
+        codebase:
+          build:
+            type: branch
+            spec:
+              branch: main

--- a/.harness/templates/publish_early_access_to_pypi_or_testpypi.yaml
+++ b/.harness/templates/publish_early_access_to_pypi_or_testpypi.yaml
@@ -11,9 +11,10 @@ template:
     spec:
       cloneCodebase: true
       caching:
-        enabled: true
+        enabled: false
+        paths: []
       buildIntelligence:
-        enabled: true
+        enabled: false
       infrastructure:
         type: KubernetesDirect
         spec:

--- a/.harness/templates/publish_early_access_to_pypi_or_testpypi.yaml
+++ b/.harness/templates/publish_early_access_to_pypi_or_testpypi.yaml
@@ -87,3 +87,10 @@ template:
                   }
 
                   main "$@"
+    variables:
+      - name: BUILD_TYPE
+        type: String
+        default: test
+        description: ""
+        required: true
+        value: <+input>.default(test).allowedValues(test,early-access,pypi)

--- a/.harness/templates/publish_early_access_to_pypi_or_testpypi.yaml
+++ b/.harness/templates/publish_early_access_to_pypi_or_testpypi.yaml
@@ -48,12 +48,12 @@ template:
                       export SETUPTOOLS_SCM_PRETEND_VERSION='<+trigger.tag>'
                       BUILD_TYPE='<+stage.variables.BUILD_TYPE>'
                       REPO_URL='https://test.pypi.org/legacy/'
-                      UPLOAD_SECRET='<+secrets.getValue("org.test_pypi_token")>'
+                      UPLOAD_SECRET='<+secrets.getValue("testpypi_token")>'
                       VERSION=$(python3 setup_early_access.py --version)
 
                       if [ "$BUILD_TYPE" == "pypi" ]; then
                           REPO_URL='https://upload.pypi.org/legacy/'
-                          UPLOAD_SECRET='<+secrets.getValue("org.pypi_token")>'
+                          UPLOAD_SECRET='<+secrets.getValue("PyPI_token_for_airflow-provider-datarobot")>'
                       fi
                   }
 

--- a/.harness/templates/publish_early_access_to_pypi_or_testpypi.yaml
+++ b/.harness/templates/publish_early_access_to_pypi_or_testpypi.yaml
@@ -71,7 +71,7 @@ template:
                           --repository-url "$REPO_URL" \
                           --username '__token__' \
                           --password "$UPLOAD_SECRET" \
-                          dist/*
+                          dist/*early_access*
                   }
 
                   push_tags() {

--- a/.harness/templates/publish_early_access_to_pypi_or_testpypi.yaml
+++ b/.harness/templates/publish_early_access_to_pypi_or_testpypi.yaml
@@ -82,6 +82,7 @@ template:
 
                   main() {
                       configure_git
+                      pip3 install --no-cache-dir --upgrade pip setuptools wheel six twine
                       set_build_variables
                       build_and_upload
                       push_tags

--- a/.harness/templates/publish_early_access_to_pypi_or_testpypi.yaml
+++ b/.harness/templates/publish_early_access_to_pypi_or_testpypi.yaml
@@ -67,6 +67,7 @@ template:
 
                       echo "[TWINE UPLOAD]"
                       twine upload \
+                          --verbose \
                           --repository-url "$REPO_URL" \
                           --username '__token__' \
                           --password "$UPLOAD_SECRET" \

--- a/setup.py
+++ b/setup.py
@@ -84,32 +84,27 @@ classifiers = [
 DESCRIPTION_TEMPLATE = """
 About {package_name}
 =============================================
-.. image:: https://img.shields.io/pypi/v/{package_name}.svg
-   :target: {pypi_url_target}
-.. image:: https://img.shields.io/pypi/pyversions/{package_name}.svg
-.. image:: https://img.shields.io/pypi/status/{package_name}.svg
+![package](https://img.shields.io/pypi/v/{package_name}.svg)]
+![versions](https://img.shields.io/pypi/pyversions/{package_name}.svg)]
+![status](https://img.shields.io/pypi/status/{package_name}.svg)]
 
 This package provides operators, sensors, and a hook to integrate [DataRobot](https://www.datarobot.com)
 into Apache Airflow. {extra_desc}
 
 This package is released under the terms of the DataRobot Tool and Utility Agreement, which
-can be found on our `Legal`_ page, along with our privacy policy and more.
+can be found on our [Legal](https://www.datarobot.com/legal/) page, along with our privacy policy and more.
 
 Installation
 =========================
 You must have a datarobot account.
 
-::
-
-   $ pip install {pip_package_name}
+```
+$ pip install {pip_package_name}
+```
 
 Bug Reporting and Q&A
 =========================
-To report issues or ask questions, send email to `the team <api-maintainer@datarobot.com>`_.
-
-.. _datarobot: https://datarobot.com
-.. _documentation: https://github.com/datarobot/airflow-provider-datarobot
-.. _legal: https://www.datarobot.com/legal/
+To report issues or ask questions, send email to [the team](mailto:api-maintainer@datarobot.com).
 """
 
 with open("datarobot_provider/_version.py") as fd:

--- a/setup.py
+++ b/setup.py
@@ -84,9 +84,9 @@ classifiers = [
 DESCRIPTION_TEMPLATE = """
 About {package_name}
 =============================================
-![package](https://img.shields.io/pypi/v/{package_name}.svg)]
-![versions](https://img.shields.io/pypi/pyversions/{package_name}.svg)]
-![status](https://img.shields.io/pypi/status/{package_name}.svg)]
+![package](https://img.shields.io/pypi/v/{package_name}.svg)
+![versions](https://img.shields.io/pypi/pyversions/{package_name}.svg)
+![status](https://img.shields.io/pypi/status/{package_name}.svg)
 
 This package provides operators, sensors, and a hook to integrate [DataRobot](https://www.datarobot.com)
 into Apache Airflow. {extra_desc}

--- a/setup_early_access.py
+++ b/setup_early_access.py
@@ -20,7 +20,7 @@ from setup import version
 version += datetime.today().strftime(".%Y.%m.%d")
 
 classifiers = [
-    "Development Status :: 4 - Preview",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "License :: Other/Proprietary License",

--- a/setup_early_access.py
+++ b/setup_early_access.py
@@ -36,6 +36,7 @@ classifiers = [
 
 # RELEASE SETUP
 package_name = "airflow_provider_datarobot_early_access"
+pip_package_name = "airflow-provider-datarobot-early-access"
 
 description = DESCRIPTION_TEMPLATE.format(
     package_name=package_name,
@@ -45,7 +46,7 @@ description = DESCRIPTION_TEMPLATE.format(
         " in production--you will expose yourself to risk of breaking changes and bugs.** For"
         " the most stable version, see https://pypi.org/project/airflow-provider-datarobot/."
     ),
-    pip_package_name=package_name,
+    pip_package_name=pip_package_name,
 )
 
 common_setup_kwargs.update(

--- a/setup_early_access.py
+++ b/setup_early_access.py
@@ -17,7 +17,7 @@ from setup import DESCRIPTION_TEMPLATE
 from setup import common_setup_kwargs
 from setup import version
 
-version += datetime.today().strftime(".%Y.%m.%d")
+version += datetime.today().strftime(".%Y%m%d%M")
 
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/setup_early_access.py
+++ b/setup_early_access.py
@@ -17,7 +17,7 @@ from setup import DESCRIPTION_TEMPLATE
 from setup import common_setup_kwargs
 from setup import version
 
-version += datetime.today().strftime(".%Y%m%d%M")
+version += datetime.today().strftime(".%Y.%m.%d")
 
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
This adds a new early access release pipeline with test as the default option here. Once this works ok, I'll create a separate mirror with `pypi` as the `BUILD_TYPE` which should formally release early access to pypi.

See the test build on test.pypi for the result of the pipeline running in test mode

## TestPyPi Build
https://test.pypi.org/project/airflow-provider-datarobot-early-access/