### PR TITLE
[MLDEV-1239] Update release pipelines for pypi and early-access pypi to have valid tokens

### DIFF
--- a/.harness/build_and_publish_early_access_pypi.yaml
+++ b/.harness/build_and_publish_early_access_pypi.yaml
@@ -23,7 +23,7 @@ pipeline:
               - name: BUILD_TYPE
                 type: String
                 default: release-early-access-test-pypi
-                value: <+input>.default(release-early-access-test-pypi).allowedValues(release-mainline-pypi,release-early-access-pypi,release-mainline-test-pypi,release-early-access-test-pypi)
+                value: release-early-access-test-pypi
   properties:
     ci:
       codebase:

--- a/.harness/build_and_publish_early_access_pypi.yaml
+++ b/.harness/build_and_publish_early_access_pypi.yaml
@@ -22,8 +22,8 @@ pipeline:
             variables:
               - name: BUILD_TYPE
                 type: String
-                default: test-early-access
-                value: test-early-access
+                default: release-early-access-test-pypi
+                value: <+input>.default(release-early-access-test-pypi).allowedValues(release-mainline-pypi,release-early-access-pypi,release-mainline-test-pypi,release-early-access-test-pypi)
   properties:
     ci:
       codebase:

--- a/.harness/release_early_access_pypi.yaml
+++ b/.harness/release_early_access_pypi.yaml
@@ -21,7 +21,7 @@ pipeline:
               - name: BUILD_TYPE
                 type: String
                 default: release-early-access-test-pypi
-                value: <+input>.default(release-early-access-test-pypi).allowedValues(release-mainline-pypi,release-early-access-pypi,release-mainline-test-pypi,release-early-access-test-pypi)
+                value: release-early-access-pypi
   identifier: releaseearlyaccesspypi
   name: release-early-access-pypi
   properties:

--- a/.harness/release_early_access_pypi.yaml
+++ b/.harness/release_early_access_pypi.yaml
@@ -20,8 +20,8 @@ pipeline:
             variables:
               - name: BUILD_TYPE
                 type: String
-                default: test-early-access
-                value: early-access
+                default: release-early-access-test-pypi
+                value: <+input>.default(release-early-access-test-pypi).allowedValues(release-mainline-pypi,release-early-access-pypi,release-mainline-test-pypi,release-early-access-test-pypi)
   identifier: releaseearlyaccesspypi
   name: release-early-access-pypi
   properties:

--- a/.harness/release_pypi.yaml
+++ b/.harness/release_pypi.yaml
@@ -21,7 +21,7 @@ pipeline:
               - name: BUILD_TYPE
                 type: String
                 default: test-early-access
-                value: test
+                value: release-mainline-test-pypi
     - stage:
         name: Approve Release to Pypi
         identifier: Approve_Release
@@ -61,7 +61,7 @@ pipeline:
               - name: BUILD_TYPE
                 type: String
                 default: test-early-access
-                value: pypi
+                value: release-mainline-pypi
   properties:
     ci:
       codebase:

--- a/.harness/release_pypi.yaml
+++ b/.harness/release_pypi.yaml
@@ -20,7 +20,7 @@ pipeline:
             variables:
               - name: BUILD_TYPE
                 type: String
-                default: test-early-access
+                default: release-early-access-test-pypi
                 value: release-mainline-test-pypi
     - stage:
         name: Approve Release to Pypi
@@ -60,7 +60,7 @@ pipeline:
             variables:
               - name: BUILD_TYPE
                 type: String
-                default: test-early-access
+                default: release-early-access-test-pypi
                 value: release-mainline-pypi
   properties:
     ci:

--- a/.harness/templates/publish_early_access_to_pypi_or_testpypi.yaml
+++ b/.harness/templates/publish_early_access_to_pypi_or_testpypi.yaml
@@ -118,4 +118,4 @@ template:
         default: test-early-access
         description: ""
         required: true
-        value: <+input>.default(test-early-access).allowedValues(test,early-access,pypi,test-early-access)
+        value: <+input>.default(test-early-access).allowedValues(release-mainline,release-early-access,test-mainline,test-early-access)

--- a/.harness/templates/publish_early_access_to_pypi_or_testpypi.yaml
+++ b/.harness/templates/publish_early_access_to_pypi_or_testpypi.yaml
@@ -51,23 +51,23 @@ template:
                       REPO_URL='https://test.pypi.org/legacy/'
                       UPLOAD_SECRET='<+secrets.getValue("testpypi_token")>'
 
