### PR TITLE
[MLDEV-1211] Add full Early Access release pipeline and update template for linter

### DIFF
--- a/.harness/build_and_publish_early_access_pypi.yaml
+++ b/.harness/build_and_publish_early_access_pypi.yaml
@@ -8,36 +8,9 @@ pipeline:
     - stage:
         name: Lint
         identifier: Lint
-        description: ""
-        type: CI
-        spec:
-          cloneCodebase: true
-          caching:
-            enabled: true
-          buildIntelligence:
-            enabled: true
-          infrastructure:
-            type: KubernetesDirect
-            spec:
-              connectorRef: account.cigeneral
-              namespace: harness-delegate-ng
-              automountServiceAccountToken: true
-              nodeSelector: {}
-              os: Linux
-          execution:
-            steps:
-              - step:
-                  type: Run
-                  name: lint check step
-                  identifier: lint_check_step
-                  spec:
-                    connectorRef: account.dockerhub_datarobot_read
-                    image: python:3.12
-                    shell: Bash
-                    command: |-
-                      set -exuo pipefail
-                      make req-dev
-                      make lint
+        template:
+          templateRef: Lint_Repo
+          versionLabel: "1"
     - stage:
         name: Publish to TestPypi
         identifier: Publish_to_TestPypi

--- a/.harness/release_early_access_pypi.yaml
+++ b/.harness/release_early_access_pypi.yaml
@@ -6,36 +6,10 @@ pipeline:
     - stage:
         name: Lint
         identifier: Lint
-        description: ""
-        type: CI
-        spec:
-          cloneCodebase: true
-          caching:
-            enabled: true
-          buildIntelligence:
-            enabled: true
-          infrastructure:
-            type: KubernetesDirect
-            spec:
-              connectorRef: account.cigeneral
-              namespace: harness-delegate-ng
-              automountServiceAccountToken: true
-              nodeSelector: {}
-              os: Linux
-          execution:
-            steps:
-              - step:
-                  type: Run
-                  name: lint check step
-                  identifier: lint_check_step
-                  spec:
-                    connectorRef: account.dockerhub_datarobot_read
-                    image: python:3.12
-                    shell: Bash
-                    command: |-
-                      set -exuo pipefail
-                      make req-dev
-                      make lint
+        template:
+          templateRef: Lint_Repo
+          versionLabel: "1"
+          gitBranch: mattn/MLDEV-1211-full-ea-pipeline
     - stage:
         name: Publish to Pypi
         identifier: Publish_to_Pypi

--- a/.harness/release_early_access_pypi.yaml
+++ b/.harness/release_early_access_pypi.yaml
@@ -38,7 +38,7 @@ pipeline:
                       make lint
     - stage:
         name: Publish to Pypi
-        identifier: Publish_to_TestPypi
+        identifier: Publish_to_Pypi
         template:
           templateRef: publish_early_access_to_pypi_or_testpypi
           versionLabel: "1"

--- a/.harness/release_early_access_pypi.yaml
+++ b/.harness/release_early_access_pypi.yaml
@@ -37,7 +37,7 @@ pipeline:
                       make req-dev
                       make lint
     - stage:
-        name: Publish to TestPypi
+        name: Publish to Pypi
         identifier: Publish_to_TestPypi
         template:
           templateRef: publish_early_access_to_pypi_or_testpypi
@@ -48,7 +48,7 @@ pipeline:
               - name: BUILD_TYPE
                 type: String
                 default: test
-                value: test
+                value: pypi
   properties:
     ci:
       codebase:

--- a/.harness/release_early_access_pypi.yaml
+++ b/.harness/release_early_access_pypi.yaml
@@ -1,0 +1,59 @@
+pipeline:
+  projectIdentifier: airflowproviderdatarobot
+  orgIdentifier: AGENTS
+  tags: {}
+  stages:
+    - stage:
+        name: Lint
+        identifier: Lint
+        description: ""
+        type: CI
+        spec:
+          cloneCodebase: true
+          caching:
+            enabled: true
+          buildIntelligence:
+            enabled: true
+          infrastructure:
+            type: KubernetesDirect
+            spec:
+              connectorRef: account.cigeneral
+              namespace: harness-delegate-ng
+              automountServiceAccountToken: true
+              nodeSelector: {}
+              os: Linux
+          execution:
+            steps:
+              - step:
+                  type: Run
+                  name: lint check step
+                  identifier: lint_check_step
+                  spec:
+                    connectorRef: account.dockerhub_datarobot_read
+                    image: python:3.12
+                    shell: Bash
+                    command: |-
+                      set -exuo pipefail
+                      make req-dev
+                      make lint
+    - stage:
+        name: Publish to TestPypi
+        identifier: Publish_to_TestPypi
+        template:
+          templateRef: publish_early_access_to_pypi_or_testpypi
+          versionLabel: "1"
+          templateInputs:
+            type: CI
+            variables:
+              - name: BUILD_TYPE
+                type: String
+                default: test
+                value: test
+  properties:
+    ci:
+      codebase:
+        connectorRef: account.svc_harness_git1
+        repoName: airflow-provider-datarobot
+        build: <+input>
+  identifier: releaseearlyaccesspypi
+  name: release-early-access-pypi

--- a/.harness/templates/lint.yaml
+++ b/.harness/templates/lint.yaml
@@ -1,0 +1,37 @@
+template:
+  name: Lint Repo
+  type: Stage
+  projectIdentifier: airflowproviderdatarobot
+  orgIdentifier: AGENTS
+  spec:
+    type: CI
+    spec:
+      cloneCodebase: true
+      caching:
+        enabled: true
+      buildIntelligence:
+        enabled: true
+      infrastructure:
+        type: KubernetesDirect
+        spec:
+          connectorRef: account.cigeneral
+          namespace: harness-delegate-ng
+          automountServiceAccountToken: true
+          nodeSelector: {}
+          os: Linux
+      execution:
+        steps:
+          - step:
+              type: Run
+              name: lint check step
+              identifier: lint_check_step
+              spec:
+                connectorRef: account.dockerhub_datarobot_read
+                image: python:3.12
+                shell: Bash
+                command: |-
+                  set -exuo pipefail
+                  make req-dev
+                  make lint
+  identifier: Lint_Repo
+  versionLabel: "1"


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
This is a clone of the `test` variant of the pipeline, but where the release attribute is set to `pypi`. This will release an early access build.

See https://github.com/datarobot/airflow-provider-datarobot/pull/140 for the test pipeline PR. I will hold off on actually executing this pipeline for now.

## Changes
- Add new release pipeline
- Convert `Lint repo` step to a template so that it can be re-used across all the release pipelines
- Update the test pypi early access pipeline to use the template