### PR TITLE
[MLDEV-1175] Update packaging to only include `_experimental` when building early-access version of package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@
 # Released under the terms of DataRobot Tool and Utility Agreement.
 import re
 
+from setuptools import find_packages
 from setuptools import setup
 
 common_setup_kwargs = dict(
@@ -30,7 +31,6 @@ common_setup_kwargs = dict(
     packages=None,
     package_data={"airflow_provider_datarobot": ["py.typed"]},
     python_requires=">=3.9",
-    python_versions=">= 3.9",
     long_description=None,
     long_description_content_type="text/markdown",
     classifiers=None,
@@ -126,10 +126,12 @@ description = DESCRIPTION_TEMPLATE.format(
     pip_package_name=package_name,
 )
 
+packages = find_packages(exclude=["docs*", "tests*", "*_experimental*"])
+
 common_setup_kwargs.update(
     name=package_name,
     version=version,
-    packages=["datarobot_provider"],
+    packages=packages,
     long_description=description,
     classifiers=classifiers,
 )

--- a/setup_early_access.py
+++ b/setup_early_access.py
@@ -11,6 +11,7 @@
 # Released under the terms of DataRobot Tool and Utility Agreement.
 from datetime import datetime
 
+from setuptools import find_packages
 from setuptools import setup
 
 from setup import DESCRIPTION_TEMPLATE
@@ -49,10 +50,12 @@ description = DESCRIPTION_TEMPLATE.format(
     pip_package_name=pip_package_name,
 )
 
+packages = find_packages(exclude=["docs*", "tests*"])
+
 common_setup_kwargs.update(
     name=package_name,
     version=version,
-    packages=["datarobot_provider"],
+    packages=packages,
     long_description=description,
     classifiers=classifiers,
     install_requires=["apache-airflow>=2.3.0", "datarobot-early-access"],


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Update packaging that's used in build process

## Rationale

We need and want to exclude `_experimental` from _non_ early-access builds

## Changes
- Removed usage of unsupported `python_versions` - checked [docs. here](https://setuptools.pypa.io/en/latest/references/keywords.html) after seeing warning in build output about param
- Updated to use `find_packages()` - [docs here](https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#finding-simple-packages)

## Testing

Here's resulting directory output of command `make build-release` (and then the extracted version of the `.tar.gz`):

<img width="389" alt="Screenshot 2025-02-12 at 6 02 46 PM" src="https://github.com/user-attachments/assets/bfd83ceb-f65e-4bf7-ae5a-bac9dbdefbb2" />

<hr>

Here's resulting directory output of command `make build-early-access` (and then the extracted version of the `.tar.gz`):

<img width="421" alt="Screenshot 2025-02-12 at 6 07 39 PM" src="https://github.com/user-attachments/assets/ae1e4ee7-4997-444e-a697-b660dfe7f6c5" />
