### PR TITLE
[MODEL-17045][MODEL-17046][MODEL-17053] Cleanup feature impact/effects docstrings and shap impact operator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,17 @@
 # Changelog
 
-## Unreleased Changes
-- Add `hospital_readmissions_xgboost_example.py` DAG.
+## 0.2.0
+- Add `hospital_readmissions_xgboost_example.py` example DAG.
+- Add `hospital_readmissions_deployment_prediction_generation.py` example DAG.
+- Update `TrainModelsOperator` to latest sdk.
+- Add updated `TrainModelOperator` for training single models.
+- Add `GetProjectBlueprintsOperator` for getting blueprint ids for a project.
+- Add `DeployRegisteredModelOperator` for deploying registered models.
+- Add `UpdateDriftTrackingOperator` for updating drift tracking settings on deployments.
+- Update `ComputeFeatureImpactOperator` to latest sdk compatibility.
+- Updated `ComputeFeatureEffectsOperator` to latest sdk compatibility.
+- Add `ComputeShapPreviewOperator` to compute SHAP previews for a model.
+- Add `ComputeShapImpactOperator` to compute SHAP impact for a model.
 
 ## 0.1.0
 
@@ -20,14 +30,6 @@ to create datasets from project data.
 - Add `feature_discovery_example.py` DAG.
 - Add an optional *use_case_id* parameter into `CreateProjectOperator <datarobot_provider.operators.ai_catalog.datarobot.CreateProjectOperator>`
 - Add `GetDataStoreOperator <datarobot_provider.operators.datarobot.GetProjectBlueprintsOperator>` to get blueprint ids for a project.
-
-### Bugfixes
-
-### API changes
-
-### Deprecation summary
-
-### Documentation changes
 
 ### Experimental changes
 

--- a/datarobot_provider/__init__.py
+++ b/datarobot_provider/__init__.py
@@ -34,7 +34,7 @@ def get_provider_info() -> ProviderInfoType:
         "package-name": "airflow-provider-datarobot",
         "name": "DataRobot Airflow Provider",
         "description": "DataRobot Airflow provider.",
-        "versions": ["0.1.0"],
+        "versions": ["0.2.0"],
         "connection-types": [
             {
                 "hook-class-name": "datarobot_provider.hooks.datarobot.DataRobotHook",

--- a/datarobot_provider/_version.py
+++ b/datarobot_provider/_version.py
@@ -9,4 +9,4 @@
 # affiliates.
 #
 # Released under the terms of DataRobot Tool and Utility Agreement.
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/docs/autodoc/operators_insights.md
+++ b/docs/autodoc/operators_insights.md
@@ -3,6 +3,21 @@
 # Insights Modules
 
 ```{eval-rst}
+.. autoclass:: datarobot_provider.operators.model_insights.ComputeFeatureImpactOperator
+   :members:
+```
+
+```{eval-rst}
+.. autoclass:: datarobot_provider.operators.model_insights.ComputeFeatureEffectsOperator
+   :members:
+```
+
+```{eval-rst}
+.. autoclass:: datarobot_provider.operators.model_insights.ComputeShapImpactOperator
+   :members:
+```
+
+```{eval-rst}
 .. autoclass:: datarobot_provider.operators.model_insights.ComputeShapPreviewOperator
    :members:
 ```

--- a/tests/unit/operators/test_model_insights_job.py
+++ b/tests/unit/operators/test_model_insights_job.py
@@ -9,10 +9,12 @@
 import datarobot as dr
 import pytest
 from airflow.exceptions import AirflowException
+from datarobot.insights import ShapImpact
 from datarobot.insights import ShapPreview
 
 from datarobot_provider.operators.model_insights import ComputeFeatureEffectsOperator
 from datarobot_provider.operators.model_insights import ComputeFeatureImpactOperator
+from datarobot_provider.operators.model_insights import ComputeShapImpactOperator
 from datarobot_provider.operators.model_insights import ComputeShapPreviewOperator
 
 
@@ -143,7 +145,7 @@ def test_operator_compute_shap(mocker):
     job_id = 123
 
     job_mock = mocker.Mock()
-    job_mock.id = job_id
+    job_mock.job_id = job_id
 
     request_shap_mock = mocker.patch.object(ShapPreview, "compute", return_value=job_mock)
 
@@ -152,9 +154,31 @@ def test_operator_compute_shap(mocker):
     result = operator.execute(context={"params": {}})
 
     request_shap_mock.assert_called_with(entity_id=model_id)
-    assert result is None
+    assert result == 123
 
 
 def test_operator_compute_shap_no_model_id():
     with pytest.raises(AirflowException):
         ComputeShapPreviewOperator(task_id="compute_shap")
+
+
+def test_operator_compute_shap_impact(mocker):
+    model_id = "test-model-id"
+    job_id = 123
+
+    job_mock = mocker.Mock()
+    job_mock.job_id = job_id
+
+    request_shap_mock = mocker.patch.object(ShapImpact, "compute", return_value=job_mock)
+
+    operator = ComputeShapImpactOperator(task_id="compute_shap", model_id=model_id)
+
+    result = operator.execute(context={"params": {}})
+
+    request_shap_mock.assert_called_with(entity_id=model_id)
+    assert result == 123
+
+
+def test_operator_compute_shap_impact_no_model_id():
+    with pytest.raises(AirflowException):
+        ComputeShapImpactOperator(task_id="compute_shap")


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
This cleans up many of the insight operators.

Updates changelog and versions to 0.2.0.


## Rationale
- Add `ShapImpact` compute operator (simple operator with tests)
- Cleanup docstrings for the feature impact operators since they are using the correct calls to the API
- Add to docs
