### PR TITLE
[-] Add Read the Docs Config in Preparation for RTD Generation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version, and other tools you might need
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.13"
+
+# Build documentation with Mkdocs
+mkdocs:
+   configuration: mkdocs.yml
+
+# Optionally, but recommended,
+# declare the Python requirements required to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#    install:
+#    - requirements: docs/requirements.txt


### PR DESCRIPTION
## Summary

This PR adds in a config template for RTD to control generation of documentation for this repo.

## Rationale

Since this is a public repo, we can't add the docs to docs.datarobot.com just yet, so we need to get it ready for public documentation via another source: Read the Docs.