### PR TITLE
[MLDEV-1235] Add documentation for first example dag

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,5 +12,5 @@
 /datarobot_provider/operators/monitoring.py              @datarobot/model-management
 /datarobot_provider/operators/monitoring_job.py          @datarobot/tracking-agent
 /datarobot_provider/operators/prediction_explanations.py @datarobot/trust-explainable-ai
-/docs                                                    @datarobot/api-docs
+/docs/                                                   @datarobot/api-docs
 /tests/                                                  @datarobot/machine-learning-development

--- a/docs/examples/hospital_readmissions_example.md
+++ b/docs/examples/hospital_readmissions_example.md
@@ -1,0 +1,23 @@
+# Hospital Readmissions Example
+
+> **datarobot_provider/examples/hospital_readmissions_example.py**
+
+```{admonition} Required Feature Flags
+* ENABLE_DATA_REGISTRY_WRANGLING
+* ENABLE_MLOPS
+```
+
+The `hospital_readmissions_example` DAG demonstrates how to use the DataRobot provider for Apache Airflow to
+create a project, train a model, and register it to DataRobot MLOps. The initial demo flow utilizes a public csv
+file with hospital readmissions data.
+
+This example covers the following steps:
+* Create or reuse a use case
+* Upload a dataset
+* Create a wrangler recipe
+* Publish and run the wrangler recipe
+* Create a new project/experiment in the use case
+* Run autopilot in quick mode
+* Wait for autopilot to complete before continuing
+* Select the top model
+* Register the model for deployment

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,0 +1,10 @@
+(example-dag-reference)=
+
+# Example DAGs
+
+```{toctree}
+:glob: true
+:maxdepth: 1
+
+*
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ This package provides operators, sensors, and a hook to integrate [DataRobot](ht
 Using these components, you should be able to build the essential DataRobot pipeline - create a project, train models, deploy a model,
 and score predictions against the model deployment.
 
-To access other clients and additional information about DataRobot's APIs, visit the 
+To access other clients and additional information about DataRobot's APIs, visit the
 [API documentation home](https://docs.datarobot.com/en/docs/api/index.html).
 
 
@@ -14,6 +14,7 @@ To access other clients and additional information about DataRobot's APIs, visit
 :maxdepth: 2
 
 reference/index.md
+examples/index.md
 autodoc/api_reference.md
 CHANGES.md
 ```

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,8 +1,3 @@
-% DataRobot Airflow Package documentation master file, created by
-% sphinx-quickstart on Mon Mar 16 10:50:19 2015.
-% You can adapt this file completely to your liking, but it should at least
-% contain the root `toctree` directive.
-
 ```{toctree}
 :hidden:
 installation.md


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
This adds a small examples dropdown that we can easily expand, and an initial description + steps + needed feature flags for the first released example dag.

See screenshot below for html build:
![Screenshot 2025-02-21 at 10 16 27 AM](https://github.com/user-attachments/assets/ec1b889a-9956-4e3d-abe6-5744cc16b261)
