### PR TITLE
[MLDEV-1131] Update early-access version to have a slightly altered dunder intit file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,16 +99,29 @@ kill-astro-dev:
 build-astro-dev:
 	-$(MAKE) stop-astro-dev
 	rm -rf ./dist
-	pip install --upgrade build
-	python -m build
+	$(MAKE) build
 	cp -p "`ls -dtr1 ./dist/*.whl | sort -n | tail -1`" "./astro-dev/"
 	echo "/usr/local/airflow/`find ./dist/*.whl -exec basename {} \; | sort -n | tail -1`" > \
- 		./astro-dev/requirements_dev.txt
+		./astro-dev/requirements_dev.txt
 	$(MAKE) copy-examples-astro-dev
+	$(MAKE) start-astro-dev
+
+build-astro-dev-early-access:
+	-$(MAKE) stop-astro-dev
+	rm -rf ./dist
+	$(MAKE) build-early-access
+	cp -p "`ls -dtr1 ./dist/*.whl | sort -n | tail -1`" "./astro-dev/"
+	echo "/usr/local/airflow/`find ./dist/*.whl -exec basename {} \; | sort -n | tail -1`" > \
+		./astro-dev/requirements_dev.txt
+	$(MAKE) copy-examples-astro-dev
+	$(MAKE) copy-experimental-examples-astro-dev
 	$(MAKE) start-astro-dev
 
 copy-examples-astro-dev:
 	cp -r ./datarobot_provider/example_dags/* ./astro-dev/dags/
+
+copy-experimental-examples-astro-dev:
+	cp -r ./datarobot_provider/_experimental/example_dags/* ./astro-dev/dags/
 
 autogen-operators:
 	python ./datarobot_provider/autogen/generate_operator.py --whitelist ./datarobot_provider/autogen/whitelist.yaml --output_folder ./datarobot_provider/operators/gen

--- a/early_access_dunder_init.txt
+++ b/early_access_dunder_init.txt
@@ -1,0 +1,69 @@
+# Copyright 2022 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+from typing import TypedDict
+
+ConnectionType = TypedDict(
+    "ConnectionType",
+    {
+        "hook-class-name": str,
+        "connection-type": str,
+    },
+)
+
+
+ProviderInfoType = TypedDict(
+    "ProviderInfoType",
+    {
+        "package-name": str,
+        "name": str,
+        "description": str,
+        "versions": list[str],
+        "connection-types": list[ConnectionType],
+        "extra-links": list[str],
+    },
+)
+
+
+def get_provider_info() -> ProviderInfoType:
+    return {
+        "package-name": "airflow-provider-datarobot-early-access",
+        "name": "DataRobot Airflow Provider Early Access",
+        "description": "DataRobot Airflow provider early access.",
+        "versions": ["0.1.0"],
+        "connection-types": [
+            {
+                "hook-class-name": "datarobot_provider.hooks.datarobot.DataRobotHook",
+                "connection-type": "http",
+            },
+            {
+                "hook-class-name": "datarobot_provider.hooks.connections.JDBCDataSourceHook",
+                "connection-type": "datarobot.datasource.jdbc",
+            },
+            {
+                "hook-class-name": "datarobot_provider.hooks.credentials.BasicCredentialsHook",
+                "connection-type": "datarobot.credentials.basic",
+            },
+            {
+                "hook-class-name": "datarobot_provider.hooks.credentials.GoogleCloudCredentialsHook",
+                "connection-type": "datarobot.credentials.gcp",
+            },
+            {
+                "hook-class-name": "datarobot_provider.hooks.credentials.AwsCredentialsHook",
+                "connection-type": "datarobot.credentials.aws",
+            },
+            {
+                "hook-class-name": "datarobot_provider.hooks.credentials.AzureStorageCredentialsHook",
+                "connection-type": "datarobot.credentials.azure",
+            },
+            {
+                "hook-class-name": "datarobot_provider.hooks.credentials.OAuthCredentialsHook",
+                "connection-type": "datarobot.credentials.oauth",
+            },
+        ],
+        "extra-links": [],
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,6 @@ pretty = true
 [[tool.mypy.overrides]]
 module = [
     "datarobot_provider.autogen.*",
-    "datarobot_provider._experimental.example_dags.*"
+    "datarobot_provider._experimental.deprecated_example_dags.*"
 ]
 ignore_errors = true

--- a/setup_early_access.py
+++ b/setup_early_access.py
@@ -9,6 +9,7 @@
 # affiliates.
 #
 # Released under the terms of DataRobot Tool and Utility Agreement.
+import os
 from datetime import datetime
 
 from setuptools import find_packages
@@ -51,6 +52,22 @@ description = DESCRIPTION_TEMPLATE.format(
 
 packages = find_packages(exclude=["docs*", "tests*"])
 
+
+def _copy_file(source_file, destination_file):
+    with open(source_file, "r") as source, open(destination_file, "w") as destination:
+        for line in source:
+            destination.write(line)
+
+
+# Airflow relies on entry point for provider discovery (as seen defined in common_setup_kwargs)
+early_access_dunder_init = "./early_access_dunder_init.txt"
+copy_of_dunder_init = "datarobot_provider/__init__BKP.py"
+dunder_init = "datarobot_provider/__init__.py"
+# Make copy in order to reset below after building package
+_copy_file(dunder_init, copy_of_dunder_init)
+_copy_file(early_access_dunder_init, dunder_init)
+
+
 common_setup_kwargs.update(
     name=package_name,
     version=version,
@@ -61,3 +78,7 @@ common_setup_kwargs.update(
 )
 
 setup(**common_setup_kwargs)
+
+# Reset changes we made to dunder init file and remove backup
+_copy_file(copy_of_dunder_init, dunder_init)
+os.remove(copy_of_dunder_init)


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Early access package needs a slightly altered dunder init file since it's used as an entry point by Apache Airlfow

## Rationale

While testing the early-access provider package locally I discovered an issue where the local astro development environment would not start up.

It was caused by the underlying use of [_discover_all_providers_from_packages()](https://github.com/apache/airflow/blob/main/airflow/providers_manager.py#L588) 

And resulted in this error:
`ValueError: The package 'airflow-provider-datarobot-early-access' from setuptools and airflow-provider-datarobot do not match. Please make sure they are aligned`

<img width="1135" alt="Screenshot 2025-02-24 at 2 53 45 PM" src="https://github.com/user-attachments/assets/7f21978a-b9d8-4bf0-9d75-012a295aa177" />

## CHANGES

- Update `build-astro-dev` make command to use `build` make command
- Add new `copy-experimental-examples-astro-dev` make command to copy over relevant experimental DAGs
- Add new `build-astro-dev-early-access` make command to run local astro dev. with early-access version of pacakage
- Update mypy ignores to properly ignore deprecated but not experimental DAGs for type checking
- Update `setup_early_access.py` so that we have a dunder init file that has `"package-name": "airflow-provider-datarobot-early-access",`