### PR TITLE
[DM-17022] Default use case

### DIFF
--- a/datarobot_provider/example_dags/hospital_readmissions_example.py
+++ b/datarobot_provider/example_dags/hospital_readmissions_example.py
@@ -37,7 +37,7 @@ Configurable parameters for this dag:
 )
 def hospital_readmissions_example():
     # Create a Use Case to keep all subsequent assets. Default name is "Airflow"
-    create_use_case = GetOrCreateUseCaseOperator(task_id="create_use_case")
+    create_use_case = GetOrCreateUseCaseOperator(task_id="create_use_case", set_default=True)
 
     # Upload the data into Data Registry.
     upload_dataset = UploadDatasetOperator(task_id="upload_dataset")

--- a/datarobot_provider/example_dags/hospital_readmissions_example.py
+++ b/datarobot_provider/example_dags/hospital_readmissions_example.py
@@ -40,9 +40,7 @@ def hospital_readmissions_example():
     create_use_case = GetOrCreateUseCaseOperator(task_id="create_use_case")
 
     # Upload the data into Data Registry.
-    upload_dataset = UploadDatasetOperator(
-        task_id="upload_dataset", use_case_id=create_use_case.output
-    )
+    upload_dataset = UploadDatasetOperator(task_id="upload_dataset")
 
     # Define data preparation.
     create_recipe = CreateWranglingRecipeOperator(
@@ -106,7 +104,6 @@ def hospital_readmissions_example():
                 },
             },
         ],
-        use_case_id=create_use_case.output,
     )
 
     # Apply data preparation and save the modified data in the Data Registry.
@@ -114,14 +111,12 @@ def hospital_readmissions_example():
         task_id="publish_recipe",
         recipe_id=create_recipe.output,
         do_snapshot=True,
-        use_case_id=create_use_case.output,
     )
 
     # Create a new Project.
     create_project = CreateProjectOperator(
         task_id="create_project",
         dataset_id=publish_recipe.output,
-        use_case_id=create_use_case.output,
     )
 
     # Launch modeling autopilot.

--- a/datarobot_provider/example_dags/hospital_readmissions_example.py
+++ b/datarobot_provider/example_dags/hospital_readmissions_example.py
@@ -13,7 +13,7 @@ from datarobot_provider.operators.ai_catalog import CreateDatasetFromRecipeOpera
 from datarobot_provider.operators.ai_catalog import CreateWranglingRecipeOperator
 from datarobot_provider.operators.ai_catalog import UploadDatasetOperator
 from datarobot_provider.operators.datarobot import CreateProjectOperator
-from datarobot_provider.operators.datarobot import CreateUseCaseOperator
+from datarobot_provider.operators.datarobot import GetOrCreateUseCaseOperator
 from datarobot_provider.operators.datarobot import TrainModelsOperator
 from datarobot_provider.sensors.datarobot import AutopilotCompleteSensor
 
@@ -37,7 +37,7 @@ Configurable parameters for this dag:
 )
 def hospital_readmissions_example():
     # Create a Use Case to keep all subsequent assets. Default name is "Airflow"
-    create_use_case = CreateUseCaseOperator(task_id="create_use_case")
+    create_use_case = GetOrCreateUseCaseOperator(task_id="create_use_case")
 
     # Upload the data into Data Registry.
     upload_dataset = UploadDatasetOperator(

--- a/datarobot_provider/operators/ai_catalog.py
+++ b/datarobot_provider/operators/ai_catalog.py
@@ -609,13 +609,7 @@ class CreateWranglingRecipeOperator(BaseUseCaseEntityOperator):
             )
 
     def execute(self, context: Context) -> str:
-        if (use_case := self.get_use_case(context)) is None:
-            raise AirflowException(
-                "Recipe must belong to a Use Case. You must define one of:\n"
-                "*use_case_id* parameter in the operator\n"
-                "*use_case_id* DAG context parameter\n"
-                "`GetOrCreateUseCaseOperator(..., set_default=True)` as one of the previous DAG tasks"
-            )
+        use_case: dr.UseCase = self.get_use_case(context, required=True)  # type: ignore[assignment]
 
         if self.dataset_id:
             self.log.info("Working with dataset_id=%s", self.dataset_id)

