### PR TITLE
[DM-17115] Remove use of `use_feature_discovery` as input

### DIFF
--- a/datarobot_provider/operators/datarobot.py
+++ b/datarobot_provider/operators/datarobot.py
@@ -201,7 +201,6 @@ class CreateProjectOperator(BaseUseCaseEntityOperator):
             )
             self.log.info(f"Project created: project_id={project.id} from local file")
             project.unsupervised_mode = context["params"].get("unsupervised_mode")
-            project.use_feature_discovery = context["params"].get("use_feature_discovery")
             project.unlock_holdout()
             return project.id
         elif self.dataset_id is not None or "training_dataset_id" in context["params"]:


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
The `use_feature_discovery` parameter isn't an input option, but is instead used as an indicator of whether Feature Discovery was run **after** a project completes. Updated to remove the use of this parameter as an input via the context - this step has no effect and might mislead customers.

## Rationale
