### PR TITLE
[MLDEV-1225] Update and tag version 0.1.0 for release to pypi with P0 example DAG

### DIFF
--- a/.harness/release_pypi.yaml
+++ b/.harness/release_pypi.yaml
@@ -49,6 +49,19 @@ pipeline:
                     isAutoRejectEnabled: false
                     approverInputs: []
         tags: {}
+    - stage:
+        name: Publish Release to Pypi
+        identifier: Publish_Release_to_Pypi
+        template:
+          templateRef: publish_early_access_to_pypi_or_testpypi
+          versionLabel: "1"
+          templateInputs:
+            type: CI
+            variables:
+              - name: BUILD_TYPE
+                type: String
+                default: test-early-access
+                value: pypi
   properties:
     ci:
       codebase:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.1.0
 
 ### New features
 - Introduce `CreateRegisteredModelVersionOperator <datarobot_provider.operators.CreateRegisteredModelVersionOperator>`

--- a/datarobot_provider/__init__.py
+++ b/datarobot_provider/__init__.py
@@ -10,7 +10,7 @@ def get_provider_info():
         "package-name": "airflow-provider-datarobot",
         "name": "DataRobot Airflow Provider",
         "description": "DataRobot Airflow provider.",
-        "versions": ["0.0.14"],
+        "versions": ["0.1.0"],
         "connection-types": [
             {
                 "hook-class-name": "datarobot_provider.hooks.datarobot.DataRobotHook",

--- a/datarobot_provider/_version.py
+++ b/datarobot_provider/_version.py
@@ -9,4 +9,4 @@
 # affiliates.
 #
 # Released under the terms of DataRobot Tool and Utility Agreement.
-__version__ = "0.0.14"
+__version__ = "0.1.0"


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
- Update the release pipeline to enable `pypi release`.
- Bump the tag version to 0.1.0 for this initial alpha release (plan is currently that the 11.0 final release will be v1.0.0).
- Make current changelog indicate 0.1.0 instead of unreleased.
