### PR TITLE
[MLDEV-1224] Fix input param in example dataset

### DIFF
--- a/datarobot_provider/example_dags/hospital_readmissions_example.py
+++ b/datarobot_provider/example_dags/hospital_readmissions_example.py
@@ -134,7 +134,7 @@ def hospital_readmissions_example():
     select_best_model = SelectBestModelOperator(
         task_id="select_best_model",
         project_id=create_project.output,
-        metric="readmitted",
+        metric="RMSE",
     )
     # register model
     register_model = CreateRegisteredModelVersionOperator(


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
This param has to be defined as a metric for the project (e.g. RMSE, MSE, etc...). This fixes the dag so it runs in the test environments now.

We do need to probably add some better testing around this concept to ensure the example DAGs are fully working, but this is a bit of a challenging task and we're trying to sort this out as part of `MLDEV-1223` (currently in progress).
