### PR TITLE
[MMM-18684] p0 dag 2 deployment from registered model version implementation of first deployment step

### DIFF
--- a/datarobot_provider/example_dags/hospital_readmissions_deployment_prediction_generation.py
+++ b/datarobot_provider/example_dags/hospital_readmissions_deployment_prediction_generation.py
@@ -9,6 +9,7 @@
 from airflow.decorators import dag
 
 from datarobot_provider.operators.deployment import DeployRegisteredModelOperator
+from datarobot_provider.operators.monitoring import UpdateDriftTrackingOperator
 
 """
 Example of Aiflow DAG for DataRobot data deployment and prediction generation.
@@ -17,16 +18,22 @@ Configurable parameters for this dag:
 * deployment_label - A human readable label of the deployment.
 * default_prediction_server_id - an identifier of a prediction server to be used as the default prediction server
   When working with prediction environments, default prediction server Id should not be provided
+* target_drift_enabled - if target drift tracking is to be turned on
+* feature_drift_enabled - if feature drift tracking is to be turned on
+
 """
 
 
 @dag(
     schedule=None,
+    render_template_as_native_obj=True,
     tags=["example", "csv", "predictions", "deployment"],
     params={
         "model_package_id": "",
         "deployment_label": "hospital-readmissions-example-deployment-prediction",
         "default_prediction_server_id": "",
+        "target_drift_enabled": True,
+        "feature_drift_enabled": True,
     },
 )
 def hospital_readmissions_deployment_prediction_generation():
@@ -37,7 +44,14 @@ def hospital_readmissions_deployment_prediction_generation():
         extra_params={"default_prediction_server_id": "{{ params.default_prediction_server_id }}"},
     )
 
-    deploy_registered_model
+    update_drift_tracking = UpdateDriftTrackingOperator(
+        task_id="update_drift_tracking",
+        deployment_id=deploy_registered_model.output,
+        target_drift_enabled="{{ params.target_drift_enabled }}",
+        feature_drift_enabled="{{ params.feature_drift_enabled }}",
+    )
+
+    (deploy_registered_model >> update_drift_tracking)
 
 
 hospital_readmissions_deployment_prediction_generation()

--- a/datarobot_provider/example_dags/hospital_readmissions_deployment_prediction_generation.py
+++ b/datarobot_provider/example_dags/hospital_readmissions_deployment_prediction_generation.py
@@ -1,0 +1,43 @@
+# Copyright 2025 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+
+from airflow.decorators import dag
+
+from datarobot_provider.operators.deployment import DeployRegisteredModelOperator
+
+"""
+Example of Aiflow DAG for DataRobot data deployment and prediction generation.
+Configurable parameters for this dag:
+* model_package_id - The ID of the DataRobot model package (version) to deploy.
+* deployment_label - A human readable label of the deployment.
+* default_prediction_server_id - an identifier of a prediction server to be used as the default prediction server
+  When working with prediction environments, default prediction server Id should not be provided
+"""
+
+
+@dag(
+    schedule=None,
+    tags=["example", "csv", "predictions", "deployment"],
+    params={
+        "model_package_id": "",
+        "deployment_label": "hospital-readmissions-example-deployment-prediction",
+        "default_prediction_server_id": "",
+    },
+)
+def hospital_readmissions_deployment_prediction_generation():
+    deploy_registered_model = DeployRegisteredModelOperator(
+        task_id="deploy_registered_model",
+        model_package_id="{{ params.model_package_id }}",
+        deployment_label="{{ params.deployment_label }}",
+        extra_params={"default_prediction_server_id": "{{ params.default_prediction_server_id }}"},
+    )
+
+    deploy_registered_model
+
+
+hospital_readmissions_deployment_prediction_generation()

--- a/datarobot_provider/operators/deployment.py
+++ b/datarobot_provider/operators/deployment.py
@@ -476,20 +476,20 @@ class GetTargetDriftOperator(BaseDatarobotOperator):
 
 
 class DeployRegisteredModelOperator(BaseDatarobotOperator):
