### PR TITLE
[MODEL-18068] Fix some tests that don't work right on latest mac dev env

### DIFF
--- a/tests/unit/operators/test_custom_models.py
+++ b/tests/unit/operators/test_custom_models.py
@@ -335,7 +335,7 @@ def test_operator_create_custom_model_test_status_op(mocker, custom_model_params
 
 
 def test_operator_get_custom_model_test_no_custom_model_test_id_op():
-    custom_model_test_id = "custom-model-test-id"
+    custom_model_test_id = None
 
     operator = GetCustomModelTestOverallStatusOperator(
         task_id="create_custom_model_test",
@@ -343,7 +343,7 @@ def test_operator_get_custom_model_test_no_custom_model_test_id_op():
     )
 
     with pytest.raises(ValueError):
-        operator.execute(context={"params": custom_model_params})
+        operator.validate()
 
 
 def test_operator_create_custom_model_deployment_op(mocker, custom_model_params):
@@ -396,7 +396,7 @@ def test_operator_create_custom_model_deployment_no_custom_model_id_op():
     )
 
     with pytest.raises(ValueError):
-        operator.execute(context={"params": custom_model_params})
+        operator.validate()
 
 
 def test_operator_create_custom_model_deployment_no_deployment_name_op():
@@ -410,4 +410,4 @@ def test_operator_create_custom_model_deployment_no_deployment_name_op():
     )
 
     with pytest.raises(ValueError):
-        operator.execute(context={"params": custom_model_params})
+        operator.validate()

--- a/tests/unit/operators/test_deployment.py
+++ b/tests/unit/operators/test_deployment.py
@@ -228,7 +228,7 @@ def test_operator_activate_deployment_not_provided(mocker):
     )
 
     with pytest.raises(ValueError):
-        operator.execute(operator.execute(context={"params": {}}))
+        operator.validate()
 
 
 def test_operator_get_deployment_status(mocker):
@@ -259,7 +259,7 @@ def test_operator_get_deployment_status_not_provided(mocker):
     )
 
     with pytest.raises(ValueError):
-        operator.execute(operator.execute(context={"params": {}}))
+        operator.validate()
 
 
 def test_deploy_register_model_validate_missing_params():

--- a/tests/unit/operators/test_model_retraining.py
+++ b/tests/unit/operators/test_model_retraining.py
@@ -66,7 +66,7 @@ def test_operator_train_model_no_project_id():
     )
 
     with pytest.raises(ValueError):
-        operator.execute(context={"params": {}})
+        operator.validate()
 
 
 def test_operator_train_model_no_model_id():
@@ -78,4 +78,4 @@ def test_operator_train_model_no_model_id():
     )
 
     with pytest.raises(ValueError):
-        operator.execute(context={"params": {}})
+        operator.validate()

--- a/tests/unit/operators/test_model_training.py
+++ b/tests/unit/operators/test_model_training.py
@@ -66,7 +66,7 @@ def test_operator_train_model_no_project_id():
     )
 
     with pytest.raises(ValueError):
-        operator.execute(context={"params": {}})
+        operator.validate()
 
 
 def test_operator_train_model_no_blueprint_id():
@@ -78,4 +78,4 @@ def test_operator_train_model_no_blueprint_id():
     )
 
     with pytest.raises(ValueError):
-        operator.execute(context={"params": {}})
+        operator.validate()


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Fixes some calls to work on mac dev environments. The `validate` operation is actually called in the context of `pre_execute` which is called by airflow, but is not actually called if the user simply calls `operator.execute()` in the context of testing. This hooks leads to some tests not working correctly in some environments. These calls should be checking the `validate` function instead.
