### PR TITLE
[CFX-1590] More mypy updates including ignoring autogen and experimental example DAGs

### DIFF
--- a/datarobot_provider/__init__.py
+++ b/datarobot_provider/__init__.py
@@ -5,7 +5,31 @@
 # This is proprietary source code of DataRobot, Inc. and its affiliates.
 #
 # Released under the terms of DataRobot Tool and Utility Agreement.
-def get_provider_info():
+from typing import TypedDict
+
+ConnectionType = TypedDict(
+    "ConnectionType",
+    {
+        "hook-class-name": str,
+        "connection-type": str,
+    },
+)
+
+
+ProviderInfoType = TypedDict(
+    "ProviderInfoType",
+    {
+        "package-name": str,
+        "name": str,
+        "description": str,
+        "versions": list[str],
+        "connection-types": list[ConnectionType],
+        "extra-links": list[str],
+    },
+)
+
+
+def get_provider_info() -> ProviderInfoType:
     return {
         "package-name": "airflow-provider-datarobot",
         "name": "DataRobot Airflow Provider",

--- a/datarobot_provider/autogen/generate_operator.py
+++ b/datarobot_provider/autogen/generate_operator.py
@@ -244,7 +244,7 @@ parser.add_argument("--whitelist", type=str, help="Whitelist file path")
 parser.add_argument("--output_folder", type=str, help="Output folder path")
 
 
-def to_snake_case(camel_case_str):
+def to_snake_case(camel_case_str: str) -> str:
     return "".join(["_" + i.lower() if i.isupper() else i for i in camel_case_str]).lstrip("_")
 
 

--- a/datarobot_provider/hooks/connections.py
+++ b/datarobot_provider/hooks/connections.py
@@ -6,6 +6,7 @@
 #
 # Released under the terms of DataRobot Tool and Utility Agreement.
 from typing import Any
+from typing import Tuple
 
 from airflow.exceptions import AirflowException
 from datarobot import Credential
@@ -159,7 +160,7 @@ class JDBCDataSourceHook(BasicCredentialsHook):
         # get or create DataStore object updated with actual parameters
         return self.get_conn()
 
-    def test_connection(self):
+    def test_connection(self) -> Tuple[bool, str]:
         """Test DataRobot connection to JDBC DataSource"""
         try:
             _, credential_data, data_store = self.run()

--- a/datarobot_provider/hooks/credentials.py
+++ b/datarobot_provider/hooks/credentials.py
@@ -9,6 +9,7 @@
 import json
 from typing import Any
 from typing import Optional
+from typing import Tuple
 from typing import Union
 
 from airflow.exceptions import AirflowException
@@ -112,7 +113,7 @@ class CredentialsBaseHook(BaseHook):
         # get Credentials with credential_data
         return self.get_conn()
 
-    def test_connection(self):
+    def test_connection(self) -> Tuple[bool, str]:
         """Test that we can create DataRobot Credentials without errors"""
         try:
             credential, _ = self.run()

--- a/datarobot_provider/hooks/datarobot.py
+++ b/datarobot_provider/hooks/datarobot.py
@@ -6,6 +6,7 @@
 #
 # Released under the terms of DataRobot Tool and Utility Agreement.
 from typing import Any
+from typing import Tuple
 
 from airflow import __version__ as AIRFLOW_VERSION
 from airflow.exceptions import AirflowException
@@ -80,7 +81,7 @@ class DataRobotHook(BaseHook):
 
         # Creating version-specific user agent suffix for collecting usage statistics and troubleshoot purposes:
         provider_package_name = get_provider_info().get("package-name")
-        provider_versions = "".join(get_provider_info().get("versions"))
+        provider_versions = "".join(get_provider_info()["versions"])
         user_agent_suffix = "{}-{}-airflow-{}".format(
             provider_package_name, provider_versions, AIRFLOW_VERSION
         )
@@ -91,7 +92,7 @@ class DataRobotHook(BaseHook):
         # Initialize DataRobot client
         return self.get_conn()
 
-    def test_connection(self):
+    def test_connection(self) -> Tuple[bool, str]:
         """Test HTTP Connection"""
         try:
             self.run()

--- a/datarobot_provider/operators/ai_catalog.py
+++ b/datarobot_provider/operators/ai_catalog.py
@@ -87,7 +87,7 @@ class UploadDatasetOperator(BaseUseCaseEntityOperator):
 
         return ai_catalog_dataset.id
 
-    def _file_path_param_is_deprecated(self):
+    def _file_path_param_is_deprecated(self) -> None:
         self.log.warning(
             "**file_path_param** is deprecated. "
             f"Use `file_path={{{{ params.{self.file_path_param} }}}}` instead."
@@ -608,7 +608,7 @@ class CreateWranglingRecipeOperator(BaseUseCaseEntityOperator):
         self.downsampling_directive = downsampling_directive
         self.downsampling_arguments = downsampling_arguments
 
-    def validate(self):
+    def validate(self) -> None:
         if self.dataset_id and self.data_store_id:
             raise AirflowException(
                 "You have to specify either dataset_id or data_store_id. Not both."

--- a/datarobot_provider/operators/base_datarobot_operator.py
+++ b/datarobot_provider/operators/base_datarobot_operator.py
@@ -33,7 +33,7 @@ class BaseDatarobotOperator(BaseOperator):
 
         self.validate()
 
-    def validate(self):
+    def validate(self) -> None:
         """Implement your validation of rendered operator fields here."""
 
     def __init__(self, *, datarobot_conn_id: str = "datarobot_default", **kwargs: Any):
@@ -54,7 +54,7 @@ class BaseUseCaseEntityOperator(BaseDatarobotOperator):
     """
 
     @classmethod
-    def __init_subclass__(cls, **kwargs):
+    def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
         if "use_case_id" not in cls.template_fields:
             cls.template_fields = (*cls.template_fields, "use_case_id")

--- a/datarobot_provider/operators/custom_models.py
+++ b/datarobot_provider/operators/custom_models.py
@@ -298,7 +298,7 @@ class CreateCustomModelVersionOperator(BaseDatarobotOperator):
         self.create_from_previous = create_from_previous
         self.max_wait_sec = max_wait_sec
 
-    def validate(self):
+    def validate(self) -> None:
         if self.custom_model_id is None:
             raise ValueError(
                 "custom_model_id is required attribute for CreateCustomModelVersionOperator"
@@ -398,7 +398,7 @@ class CustomModelTestOperator(BaseDatarobotOperator):
         self.dataset_id = dataset_id
         self.max_wait_sec = max_wait_sec
 
-    def validate(self):
+    def validate(self) -> None:
         if self.custom_model_id is None:
             raise ValueError("custom_model_id is required attribute")
 
@@ -444,7 +444,7 @@ class GetCustomModelTestOverallStatusOperator(BaseDatarobotOperator):
         super().__init__(**kwargs)
         self.custom_model_test_id = custom_model_test_id
 
-    def validate(self):
+    def validate(self) -> None:
         if self.custom_model_test_id is None:
             raise ValueError("custom_model_test_id is required attribute")
 
@@ -505,7 +505,7 @@ class CreateCustomModelDeploymentOperator(BaseDatarobotOperator):
         self.importance = importance
         self.max_wait_sec = max_wait_sec
 
-    def validate(self):
+    def validate(self) -> None:
         if self.custom_model_version_id is None:
             raise ValueError("Invalid or missing `custom_model_version_id` value")
 

--- a/datarobot_provider/operators/deployment.py
+++ b/datarobot_provider/operators/deployment.py
@@ -184,7 +184,7 @@ class GetDeploymentStatusOperator(BaseDatarobotOperator):
         super().__init__(**kwargs)
         self.deployment_id = deployment_id
 
-    def validate(self):
+    def validate(self) -> None:
         if not self.deployment_id:
             raise ValueError("Invalid or missing `deployment_id` value")
 
@@ -234,7 +234,7 @@ class ReplaceModelOperator(BaseDatarobotOperator):
         self.reason = reason
         self.max_wait_sec = max_wait_sec
 
-    def validate(self):
+    def validate(self) -> None:
         if self.deployment_id is None:
             raise AirflowFailException("deployment_id must be provided")
 
@@ -396,7 +396,7 @@ class ActivateDeploymentOperator(BaseDatarobotOperator):
         self.activate = activate
         self.max_wait_sec = max_wait_sec
 
-    def validate(self):
+    def validate(self) -> None:
         if self.deployment_id is None:
             raise ValueError("Invalid or missing `deployment_id` value")
 

--- a/datarobot_provider/operators/mlops.py
+++ b/datarobot_provider/operators/mlops.py
@@ -36,7 +36,7 @@ class SubmitActualsFromCatalogOperator(BaseDatarobotOperator):
         self.dataset_id = dataset_id
         self.dataset_version_id = dataset_version_id
 
-    def validate(self):
+    def validate(self) -> None:
         if self.deployment_id is None:
             raise ValueError("deployment_id is required to submit actuals.")
 

--- a/datarobot_provider/operators/model_insights.py
+++ b/datarobot_provider/operators/model_insights.py
@@ -45,7 +45,7 @@ class ComputeFeatureImpactOperator(BaseDatarobotOperator):
         self.project_id = project_id
         self.model_id = model_id
 
-    def validate(self):
+    def validate(self) -> None:
         if not self.project_id:
             raise ValueError("project_id is required to compute Feature Impact.")
 
@@ -92,7 +92,7 @@ class ComputeFeatureEffectsOperator(BaseDatarobotOperator):
         self.project_id = project_id
         self.model_id = model_id
 
-    def validate(self):
+    def validate(self) -> None:
         if not self.project_id:
             raise ValueError("project_id is required to compute Feature Effects.")
 
@@ -139,7 +139,7 @@ class ComputeShapOperator(BaseDatarobotOperator):
         self.project_id = project_id
         self.model_id = model_id
 
-    def validate(self):
+    def validate(self) -> None:
         if self.project_id is None:
             raise ValueError("project_id is required to compute SHAP impact.")
 

--- a/datarobot_provider/operators/model_package.py
+++ b/datarobot_provider/operators/model_package.py
@@ -182,7 +182,7 @@ class DeployModelPackageOperator(BaseDatarobotOperator):
             e_msg = "Server unexpectedly returned status code {}"
             raise AirflowFailException(e_msg.format(response.status_code))
 
-    def validate(self):
+    def validate(self) -> None:
         if self.deployment_name is None:
             raise ValueError("deployment_name is required.")
 

--- a/datarobot_provider/operators/model_predictions.py
+++ b/datarobot_provider/operators/model_predictions.py
@@ -59,7 +59,7 @@ class AddExternalDatasetOperator(BaseDatarobotOperator):
         self.dataset_version_id = dataset_version_id
         self.max_wait_sec = max_wait_sec
 
-    def validate(self):
+    def validate(self) -> None:
         if self.project_id is None:
             raise ValueError("project_id is required to add external dataset.")
 
@@ -118,7 +118,7 @@ class RequestModelPredictionsOperator(BaseDatarobotOperator):
         self.model_id = model_id
         self.external_dataset_id = external_dataset_id
 
-    def validate(self):
+    def validate(self) -> None:
         if self.project_id is None:
             raise ValueError("project_id is required to compute model predictions.")
 

--- a/datarobot_provider/operators/model_training.py
+++ b/datarobot_provider/operators/model_training.py
@@ -58,7 +58,7 @@ class TrainModelOperator(BaseDatarobotOperator):
         self.featurelist_id = featurelist_id
         self.source_project_id = source_project_id
 
-    def validate(self):
+    def validate(self) -> None:
         if not self.project_id:
             raise ValueError("project_id is required.")
 
@@ -120,7 +120,7 @@ class RetrainModelOperator(BaseDatarobotOperator):
         self.model_id = model_id
         self.featurelist_id = featurelist_id
 
-    def validate(self):
+    def validate(self) -> None:
         if self.project_id is None:
             raise ValueError("project_id is required.")
 

--- a/datarobot_provider/operators/prediction_explanations.py
+++ b/datarobot_provider/operators/prediction_explanations.py
@@ -47,7 +47,7 @@ class PredictionExplanationsInitializationOperator(BaseDatarobotOperator):
         self.project_id = project_id
         self.model_id = model_id
 
-    def validate(self):
+    def validate(self) -> None:
         if self.project_id is None:
             raise ValueError(
                 "project_id is required to trigger a prediction explanations initialization."
@@ -104,7 +104,7 @@ class ComputePredictionExplanationsOperator(BaseDatarobotOperator):
         self.model_id = model_id
         self.external_dataset_id = external_dataset_id
 
-    def validate(self):
+    def validate(self) -> None:
         if self.project_id is None:
             raise ValueError("project_id is required to compute prediction explanations.")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,3 +62,10 @@ warn_unused_configs = true
 warn_unused_ignores = true
 show_error_codes = true
 pretty = true
+
+[[tool.mypy.overrides]]
+module = [
+    "datarobot_provider.autogen.*",
+    "datarobot_provider._experimental.example_dags.*"
+]
+ignore_errors = true


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Adding very small set of type annotations as a follow up to:
https://github.com/datarobot/airflow-provider-datarobot/pull/158

Also ignoring for autogen and example DAGs in the _experimental directory

## Rationale

Wanted to do one follow up contribution to some easy, low-hanging fruit for typing in the repo.

I'll call it here though - especially since the rest of the errors I see when turning rules on seem like each team/domain may have a more specific understanding of how to annotate.