-"""
-Create a deployment from a registered model version using DataRobot's API.
-
-This operator creates a deployment for a registered model version by calling
-DataRobot's `Deployment.create_from_registered_model_version()` method. It allows
-optional extra parameters to be passed to the DataRobot client call.
-
-Args:
-    model_package_id (str): The registered model version ID to deploy.
-    deployment_label (str): The label or name to assign to the deployment.
-    extra_params (dict, optional): A dictionary of additional parameters to pass
-        to the DataRobot deployment creation API.
-    kwargs (dict): Additional keyword arguments passed to the BaseDatarobotOperator.
-"""
+    """
+    Create a deployment from a registered model version using DataRobot's API.
+    
+    This operator creates a deployment for a registered model version by calling
+    DataRobot's `Deployment.create_from_registered_model_version()` method. It allows
+    optional extra parameters to be passed to the DataRobot client call.
+    
+    Args:
+        model_package_id (str): The registered model version ID to deploy.
+        deployment_label (str): The label or name to assign to the deployment.
+        extra_params (dict, optional): A dictionary of additional parameters to pass
+            to the DataRobot deployment creation API.
+        kwargs (dict): Additional keyword arguments passed to the BaseDatarobotOperator.
+    """
 
     template_fields: Sequence[str] = ["model_package_id", "deployment_label", "extra_params"]
 