--- a/datarobot_provider/operators/base_datarobot_operator.py
+++ b/datarobot_provider/operators/base_datarobot_operator.py
@@ -71,7 +71,7 @@ class BaseUseCaseEntityOperator(BaseDatarobotOperator):
     def get_use_case_id(self, context: Context, required=False) -> Optional[str]:
         """Get self.use_case_id or a default Use Case id defined at runtime.
         Raises an exception if no Use Case id is defined and required=True"""
-        if use_case_id := (self.use_case_id or self.xcom_pull(context, XCOM_DEFAULT_USE_CASE_ID)):
+        if use_case_id := (self.use_case_id or self.xcom_pull(context, key=XCOM_DEFAULT_USE_CASE_ID)):
             return use_case_id
 
         if required:

--- a/datarobot_provider/operators/base_datarobot_operator.py
+++ b/datarobot_provider/operators/base_datarobot_operator.py
@@ -63,6 +63,8 @@ class BaseUseCaseEntityOperator(BaseDatarobotOperator):
         if use_case_id := self.get_use_case_id(context):
             return dr.UseCase.get(use_case_id)
 
+        return None
+
     def get_use_case_id(self, context: Context) -> Optional[str]:
         return self.use_case_id or self.xcom_pull(context, XCOM_DEFAULT_USE_CASE_ID)
 

--- a/datarobot_provider/operators/base_datarobot_operator.py
+++ b/datarobot_provider/operators/base_datarobot_operator.py
@@ -8,20 +8,22 @@
 
 from typing import Any
 from typing import Optional
+from typing import Union
 
+import datarobot as dr
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.utils.context import Context
 
 from datarobot_provider.hooks.datarobot import DataRobotHook
 
+XCOM_DEFAULT_USE_CASE_ID = "default_use_case_id"
+
 
 class BaseDatarobotOperator(BaseOperator):
     ui_color = "#f4a460"
 
     dr_hook: DataRobotHook
-    min_version: Optional[str] = None
-    requires_early_access = False
 
     def pre_execute(self, context: Context):
         super().pre_execute(context)
@@ -41,3 +43,40 @@ class BaseDatarobotOperator(BaseOperator):
             raise AirflowException(
                 "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead"
             )
