### PR TITLE
[CFX-1605] DR AF Provider - Remove declared python 3.13 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,6 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
 ]
 
 DESCRIPTION_TEMPLATE = """

--- a/setup_early_access.py
+++ b/setup_early_access.py
@@ -32,7 +32,6 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
 ]
 
 # RELEASE SETUP


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Trying to pip install our package in a 3.13 virtual env fails:
`Collecting google-re2>=1.0 (from apache-airflow>=2.6.0->airflow-provider-datarobot)`

![Screenshot 2025-02-17 at 4 28 21 PM](https://github.com/user-attachments/assets/3fbb1b89-026b-4c14-a4d1-18e7ac5fa36a)


## Rationale

Looks like there's a known issue here:
https://github.com/google/re2/issues/516?email_source=slack

And also apache-airflow only declares support up to 3.12:
https://pypi.org/project/apache-airflow/
<img width="496" alt="Screenshot 2025-02-18 at 8 33 10 AM" src="https://github.com/user-attachments/assets/47b50667-45e3-4361-808b-5392c2073754" />