-                      if [ "$BUILD_TYPE" == "test-early-access" ] || [ "$BUILD_TYPE" == "early-access" ]; then
+                      if [ "$BUILD_TYPE" == "release-early-access-pypi" ] || [ "$BUILD_TYPE" == "release-early-access-test-pypi" ]; then
                           VERSION=$(python3 setup_early_access.py --version)
                       else
                           VERSION=$(python3 setup.py --version)  
                       fi
 
-                      if [ "$BUILD_TYPE" == "pypi" ]; then
+                      if [ "$BUILD_TYPE" == "release-mainline-pypi" ]; then
                           REPO_URL='https://upload.pypi.org/legacy/'
                           UPLOAD_SECRET='<+secrets.getValue("pypi_release_token")>'
-                      elif [ "$BUILD_TYPE" == "early-access" ]; then
+                      elif [ "$BUILD_TYPE" == "release-early-access-pypi" ]; then
                           REPO_URL='https://upload.pypi.org/legacy/'
                           UPLOAD_SECRET='<+secrets.getValue("pypi_early_access_token")>'
                       fi
                   }
 
                   build_and_upload() {
-                      if [ "$BUILD_TYPE" == "test-early-access" ] || [ "$BUILD_TYPE" == "early-access" ]; then
+                      if [ "$BUILD_TYPE" == "release-early-access-pypi" ] || [ "$BUILD_TYPE" == "release-early-access-test-pypi" ]; then
                           echo "[BUILD PACKAGE - EARLY ACCESS]"
                           make build-early-access
                       else
@@ -78,7 +78,7 @@ template:
                       echo "[TWINE CHECK]"
                       twine check dist/*
 
-                      if [ "$BUILD_TYPE" == "test-early-access" ] || [ "$BUILD_TYPE" == "early-access" ]; then
+                      if [ "$BUILD_TYPE" == "release-early-access-pypi" ] || [ "$BUILD_TYPE" == "release-early-access-test-pypi" ]; then
                           echo "[TWINE UPLOAD - EARLY ACCESS]"
                           twine upload \
                               --verbose \
@@ -98,7 +98,7 @@ template:
                   }
 
                   push_tags() {
-                      if [ "$BUILD_TYPE" == "early-access" ]; then
+                      if [ "$BUILD_TYPE" == "release-early-access-pypi" ]; then
                           echo '[PUSHING EARLY ACCESS TAGS]'
                           git tag -f early-access && git push -f origin early-access
                       fi
@@ -115,7 +115,7 @@ template:
     variables:
       - name: BUILD_TYPE
         type: String
-        default: test-early-access
+        default: release-early-access-test-pypi
         description: ""
         required: true
-        value: <+input>.default(test-early-access).allowedValues(release-mainline,release-early-access,test-mainline,test-early-access)
+        value: <+input>.default(release-early-access-test-pypi).allowedValues(release-mainline-pypi,release-early-access-pypi,release-mainline-test-pypi,release-early-access-test-pypi)

--- a/.harness/templates/publish_early_access_to_pypi_or_testpypi.yaml
+++ b/.harness/templates/publish_early_access_to_pypi_or_testpypi.yaml
@@ -57,9 +57,12 @@ template:
                           VERSION=$(python3 setup.py --version)  
                       fi
 
-                      if [ "$BUILD_TYPE" == "pypi" ] || [ "$BUILD_TYPE" == "early-access" ]; then
+                      if [ "$BUILD_TYPE" == "pypi" ]; then
                           REPO_URL='https://upload.pypi.org/legacy/'
-                          UPLOAD_SECRET='<+secrets.getValue("PyPI_token_for_airflow-provider-datarobot")>'
+                          UPLOAD_SECRET='<+secrets.getValue("pypi_release_token")>'
+                      elif [ "$BUILD_TYPE" == "early-access" ]; then
+                          REPO_URL='https://upload.pypi.org/legacy/'
+                          UPLOAD_SECRET='<+secrets.getValue("pypi_early_access_token")>'
                       fi
                   }
 

--- a/.harness/templates/publish_early_access_to_pypi_or_testpypi.yaml
+++ b/.harness/templates/publish_early_access_to_pypi_or_testpypi.yaml
@@ -109,7 +109,6 @@ template:
                       pip3 install --no-cache-dir --upgrade pip setuptools wheel six twine
                       set_build_variables
                       build_and_upload
-                      push_tags
                   }
 
                   main "$@"


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Thanks to the help of IT, we now have access to both repositories. This updates the pipelines to inject the new stored secrets which are unique for each of the two repos.

Actual secrets are retrieved from the secure environments, so this is just updating the naming of how these are retrieved and changing the logic to indicate there are 2 different sets of secrets.