+
+
+class BaseUseCaseEntityOperator(BaseDatarobotOperator):
+    def __init__(
+        self, *, use_case_id: Optional[str] = "{{ params.use_case_id | default('') }}", **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if "use_case_id" not in self.template_fields:
+            raise AirflowException(
+                f"You must add use_case_id into {self.__class__.__name__} template_fields list "
+                "in order to use BaseUseCaseEntityOperator"
+            )
+
+        self.use_case_id = use_case_id
+
+    def get_use_case(self, context: Context) -> Optional[dr.UseCase]:
+        if use_case_id := self.get_use_case_id(context):
+            return dr.UseCase.get(use_case_id)
+
+    def get_use_case_id(self, context: Context) -> Optional[str]:
+        return self.use_case_id or self.xcom_pull(context, XCOM_DEFAULT_USE_CASE_ID)
+
+    def add_into_use_case(
+        self,
+        entity: Union[dr.Project, dr.Dataset, dr.models.Recipe, dr.Application],
+        *,
+        context: Context,
+    ):
+        if use_case := self.get_use_case(context):
+            use_case.add(entity)
+            self.log.info(
+                '%s is added into use case "%s"', entity.__class__.__name__, use_case.name
+            )
+
+        else:
+            self.log.info("The %s won't be added into any use case.", entity.__class__.__name__)

--- a/datarobot_provider/operators/datarobot.py
+++ b/datarobot_provider/operators/datarobot.py
@@ -14,14 +14,16 @@ from airflow.exceptions import AirflowFailException
 from airflow.utils.context import Context
 from strenum import StrEnum
 
+from datarobot_provider.operators.base_datarobot_operator import XCOM_DEFAULT_USE_CASE_ID
 from datarobot_provider.operators.base_datarobot_operator import BaseDatarobotOperator
+from datarobot_provider.operators.base_datarobot_operator import BaseUseCaseEntityOperator
 
 DATAROBOT_MAX_WAIT = 3600
 DATAROBOT_AUTOPILOT_TIMEOUT = 86400
 DATETIME_FORMAT = "%Y-%m-%d %H:%M:%s"
 
 
-class CreateUseCaseOperator(BaseDatarobotOperator):
+class GetOrCreateUseCaseOperator(BaseDatarobotOperator):
     """
     Creates a DataRobot Use Case.
 
@@ -43,6 +45,9 @@ class CreateUseCaseOperator(BaseDatarobotOperator):
 
         default: EXACT
 
+    set_default: bool
+        Set this Use Case as a default one for all subsequent tasks in the DAG.
+
     Returns
     -------
     str: DataRobot UseCase ID
@@ -63,12 +68,14 @@ class CreateUseCaseOperator(BaseDatarobotOperator):
         name: str = "{{ params.use_case_name | default('Airflow') }}",
         description: Optional[str] = "{{ params.use_case_description | default('') }}",
         reuse_policy: ReusePolicy = ReusePolicy.EXACT,
+        set_default: bool = False,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.name = name
         self.description = description
         self.reuse_policy = reuse_policy
+        self.set_default = set_default
 
     def execute(self, context: Context) -> Optional[str]:
         use_case = None
@@ -92,6 +99,9 @@ class CreateUseCaseOperator(BaseDatarobotOperator):
             self.log.info("Creating DataRobot Use Case")
             use_case = dr.UseCase.create(name=self.name, description=self.description)
             self.log.info(f"Use case created: use_case_id={use_case.id}")
+
+        if self.set_default:
+            self.xcom_push(context, XCOM_DEFAULT_USE_CASE_ID, use_case.id)
 
         return use_case.id
 
@@ -124,7 +134,7 @@ class CreateUseCaseOperator(BaseDatarobotOperator):
         return max(candidates, key=lambda x: x.created_at)
 
 
-class CreateProjectOperator(BaseDatarobotOperator):
+class CreateProjectOperator(BaseUseCaseEntityOperator):
     """
     Creates DataRobot project.
     :param dataset_id: DataRobot AI Catalog dataset ID
@@ -153,7 +163,6 @@ class CreateProjectOperator(BaseDatarobotOperator):
         dataset_id: Optional[str] = None,
         dataset_version_id: Optional[str] = None,
         credential_id: Optional[str] = None,
-        use_case_id: Optional[str] = "{{ params.use_case_id|default('') }}",
         recipe_id: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
@@ -161,14 +170,10 @@ class CreateProjectOperator(BaseDatarobotOperator):
         self.dataset_id = dataset_id
         self.dataset_version_id = dataset_version_id
         self.credential_id = credential_id
-        self.use_case_id = use_case_id
         self.recipe_id = recipe_id
 
     def execute(self, context: Context) -> Optional[str]:
-        use_case = None
-
-        if self.use_case_id:
-            use_case = dr.models.UseCase.get(self.use_case_id)
+        use_case = self.get_use_case(context)
 
         # Create DataRobot project
         self.log.info("Creating DataRobot project")

--- a/datarobot_provider/operators/datarobot.py
+++ b/datarobot_provider/operators/datarobot.py
@@ -101,6 +101,10 @@ class GetOrCreateUseCaseOperator(BaseDatarobotOperator):
             self.log.info(f"Use case created: use_case_id={use_case.id}")
 
         if self.set_default:
+            self.log.info(
+                'Set "%(name)s" (id=%(use_case_id)s) as a default Use Case.',
+                {'name': use_case.name, 'use_case_id': use_case.id},
+            )
             self.xcom_push(context, XCOM_DEFAULT_USE_CASE_ID, use_case.id)
 
         return use_case.id

--- a/datarobot_provider/operators/datarobot.py
+++ b/datarobot_provider/operators/datarobot.py
@@ -103,7 +103,7 @@ class GetOrCreateUseCaseOperator(BaseDatarobotOperator):
         if self.set_default:
             self.log.info(
                 'Set "%(name)s" (id=%(use_case_id)s) as a default Use Case.',
-                {'name': use_case.name, 'use_case_id': use_case.id},
+                {"name": use_case.name, "use_case_id": use_case.id},
             )
             self.xcom_push(context, XCOM_DEFAULT_USE_CASE_ID, use_case.id)
 
@@ -218,7 +218,9 @@ class CreateProjectOperator(BaseUseCaseEntityOperator):
 
         elif self.recipe_id is not None:
             project = dr.Project.create_from_recipe(
-                recipe_id=self.recipe_id, project_name=context["params"]["project_name"]
+                recipe_id=self.recipe_id,
+                project_name=context["params"]["project_name"],
+                use_case=use_case,
             )
             self.log.info(
                 f"Project created: project_id={project.id} from recipe: recipe_id={self.recipe_id}"  # type: ignore[attr-defined, unused-ignore]

--- a/datarobot_provider/operators/feature_discovery.py
+++ b/datarobot_provider/operators/feature_discovery.py
@@ -16,11 +16,12 @@ from airflow.utils.context import Context
 from datarobot import SNAPSHOT_POLICY
 
 from datarobot_provider.operators.base_datarobot_operator import BaseDatarobotOperator
+from datarobot_provider.operators.base_datarobot_operator import BaseUseCaseEntityOperator
 
 DATAROBOT_MAX_WAIT = 600
 
 
-class CreateFeatureDiscoveryRecipeOperator(BaseDatarobotOperator):
+class CreateFeatureDiscoveryRecipeOperator(BaseUseCaseEntityOperator):
     """
     Create a Feature Discovery recipe.
 
@@ -57,7 +58,6 @@ class CreateFeatureDiscoveryRecipeOperator(BaseDatarobotOperator):
         self,
         *,
         dataset_id: str,
-        use_case_id: str,
         dataset_definitions: Iterable[dict],
         relationships: Iterable[dict],
         feature_discovery_settings: Optional[Iterable[dict]] = None,
@@ -65,7 +65,6 @@ class CreateFeatureDiscoveryRecipeOperator(BaseDatarobotOperator):
     ) -> None:
         super().__init__(**kwargs)
         self.dataset_id = dataset_id
-        self.use_case_id = use_case_id
         self.dataset_definitions = dataset_definitions
         self.relationships = relationships
         self.feature_discovery_settings = feature_discovery_settings
@@ -74,7 +73,7 @@ class CreateFeatureDiscoveryRecipeOperator(BaseDatarobotOperator):
         response = dr.client.get_client().post(
             "/recipes/fromDataset/",
             data={
-                "useCaseId": self.use_case_id,
+                "useCaseId": self.get_use_case_id(context, required=True),
                 "status": "draft",
                 "datasetId": self.dataset_id,
                 "recipeType": "FEATURE_DISCOVERY",

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -316,3 +316,9 @@ def mock_airflow_connection_datarobot_jdbc(
         ),
     )
     mocker.patch.dict("os.environ", AIRFLOW_CONN_DATAROBOT_TEST_CONNECTION_JDBC_TEST=conn.get_uri())
+
+
+@pytest.fixture
+def xcom_context(mocker):
+    """A context-like object with xcom_pull patched to return None."""
+    return {"params": {}, "ti": mocker.Mock(xcom_pull=mocker.Mock(return_value=None))}

--- a/tests/unit/operators/test_base_datarobot_operator.py
+++ b/tests/unit/operators/test_base_datarobot_operator.py
@@ -1,3 +1,10 @@
+# Copyright 2022 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
 from unittest.mock import ANY
 
 import datarobot as dr

--- a/tests/unit/operators/test_base_datarobot_operator.py
+++ b/tests/unit/operators/test_base_datarobot_operator.py
@@ -1,0 +1,80 @@
+from unittest.mock import ANY
+
+import datarobot as dr
+import pytest
+from airflow.exceptions import AirflowException
+
+from datarobot_provider.operators.base_datarobot_operator import XCOM_DEFAULT_USE_CASE_ID
+from datarobot_provider.operators.base_datarobot_operator import BaseUseCaseEntityOperator
+
+
+@pytest.mark.parametrize(
+    "use_case_id, default_use_case_id, expected_use_case_id, is_pulled",
+    [
+        ("explicit-id", "xcom-id", "explicit-id", False),
+        ("", "xcom-id", "xcom-id", True),
+        (None, "xcom-id", "xcom-id", True),
+        ("", None, None, True),
+    ],
+)
+def test_base_use_case_entity_get_use_case_id(
+    xcom_context, use_case_id, default_use_case_id, expected_use_case_id, is_pulled
+):
+    xcom_context["ti"].xcom_pull.return_value = default_use_case_id
+    operator = BaseUseCaseEntityOperator(task_id="test-task-id", use_case_id=use_case_id)
+    actual_use_case_id = operator.get_use_case_id(xcom_context)
+
+    assert actual_use_case_id == expected_use_case_id
+    if is_pulled:
+        xcom_context["ti"].xcom_pull.assert_called_once_with(
+            task_ids=None,
+            dag_id=None,
+            include_prior_dates=None,
+            session=ANY,
+            key=XCOM_DEFAULT_USE_CASE_ID,
+        )
+
+    else:
+        assert not xcom_context["ti"].xcom_pull.called
+
+
+def test_base_use_case_entity_get_use_case_id_required(xcom_context):
+    operator = BaseUseCaseEntityOperator(task_id="test-task-id", use_case_id=None)
+    with pytest.raises(AirflowException, match="requires a Use Case"):
+        operator.get_use_case_id(xcom_context, required=True)
+
+
+def test_base_use_case_entity_get_use_case(mocker):
+    patched_use_case_get = mocker.patch.object(dr.UseCase, "get")
+    operator = BaseUseCaseEntityOperator(task_id="test-task-id", use_case_id="test-id")
+
+    use_case = operator.get_use_case({})
+
+    assert use_case == patched_use_case_get.return_value
+    patched_use_case_get.assert_called_once_with("test-id")
+
+
+def test_base_use_case_entity_add_into_use_case(mocker):
+    patched_get_use_case = mocker.patch.object(BaseUseCaseEntityOperator, "get_use_case")
+    entity = mocker.Mock()
+    context = {}
+
+    operator = BaseUseCaseEntityOperator(task_id="test-task-id", use_case_id="test-id")
+
+    operator.add_into_use_case(entity, context=context)
+
+    patched_get_use_case.assert_called_once_with(context)
+    patched_get_use_case.return_value.add.assert_called_once_with(entity)
+
+
+def test_base_use_case_entity_add_into_use_case_none(mocker):
+    patched_get_use_case = mocker.patch.object(
+        BaseUseCaseEntityOperator, "get_use_case", return_value=None
+    )
+    context = {}
+
+    operator = BaseUseCaseEntityOperator(task_id="test-task-id", use_case_id="test-id")
+
+    operator.add_into_use_case(mocker.Mock(), context=context)
+
+    patched_get_use_case.assert_called_once_with(context)


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

* Introduce a notion of a **default Use Case** for a DAG.
* Add a `BaseUseCaseEntityOperator` class
* Rename `CreateUseCaseOperator` into `GetOrCreateUseCaseOperator`

## Rationale

There are quite many DataRobot assets which have to belong to a UseCase. Define a default one in the very beginning of your DAG to avoid repetitive `use_case_id` parameters.  