### PR TITLE
[CFX-1606] Add more project URLs that show in pypi - importantly the bug tracker

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,8 @@ common_setup_kwargs = dict(
     project_urls={
         "Documentation": "https://github.com/datarobot/airflow-provider-datarobot/",
         "Changelog": "https://github.com/datarobot/airflow-provider-datarobot/blob/main/CHANGES.md",
+        "Bug Tracker": "https://github.com/datarobot/airflow-provider-datarobot/issues",
+        "Source Code": "https://github.com/datarobot/airflow-provider-datarobot",
     },
     license="DataRobot Tool and Utility Agreement",
     packages=None,


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Add two new URLs

## Rationale

We should direct users to a specific place in order to report/search for/track bugs and issues

Also added a (somewhat redundant) source code URL

## Screenshots

Currently our entry looks like this:
https://pypi.org/project/airflow-provider-datarobot/

<img width="246" alt="Screenshot 2025-02-18 at 9 38 46 AM" src="https://github.com/user-attachments/assets/2d0f67c5-6ff2-4f98-b134-a650da50092d" />

<hr>

We'd like (IMHO) it to look more like apache-airflow's:
https://pypi.org/project/apache-airflow/

<img width="317" alt="Screenshot 2025-02-18 at 9 39 24 AM" src="https://github.com/user-attachments/assets/654fb006-f401-4ce0-98bd-319539b6cf0c" />