--- a/datarobot_provider/operators/deployment.py
+++ b/datarobot_provider/operators/deployment.py
@@ -478,11 +478,11 @@ class GetTargetDriftOperator(BaseDatarobotOperator):
 class DeployRegisteredModelOperator(BaseDatarobotOperator):
     """
     Create a deployment from a registered model version using DataRobot's API.
-    
+
     This operator creates a deployment for a registered model version by calling
     DataRobot's `Deployment.create_from_registered_model_version()` method. It allows
     optional extra parameters to be passed to the DataRobot client call.
-    
+
     Args:
         model_package_id (str): The registered model version ID to deploy.
         deployment_label (str): The label or name to assign to the deployment.

--- a/datarobot_provider/operators/deployment.py
+++ b/datarobot_provider/operators/deployment.py
@@ -476,19 +476,20 @@ class GetTargetDriftOperator(BaseDatarobotOperator):
 
 
 class DeployRegisteredModelOperator(BaseDatarobotOperator):
-    """
-    Create a deployment from a registered model version using DataRobot's API.
+"""
+Create a deployment from a registered model version using DataRobot's API.
 
-    This operator creates a deployment for a registered model version by calling
-    DataRobot's `Deployment.create_from_registered_model_version()` method. It allows
-    optional extra parameters to be passed to the DataRobot client call.
+This operator creates a deployment for a registered model version by calling
+DataRobot's `Deployment.create_from_registered_model_version()` method. It allows
+optional extra parameters to be passed to the DataRobot client call.
 
-    :param model_package_id: The registered model version ID to deploy.
-    :param deployment_label: The label or name to assign to the deployment.
-    :param extra_params: (Optional) A dictionary of additional parameters to pass
-                         to the DataRobot deployment creation API.
-    :param kwargs: Additional keyword arguments passed to the BaseDatarobotOperator.
-    """
+Args:
+    model_package_id (str): The registered model version ID to deploy.
+    deployment_label (str): The label or name to assign to the deployment.
+    extra_params (dict, optional): A dictionary of additional parameters to pass
+        to the DataRobot deployment creation API.
+    kwargs (dict): Additional keyword arguments passed to the BaseDatarobotOperator.
+"""
 
     template_fields: Sequence[str] = ["model_package_id", "deployment_label", "extra_params"]
 

--- a/datarobot_provider/operators/monitoring.py
+++ b/datarobot_provider/operators/monitoring.py
@@ -235,18 +235,19 @@ class UpdateMonitoringSettingsOperator(BaseDatarobotOperator):
 
 
 class UpdateDriftTrackingOperator(BaseDatarobotOperator):
-    """
-    Update drift tracking settings for a DataRobot deployment using DataRobot's API.
+"""
+Update drift tracking settings for a DataRobot deployment using DataRobot's API.
 
-    This operator updates drift tracking settings for an existing deployment by calling
-    the deployment's `update_drift_tracking_settings()` method. It allows optional extra parameters
-    to be passed to the DataRobot client call.
+This operator updates drift tracking settings for an existing deployment by calling
+the deployment's `update_drift_tracking_settings()` method. It allows optional extra parameters
+to be passed to the DataRobot client call.
 
-    :param deployment_id: The ID of the deployment to update.
-    :param target_drift_enabled: Boolean flag to enable target drift tracking.
-    :param feature_drift_enabled: Boolean flag to enable feature drift tracking.
-    :param kwargs: Additional keyword arguments passed to the BaseDatarobotOperator.
-    """
+Args:
+    deployment_id (str): The ID of the deployment to update.
+    target_drift_enabled (bool): Boolean flag to enable target drift tracking.
+    feature_drift_enabled (bool): Boolean flag to enable feature drift tracking.
+    kwargs (dict): Additional keyword arguments passed to the BaseDatarobotOperator.
+"""
 
     template_fields: Sequence[str] = [
         "deployment_id",

--- a/datarobot_provider/operators/monitoring.py
+++ b/datarobot_provider/operators/monitoring.py
@@ -232,3 +232,51 @@ class UpdateMonitoringSettingsOperator(BaseDatarobotOperator):
             self.log.info(
                 f"No need to update predictions data collection settings for deployment_id={self.deployment_id}"
             )
+
+
+class UpdateDriftTrackingOperator(BaseDatarobotOperator):
+    """
+    Update drift tracking settings for a DataRobot deployment using DataRobot's API.
+
+    This operator updates drift tracking settings for an existing deployment by calling
+    the deployment's `update_drift_tracking_settings()` method. It allows optional extra parameters
+    to be passed to the DataRobot client call.
+
+    :param deployment_id: The ID of the deployment to update.
+    :param target_drift_enabled: Boolean flag to enable target drift tracking.
+    :param feature_drift_enabled: Boolean flag to enable feature drift tracking.
+    :param kwargs: Additional keyword arguments passed to the BaseDatarobotOperator.
+    """
+
+    template_fields: Sequence[str] = [
+        "deployment_id",
+        "target_drift_enabled",
+        "feature_drift_enabled",
+    ]
+
+    def __init__(
+        self,
+        *,
+        deployment_id: str,
+        target_drift_enabled: bool = True,
+        feature_drift_enabled: bool = True,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.deployment_id = deployment_id
+        self.target_drift_enabled = target_drift_enabled
+        self.feature_drift_enabled = feature_drift_enabled
+
+    def validate(self) -> None:
+        if not self.deployment_id:
+            raise ValueError("deployment_id must be provided.")
+
+    def execute(self, context: Context) -> str:
+        self.log.info("Updating drift tracking settings for deployment: %s", self.deployment_id)
+        deployment = dr.Deployment.get(self.deployment_id)
+        deployment.update_drift_tracking_settings(
+            target_drift_enabled=self.target_drift_enabled,
+            feature_drift_enabled=self.feature_drift_enabled,
+        )
+        self.log.info("Drift tracking settings updated for deployment: %s", self.deployment_id)
+        return self.deployment_id

--- a/datarobot_provider/operators/monitoring.py
+++ b/datarobot_provider/operators/monitoring.py
@@ -274,7 +274,7 @@ class UpdateDriftTrackingOperator(BaseDatarobotOperator):
 
     def execute(self, context: Context) -> str:
         self.log.info("Updating drift tracking settings for deployment: %s", self.deployment_id)
-        deployment = dr.Deployment.get(self.deployment_id)
+        deployment = dr.Deployment(id=self.deployment_id)
         deployment.update_drift_tracking_settings(
             target_drift_enabled=self.target_drift_enabled,
             feature_drift_enabled=self.feature_drift_enabled,

--- a/datarobot_provider/operators/monitoring.py
+++ b/datarobot_provider/operators/monitoring.py
@@ -246,7 +246,7 @@ class UpdateDriftTrackingOperator(BaseDatarobotOperator):
         deployment_id (str): The ID of the deployment to update.
         target_drift_enabled (bool): Boolean flag to enable target drift tracking.
         feature_drift_enabled (bool): Boolean flag to enable feature drift tracking.
-        kwargs (dict): Additional keyword  arguments passed to the BaseDatarobotOperator.
+        kwargs (dict): Additional keyword arguments passed to the BaseDatarobotOperator.
     """
 
     template_fields: Sequence[str] = [

--- a/datarobot_provider/operators/monitoring.py
+++ b/datarobot_provider/operators/monitoring.py
@@ -235,19 +235,19 @@ class UpdateMonitoringSettingsOperator(BaseDatarobotOperator):
 
 
 class UpdateDriftTrackingOperator(BaseDatarobotOperator):
-"""
-Update drift tracking settings for a DataRobot deployment using DataRobot's API.
-
-This operator updates drift tracking settings for an existing deployment by calling
-the deployment's `update_drift_tracking_settings()` method. It allows optional extra parameters
-to be passed to the DataRobot client call.
-
-Args:
-    deployment_id (str): The ID of the deployment to update.
-    target_drift_enabled (bool): Boolean flag to enable target drift tracking.
-    feature_drift_enabled (bool): Boolean flag to enable feature drift tracking.
-    kwargs (dict): Additional keyword arguments passed to the BaseDatarobotOperator.
-"""
+    """
+    Update drift tracking settings for a DataRobot deployment using DataRobot's API.
+    
+    This operator updates drift tracking settings for an existing deployment by calling
+    the deployment's `update_drift_tracking_settings()` method. It allows optional extra parameters
+    to be passed to the DataRobot client call.
+    
+    Args:
+        deployment_id (str): The ID of the deployment to update.
+        target_drift_enabled (bool): Boolean flag to enable target drift tracking.
+        feature_drift_enabled (bool): Boolean flag to enable feature drift tracking.
+        kwargs (dict): Additional keyword arguments passed to the BaseDatarobotOperator.
+    """
 
     template_fields: Sequence[str] = [
         "deployment_id",

--- a/datarobot_provider/operators/monitoring.py
+++ b/datarobot_provider/operators/monitoring.py
@@ -237,16 +237,16 @@ class UpdateMonitoringSettingsOperator(BaseDatarobotOperator):
 class UpdateDriftTrackingOperator(BaseDatarobotOperator):
     """
     Update drift tracking settings for a DataRobot deployment using DataRobot's API.
-    
+
     This operator updates drift tracking settings for an existing deployment by calling
     the deployment's `update_drift_tracking_settings()` method. It allows optional extra parameters
     to be passed to the DataRobot client call.
-    
+
     Args:
         deployment_id (str): The ID of the deployment to update.
         target_drift_enabled (bool): Boolean flag to enable target drift tracking.
         feature_drift_enabled (bool): Boolean flag to enable feature drift tracking.
-        kwargs (dict): Additional keyword arguments passed to the BaseDatarobotOperator.
+        kwargs (dict): Additional keyword  arguments passed to the BaseDatarobotOperator.
     """
 
     template_fields: Sequence[str] = [

--- a/tests/unit/operators/test_deployment.py
+++ b/tests/unit/operators/test_deployment.py
@@ -262,7 +262,7 @@ def test_operator_get_deployment_status_not_provided(mocker):
         operator.execute(operator.execute(context={"params": {}}))
 
 
-def test_validate_missing_params():
+def test_deploy_register_model_validate_missing_params():
     """Test that validate() raises an error when required parameters are missing."""
     with pytest.raises(ValueError, match="model_package_id must be provided"):
         op = DeployRegisteredModelOperator(
@@ -277,7 +277,7 @@ def test_validate_missing_params():
         op.validate()
 
 
-def test_execute_creates_deployment(mocker):
+def test_deploy_register_model_execute_creates_deployment(mocker):
     """Test that execute() calls the DataRobot API and returns the deployment id."""
     test_deployment = MagicMock()
     test_deployment.id = "deployment_123"

--- a/tests/unit/operators/test_monitoring.py
+++ b/tests/unit/operators/test_monitoring.py
@@ -332,10 +332,9 @@ def test_operator_no_need_update_monitoring_settings(mocker, monitoring_settings
 
 
 def test_update_drift_settings_execute_success(mocker):
-    """Test that execute() calls update_drift_tracking_settings with the correct parameters and returns the deployment_id."""
-    dummy_deployment = dr.Deployment("test_deployment_id")
+    dummy_deployment = dr.Deployment(id="test_deployment_id")
     update_patch = mocker.patch.object(dummy_deployment, "update_drift_tracking_settings")
-    mocker.patch.object(dr.Deployment, "get", return_value=dummy_deployment)
+    mocker.patch.object(dr, "Deployment", return_value=dummy_deployment)
 
     op = UpdateDriftTrackingOperator(
         task_id="test",


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
added 1st step for model deployment from model registry and its operator
added 2nd step for setting data drift settings
![image](https://github.com/user-attachments/assets/fa99c7fe-e161-47ec-9685-7d087b4f6661)


## Rationale
