### PR TITLE
[DM-17020] Set upper limit on pip version (<24.1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,15 +22,18 @@ clean:  ## Clean up misc files like pytest and mypy cache for example
 	rm -rf build/* && rm -rf airflow_provider_datarobot_early_access.egg-info
 
 req: clean
-	pip install --upgrade pip setuptools
+	pip install --upgrade setuptools
+	pip install 'pip<24.1'
 	pip install -e .
 
 req-dev: clean
-	pip install --upgrade pip setuptools
+	pip install --upgrade setuptools
+	pip install 'pip<24.1'
 	pip install -e ".[dev]"
 
 req-dev-docs: clean
-	pip install --upgrade pip setuptools
+	pip install --upgrade setuptools
+	pip install 'pip<24.1'
 	pip install -e ".[dev,docs]"
 
 lint:


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Pip versions higher than 24.1 can't handle DataRobot package versions, e.g.:
```
WARNING: Ignoring version 2.2.3.post1+dr of pandas since it has invalid metadata:
Requested pandas>=0.15 from https://artifactory.devinfra.drdev.io/artifactory/api/pypi/python-all/pandas/pandas-2.2.3.post1%2Bdr-cp312-cp312-linux_x86_64.whl#sha256=fe795d91c90ad9fa658e5c74a8e3ae9bacd6a91d925b8efb6babdea232704dce (from datarobot>=3.6.1->airflow_provider_datarobot==0.0.13) has invalid metadata: Local version label can only be used with `==` or `!=` operators
    numpy>=1.26.4.post2+dr,<1.27
         ~~~~~~~~~~~~~~^
Please use pip<24.1 if you need to use this version.
```

Set an upper limit on the pip version install via `make req` so that we avoid this issue.


## Rationale
