### PR TITLE
[MODEL-18049] Update Early Access and Release pipelines to be more streamlined

### DIFF
--- a/.harness/cichecks.yaml
+++ b/.harness/cichecks.yaml
@@ -97,51 +97,10 @@ pipeline:
         - stage:
             name: Unit tests
             identifier: test_unit
-            description: ""
-            type: CI
-            spec:
-              cloneCodebase: true
-              infrastructure:
-                type: KubernetesDirect
-                spec:
-                  connectorRef: account.cigeneral
-                  namespace: harness-delegate-ng
-                  automountServiceAccountToken: true
-                  nodeSelector: {}
-                  os: Linux
-              execution:
-                steps:
-                  - step:
-                      type: Run
-                      name: run unit tests
-                      identifier: run_unit_tests
-                      spec:
-                        connectorRef: account.dockerhub_datarobot_read
-                        image: python:<+matrix.python_version>
-                        shell: Bash
-                        command: |-
-                          set -exuo pipefail
-                          make req-dev
-                          airflow db init
-                          airflow db check
-                          make test-harness
-                        reports:
-                          type: JUnit
-                          spec:
-                            paths:
-                              - /harness/unit_test_report.xml
-                        resources:
-                          limits:
-                            memory: 1Gi
-                            cpu: "1.5"
-                      strategy:
-                        matrix:
-                          python_version:
-                            - "3.9"
-                            - "3.10"
-                            - "3.11"
-                            - "3.12"
-                          nodeName: <+matrix.python_version>
+            template:
+              templateRef: unit_tests
+              versionLabel: "1"
+              gitBranch: mattn/MODEL-18049-update-ea-pipeline
         - stage:
             name: Build docs tests
             identifier: test_build_docs

--- a/.harness/cichecks.yaml
+++ b/.harness/cichecks.yaml
@@ -100,7 +100,6 @@ pipeline:
             template:
               templateRef: unit_tests
               versionLabel: "1"
-              gitBranch: mattn/MODEL-18049-update-ea-pipeline
         - stage:
             name: Build docs tests
             identifier: test_build_docs

--- a/.harness/release_early_access_pypi.yaml
+++ b/.harness/release_early_access_pypi.yaml
@@ -17,19 +17,6 @@ pipeline:
               templateRef: unit_tests
               versionLabel: "1"
     - stage:
-        name: Publish to Pypi
-        identifier: Publish_to_Pypi
-        template:
-          templateRef: publish_early_access_to_pypi_or_testpypi
-          versionLabel: "1"
-          templateInputs:
-            type: CI
-            variables:
-              - name: BUILD_TYPE
-                type: String
-                default: release-early-access-test-pypi
-                value: release-early-access-pypi
-    - stage:
         name: Publish to Test Pypi
         identifier: Publish_to_Test_Pypi
         template:
@@ -42,6 +29,19 @@ pipeline:
                 type: String
                 default: release-early-access-test-pypi
                 value: release-early-access-test-pypi
+    - stage:
+        name: Publish to Pypi
+        identifier: Publish_to_Pypi
+        template:
+          templateRef: publish_early_access_to_pypi_or_testpypi
+          versionLabel: "1"
+          templateInputs:
+            type: CI
+            variables:
+              - name: BUILD_TYPE
+                type: String
+                default: release-early-access-test-pypi
+                value: release-early-access-pypi
   identifier: releaseearlyaccesspypi
   name: release-early-access-pypi
   properties:

--- a/.harness/release_early_access_pypi.yaml
+++ b/.harness/release_early_access_pypi.yaml
@@ -3,12 +3,19 @@ pipeline:
   orgIdentifier: AGENTS
   tags: {}
   stages:
-    - stage:
-        name: Lint
-        identifier: Lint
-        template:
-          templateRef: Lint_Repo
-          versionLabel: "1"
+    - parallel:
+        - stage:
+            name: Lint
+            identifier: Lint
+            template:
+              templateRef: Lint_Repo
+              versionLabel: "1"
+        - stage:
+            name: Unit Tests
+            identifier: Unit_Tests
+            template:
+              templateRef: unit_tests
+              versionLabel: "1"
     - stage:
         name: Publish to Pypi
         identifier: Publish_to_Pypi
@@ -22,6 +29,19 @@ pipeline:
                 type: String
                 default: release-early-access-test-pypi
                 value: release-early-access-pypi
+    - stage:
+        name: Publish to Test Pypi
+        identifier: Publish_to_Test_Pypi
+        template:
+          templateRef: publish_early_access_to_pypi_or_testpypi
+          versionLabel: "1"
+          templateInputs:
+            type: CI
+            variables:
+              - name: BUILD_TYPE
+                type: String
+                default: release-early-access-test-pypi
+                value: release-early-access-test-pypi
   identifier: releaseearlyaccesspypi
   name: release-early-access-pypi
   properties:

--- a/.harness/release_pypi.yaml
+++ b/.harness/release_pypi.yaml
@@ -3,12 +3,19 @@ pipeline:
   orgIdentifier: AGENTS
   tags: {}
   stages:
-    - stage:
-        name: Lint
-        identifier: Lint
-        template:
-          templateRef: Lint_Repo
-          versionLabel: "1"
+    - parallel:
+        - stage:
+            name: Lint
+            identifier: Lint
+            template:
+              templateRef: Lint_Repo
+              versionLabel: "1"
+        - stage:
+            name: Unit Tests
+            identifier: Unit_Tests
+            template:
+              templateRef: unit_tests
+              versionLabel: "1"
     - stage:
         name: Publish Release to TestPypi
         identifier: Publish_Release_to_TestPypi

--- a/.harness/templates/unit_tests.yaml
+++ b/.harness/templates/unit_tests.yaml
@@ -1,0 +1,52 @@
+template:
+  name: unit_tests
+  type: Stage
+  projectIdentifier: airflowproviderdatarobot
+  orgIdentifier: AGENTS
+  spec:
+    type: CI
+    spec:
+      cloneCodebase: true
+      infrastructure:
+        type: KubernetesDirect
+        spec:
+          connectorRef: account.cigeneral
+          namespace: harness-delegate-ng
+          automountServiceAccountToken: true
+          nodeSelector: {}
+          os: Linux
+      execution:
+        steps:
+          - step:
+              type: Run
+              name: run unit tests
+              identifier: run_unit_tests
+              spec:
+                connectorRef: account.dockerhub_datarobot_read
+                image: python:<+matrix.python_version>
+                shell: Bash
+                command: |-
+                  set -exuo pipefail
+                  make req-dev
+                  airflow db init
+                  airflow db check
+                  make test-harness
+                reports:
+                  type: JUnit
+                  spec:
+                    paths:
+                      - /harness/unit_test_report.xml
+                resources:
+                  limits:
+                    memory: 1Gi
+                    cpu: "1.5"
+              strategy:
+                matrix:
+                  python_version:
+                    - "3.9"
+                    - "3.10"
+                    - "3.11"
+                    - "3.12"
+                  nodeName: <+matrix.python_version>
+  identifier: unit_tests
+  versionLabel: "1"


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
This PR makes some cleanups to the release pipelines to make them quicker and more robust.

## Changes
- Extract unit tests as a template
- Make `ci_checks` use the template
- Add `unit tests` to `early-access` and `mainline` release pipelines in parallel with lint
- Add `test-early-access-pypi` as a step before `early-access-pypi` so its just a single pipeline that needs to be run
