### PR TITLE
[MLDEV-1243] Add deployment predictions dataset upload and scoring to example DAG

### DIFF
--- a/datarobot_provider/example_dags/hospital_readmissions_deployment_prediction_generation.py
+++ b/datarobot_provider/example_dags/hospital_readmissions_deployment_prediction_generation.py
@@ -69,10 +69,6 @@ def hospital_readmissions_deployment_prediction_generation():
         task_id="create_recipe",
         dataset_id=str(predictions_dataset.output),
         dialect=DataWranglingDialect.SPARK,
-        # See the list of available *operation* options in the DataRobot API documentation:
-        # https://docs.datarobot.com/en/docs/api/reference/public-api/data_wrangling.html#schemaoneofdirective
-        # General *operation* structure is:
-        # {"directive": <One of dr.enums.WranglingOperations>, "arguments": <dictionary>}
         operations=WRANGLER_EXAMPLE_RECIPE,
     )
 

--- a/datarobot_provider/example_dags/hospital_readmissions_xgboost_example.py
+++ b/datarobot_provider/example_dags/hospital_readmissions_xgboost_example.py
@@ -9,6 +9,7 @@
 import datarobot as dr
 from airflow.decorators import dag
 
+from datarobot_provider.example_dags.wrangler_example_recipe import WRANGLER_EXAMPLE_RECIPE
 from datarobot_provider.operators.ai_catalog import CreateDatasetFromRecipeOperator
 from datarobot_provider.operators.ai_catalog import CreateWranglingRecipeOperator
 from datarobot_provider.operators.ai_catalog import UploadDatasetOperator
@@ -55,59 +56,7 @@ def hospital_readmissions_xgboost_example():
         # https://docs.datarobot.com/en/docs/api/reference/public-api/data_wrangling.html#schemaoneofdirective
         # General *operation* structure is:
         # {"directive": <One of dr.enums.WranglingOperations>, "arguments": <dictionary>}
-        operations=[
-            {
-                "directive": "rename-columns",
-                "arguments": {
-                    "columnMappings": [
-                        {"originalName": "admission_type_id", "newName": "AdmissionType"},
-                        {
-                            "originalName": "discharge_disposition_id",
-                            "newName": "DischargeDisposition",
-                        },
-                        {"originalName": "admission_source_id", "newName": "AdmissionSource"},
-                    ]
-                },
-            },
-            {
-                "directive": "replace",
-                "arguments": {
-                    "origin": "AdmissionType",
-                    "searchFor": "",
-                    "replacement": "Not Available",
-                    "matchMode": "exact",
-                },
-            },
-            {
-                "directive": "replace",
-                "arguments": {
-                    "searchFor": r"\\[(\\d+).*",
-                    "replacement": r"$1",
-                    "origin": "age",
-                    "matchMode": "regex",
-                },
-            },
-            {
-                "directive": "compute-new",
-                "arguments": {
-                    "expression": "CAST(`age` AS Integer)",
-                    "newFeatureName": "int-age",
-                },
-            },
-            {
-                "directive": "drop-columns",
-                "arguments": {
-                    "columns": [
-                        "citoglipton",
-                        "acetohexamide",
-                        "miglitol",
-                        "troglitazone",
-                        "examide",
-                        "age",
-                    ]
-                },
-            },
-        ],
+        operations=WRANGLER_EXAMPLE_RECIPE,
     )
 
     # Apply data preparation and save the modified data in the Data Registry.

--- a/datarobot_provider/example_dags/wrangler_example_recipe.py
+++ b/datarobot_provider/example_dags/wrangler_example_recipe.py
@@ -1,0 +1,65 @@
+# Copyright 2025 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+
+from typing import Any
+from typing import Dict
+from typing import List
+
+WRANGLER_EXAMPLE_RECIPE: List[Dict[str, Any]] = [
+    {
+        "directive": "rename-columns",
+        "arguments": {
+            "columnMappings": [
+                {"originalName": "admission_type_id", "newName": "AdmissionType"},
+                {
+                    "originalName": "discharge_disposition_id",
+                    "newName": "DischargeDisposition",
+                },
+                {"originalName": "admission_source_id", "newName": "AdmissionSource"},
+            ]
+        },
+    },
+    {
+        "directive": "replace",
+        "arguments": {
+            "origin": "AdmissionType",
+            "searchFor": "",
+            "replacement": "Not Available",
+            "matchMode": "exact",
+        },
+    },
+    {
+        "directive": "replace",
+        "arguments": {
+            "searchFor": r"\\[(\\d+).*",
+            "replacement": r"$1",
+            "origin": "age",
+            "matchMode": "regex",
+        },
+    },
+    {
+        "directive": "compute-new",
+        "arguments": {
+            "expression": "CAST(`age` AS Integer)",
+            "newFeatureName": "int-age",
+        },
+    },
+    {
+        "directive": "drop-columns",
+        "arguments": {
+            "columns": [
+                "citoglipton",
+                "acetohexamide",
+                "miglitol",
+                "troglitazone",
+                "examide",
+                "age",
+            ]
+        },
+    },
+]


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
This PR does the following:
- Upload a predictions dataset
- Apply a wrangler recipe (refactored this so its not duplicated as much in the examples)
- Score the wrangler dataset with the existing deployment id
