### PR TITLE
[DM-16975] [DM-17066] Bump DataRobot client to 3.6.2 and apply relevant changes to Feature Discovery workflow

### DIFF
--- a/datarobot_provider/operators/feature_discovery.py
+++ b/datarobot_provider/operators/feature_discovery.py
@@ -85,7 +85,7 @@ class CreateFeatureDiscoveryRecipeOperator(BaseUseCaseEntityOperator):
                 dataset_definition["catalogVersionId"] = secondary_dataset.version_id
 
         recipe_id = recipe.id
-        recipe_config_id = recipe.settings.relationships_configuration_id
+        recipe_config_id = recipe.settings.relationships_configuration_id  # type: ignore[union-attr]
 
         # Add secondary dataset configuration information into the Recipe config
         dr.RelationshipsConfiguration(recipe_config_id).replace(

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ common_setup_kwargs = dict(
     long_description=None,
     long_description_content_type="text/markdown",
     classifiers=None,
-    install_requires=["apache-airflow>=2.6.0", "datarobot>=3.6.1"],
+    install_requires=["apache-airflow>=2.6.0", "datarobot>=3.6.2"],
     entry_points={
         "apache_airflow_provider": [
             "provider_info = datarobot_provider.__init__:get_provider_info",

--- a/tests/unit/operators/test_feature_discovery.py
+++ b/tests/unit/operators/test_feature_discovery.py
@@ -9,6 +9,7 @@
 import datarobot as dr
 import pytest
 
+from datarobot_provider.operators.base_datarobot_operator import BaseUseCaseEntityOperator
 from datarobot_provider.operators.feature_discovery import CreateFeatureDiscoveryRecipeOperator
 from datarobot_provider.operators.feature_discovery import DatasetDefinitionOperator
 from datarobot_provider.operators.feature_discovery import DatasetRelationshipOperator
@@ -152,16 +153,19 @@ def test_dataset_relationship_operator(relationships):
 def test_create_feature_discovery_recipe(
     mocker, dataset_definitions, relationships, feature_discovery_settings, remove_version_id
 ):
-    mock_client_response = mocker.Mock(status_code=201)
-    mock_client_response.json.return_value = {
-        "id": "recipe_id",
-        "settings": {"relationshipsConfigurationId": "recipe_config_id"},
-    }
-    mock_client = mocker.Mock()
-    mock_client.post.return_value = mock_client_response
-    get_client_mock = mocker.patch.object(dr.client, "get_client", return_value=mock_client)
-    mock_dataset = mocker.Mock(version_id="replace-version-id")
-    mocker.patch.object(dr.Dataset, "get", return_value=mock_dataset)
+    recipe_settings_mock = mocker.Mock(relationships_configuration_id="recipe_config_id")
+    recipe_mock = mocker.Mock(id="recipe_id", settings=recipe_settings_mock)
+    create_recipe_mock = mocker.patch.object(
+        dr.models.Recipe, "from_dataset", return_value=recipe_mock
+    )
+    dataset_mock = mocker.Mock(version_id="version-id")
+    mocker.patch.object(
+        dr.Dataset, "get", return_value=dataset_mock
+    )
+    use_case_mock = mocker.Mock()
+    mocker.patch.object(
+        BaseUseCaseEntityOperator, "get_use_case", return_value=use_case_mock
+    )
 
     replace_config_mock = mocker.patch.object(dr.RelationshipsConfiguration, "replace")
 
@@ -181,14 +185,10 @@ def test_create_feature_discovery_recipe(
 
     operator_result = operator.execute(context={"params": {}})
 
-    mock_client.post.assert_called_once_with(
-        "/recipes/fromDataset/",
-        data={
-            "useCaseId": "use_case_id",
-            "status": "draft",
-            "datasetId": "dataset_id",
-            "recipeType": "FEATURE_DISCOVERY",
-        },
+    create_recipe_mock.assert_called_once_with(
+        use_case_mock,
+        dataset_mock,
+        recipe_type="FEATURE_DISCOVERY",
     )
 
     expected_dataset_definitions = dataset_definitions
@@ -196,7 +196,6 @@ def test_create_feature_discovery_recipe(
         for d in expected_dataset_definitions:
             d["catalogVersionId"] = "replace-version-id"
 
-    get_client_mock.assert_called_once()
     replace_config_mock.assert_called_once_with(
         expected_dataset_definitions, relationships, feature_discovery_settings
     )

--- a/tests/unit/operators/test_feature_discovery.py
+++ b/tests/unit/operators/test_feature_discovery.py
@@ -159,13 +159,9 @@ def test_create_feature_discovery_recipe(
         dr.models.Recipe, "from_dataset", return_value=recipe_mock
     )
     dataset_mock = mocker.Mock(version_id="version-id")
-    mocker.patch.object(
-        dr.Dataset, "get", return_value=dataset_mock
-    )
+    mocker.patch.object(dr.Dataset, "get", return_value=dataset_mock)
     use_case_mock = mocker.Mock()
-    mocker.patch.object(
-        BaseUseCaseEntityOperator, "get_use_case", return_value=use_case_mock
-    )
+    mocker.patch.object(BaseUseCaseEntityOperator, "get_use_case", return_value=use_case_mock)
 
     replace_config_mock = mocker.patch.object(dr.RelationshipsConfiguration, "replace")
 


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
We've just release another minor patch to the python client which enables several fixes to workarounds that were originally used for the Feature Discoery workflow.
This PR bumps the client to 3.6.2 and applies the relevant Feature Discovery changes.

## Rationale
