### PR TITLE
[CFX-1510] Use constants where appropriate

### DIFF
--- a/datarobot_provider/autogen/generate_operator.py
+++ b/datarobot_provider/autogen/generate_operator.py
@@ -105,6 +105,7 @@ class GenerateOperators:
             ("Context", "from airflow.utils.context import Context"),
             (f"from {module_key} import {module_obj_key}",),
             ("",),
+            ("DATAROBOT_CONN_ID", "from datarobot_provider.constants import DATAROBOT_CONN_ID"),
             ("DataRobotHook", "from datarobot_provider.hooks.datarobot import DataRobotHook"),
         ]
         actual_imports = []
@@ -189,7 +190,7 @@ class GenerateOperators:
         op_init = "\tdef __init__(self,*,"
         for param in docstring["Parameters"]:
             op_init += f"{param.name}: Optional[{param.type}] = None,"
-        op_init += 'datarobot_conn_id: str = "datarobot_default",\n'
+        op_init += "datarobot_conn_id: str = DATAROBOT_CONN_ID,\n"
         op_init += "**kwargs: Any) -> None:\n"
         op_init += "\t\tsuper().__init__(**kwargs)\n"
         for param in docstring["Parameters"]:

--- a/datarobot_provider/constants.py
+++ b/datarobot_provider/constants.py
@@ -8,3 +8,5 @@
 
 
 DATAROBOT_CONN_ID = "datarobot_default"
+
+XCOM_DEFAULT_USE_CASE_ID = "default_use_case_id"

--- a/datarobot_provider/hooks/datarobot.py
+++ b/datarobot_provider/hooks/datarobot.py
@@ -15,6 +15,7 @@ from datarobot.client import Client
 from datarobot.rest import RESTClientObject
 
 from datarobot_provider import get_provider_info
+from datarobot_provider.constants import DATAROBOT_CONN_ID
 
 
 class DataRobotHook(BaseHook):
