### PR TITLE
[MODEL-18051] Add early access harness cron trigger to repo

### DIFF
--- a/.harness/release_early_access_trigger.yaml
+++ b/.harness/release_early_access_trigger.yaml
@@ -1,0 +1,19 @@
+trigger:
+  name: release-early-access-weekly
+  identifier: releaseearlyaccessweekly
+  enabled: true
+  stagesToExecute: []
+  tags: {}
+  orgIdentifier: AGENTS
+  projectIdentifier: airflowproviderdatarobot
+  pipelineIdentifier: releaseearlyaccesspypi
+  source:
+    type: Scheduled
+    spec:
+      type: Cron
+      spec:
+        expression: 0 14 * * TUE
+        type: UNIX
+  pipelineBranchName: main
+  inputSetRefs:
+    - releaseearlyaccesspypiinputset


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
This adds a yaml of the early access CRON trigger. This is set to release at 9:00AM EST, or 15:00 UTC.

**NOTE: Triggers are not synced with github, but its good to keep a copy of these in code format in the repo.** 