@@ -26,7 +27,7 @@ class DataRobotHook(BaseHook):
     """
 
     conn_name_attr = "datarobot_conn_id"
-    default_conn_name = "datarobot_default"
+    default_conn_name = DATAROBOT_CONN_ID
     conn_type = "http"
     hook_name = "DataRobot"
 

--- a/datarobot_provider/operators/base_datarobot_operator.py
+++ b/datarobot_provider/operators/base_datarobot_operator.py
@@ -15,9 +15,9 @@ from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.utils.context import Context
 
+from datarobot_provider.constants import DATAROBOT_CONN_ID
+from datarobot_provider.constants import XCOM_DEFAULT_USE_CASE_ID
 from datarobot_provider.hooks.datarobot import DataRobotHook
-
-XCOM_DEFAULT_USE_CASE_ID = "default_use_case_id"
 
 
 class BaseDatarobotOperator(BaseOperator):
@@ -36,7 +36,7 @@ class BaseDatarobotOperator(BaseOperator):
     def validate(self) -> None:
         """Implement your validation of rendered operator fields here."""
 
-    def __init__(self, *, datarobot_conn_id: str = "datarobot_default", **kwargs: Any):
+    def __init__(self, *, datarobot_conn_id: str = DATAROBOT_CONN_ID, **kwargs: Any):
         super().__init__(**kwargs)
         self.datarobot_conn_id = datarobot_conn_id
         if kwargs.get("xcom_push") is not None:

--- a/datarobot_provider/operators/gen/modeljob/model_job_get_operator.py
+++ b/datarobot_provider/operators/gen/modeljob/model_job_get_operator.py
@@ -13,6 +13,7 @@ from airflow.models import BaseOperator
 from airflow.utils.context import Context
 from datarobot.models.modeljob import ModelJob
 
+from datarobot_provider.constants import DATAROBOT_CONN_ID
 from datarobot_provider.hooks.datarobot import DataRobotHook
 
 
@@ -37,7 +38,7 @@ class ModelJobGetOperator(BaseOperator):
         *,
         project_id: Optional[str] = None,
         model_job_id: Optional[str] = None,
-        datarobot_conn_id: str = "datarobot_default",
+        datarobot_conn_id: str = DATAROBOT_CONN_ID,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)

--- a/datarobot_provider/sensors/client.py
+++ b/datarobot_provider/sensors/client.py
@@ -13,6 +13,7 @@ from airflow.utils.context import Context
 from datarobot.errors import AsyncProcessUnsuccessfulError
 from datarobot.models.status_check_job import StatusCheckJob
 
+from datarobot_provider.constants import DATAROBOT_CONN_ID
 from datarobot_provider.hooks.datarobot import DataRobotHook
 
 
@@ -33,7 +34,7 @@ class BaseAsyncResolutionSensor(BaseSensorOperator):
         self,
         *,
         job_id: str,
-        datarobot_conn_id: str = "datarobot_default",
+        datarobot_conn_id: str = DATAROBOT_CONN_ID,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)

--- a/datarobot_provider/sensors/datarobot.py
+++ b/datarobot_provider/sensors/datarobot.py
@@ -12,6 +12,7 @@ from airflow.sensors.base import BaseSensorOperator
 from airflow.utils.context import Context
 from datarobot.errors import AsyncProcessUnsuccessfulError
 
+from datarobot_provider.constants import DATAROBOT_CONN_ID
 from datarobot_provider.hooks.datarobot import DataRobotHook
 
 
@@ -34,7 +35,7 @@ class AutopilotCompleteSensor(BaseSensorOperator):
         self,
         *,
         project_id: str,
-        datarobot_conn_id: str = "datarobot_default",
+        datarobot_conn_id: str = DATAROBOT_CONN_ID,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -73,7 +74,7 @@ class ScoringCompleteSensor(BaseSensorOperator):
         self,
         *,
         job_id: str,
-        datarobot_conn_id: str = "datarobot_default",
+        datarobot_conn_id: str = DATAROBOT_CONN_ID,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)

--- a/datarobot_provider/sensors/model_insights.py
+++ b/datarobot_provider/sensors/model_insights.py
@@ -14,6 +14,7 @@ from airflow.utils.context import Context
 from datarobot import Job
 from datarobot.errors import AsyncProcessUnsuccessfulError
 
+from datarobot_provider.constants import DATAROBOT_CONN_ID
 from datarobot_provider.hooks.datarobot import DataRobotHook
 
 
@@ -39,7 +40,7 @@ class DataRobotJobSensor(BaseSensorOperator):
         *,
         project_id: str,
         job_id: str,
-        datarobot_conn_id: str = "datarobot_default",
+        datarobot_conn_id: str = DATAROBOT_CONN_ID,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)

--- a/datarobot_provider/sensors/monitoring_job.py
+++ b/datarobot_provider/sensors/monitoring_job.py
@@ -12,6 +12,7 @@ from airflow.sensors.base import BaseSensorOperator
 from airflow.utils.context import Context
 from datarobot.errors import AsyncProcessUnsuccessfulError
 
+from datarobot_provider.constants import DATAROBOT_CONN_ID
 from datarobot_provider.hooks.datarobot import DataRobotHook
 
 
@@ -34,7 +35,7 @@ class MonitoringJobCompleteSensor(BaseSensorOperator):
         self,
         *,
         job_id: str,
-        datarobot_conn_id: str = "datarobot_default",
+        datarobot_conn_id: str = DATAROBOT_CONN_ID,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)

--- a/tests/fixtures/whitelist_test_output.txt
+++ b/tests/fixtures/whitelist_test_output.txt
@@ -6,6 +6,7 @@ from airflow.models import BaseOperator
 from airflow.utils.context import Context
 from datarobot.models.modeljob import ModelJob
 
+from datarobot_provider.constants import DATAROBOT_CONN_ID
 from datarobot_provider.hooks.datarobot import DataRobotHook
 
 
@@ -30,7 +31,7 @@ class ModelJobGetOperator(BaseOperator):
         *,
         project_id: Optional[str] = None,
         model_job_id: Optional[str] = None,
-        datarobot_conn_id: str = "datarobot_default",
+        datarobot_conn_id: str = DATAROBOT_CONN_ID,
         **kwargs: Any
     ) -> None:
         super().__init__(**kwargs)

--- a/tests/unit/autogen/test_generate_operator.py
+++ b/tests/unit/autogen/test_generate_operator.py
@@ -120,7 +120,7 @@ def test_construct_operator_attibutes(generator, docstring_fixture):
 def test_construct_operator_init(generator, docstring_fixture):
     result = generator.construct_operator_init(docstring_fixture)
     expected = (
-        '\tdef __init__(self,*,project_id: Optional[str] = None,model_job_id: Optional[str] = None,datarobot_conn_id: str = "datarobot_default",\n'
+        "\tdef __init__(self,*,project_id: Optional[str] = None,model_job_id: Optional[str] = None,datarobot_conn_id: str = DATAROBOT_CONN_ID,\n"
         "**kwargs: Any) -> None:\n"
         "\t\tsuper().__init__(**kwargs)\n"
         "\t\tself.project_id = project_id\n"


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Use constants instead of "[magic strings](https://en.wikipedia.org/wiki/Magic_string)"

I had recently added `DATAROBOT_CONN_ID` in my code addition for DR Notebooks support

## Rationale

I think this aids in code quality/readability/maintainability