### PR TITLE
[MODEL-17041] Add get roc curve operator

### DIFF
--- a/datarobot_provider/operators/model_insights.py
+++ b/datarobot_provider/operators/model_insights.py
@@ -246,7 +246,7 @@ class GetRocCurveInsightOperator(BaseDatarobotOperator):
         model = self.get_model()
         roc_data = model.get_roc_curve(source=self.source)
         return {
-            "rocPoints": roc_data.roc_points,
+            "roc_points": roc_data.roc_points,
             "positive_class_predictions": roc_data.positive_class_predictions,
             "negative_class_predictions": roc_data.negative_class_predictions,
         }

--- a/datarobot_provider/operators/model_insights.py
+++ b/datarobot_provider/operators/model_insights.py
@@ -156,6 +156,46 @@ class ComputeShapPreviewOperator(BaseDatarobotOperator):
         return job.job_id
 
 
+class ComputeShapImpactOperator(BaseDatarobotOperator):
+    """
+    Creates SHAP impact job in DataRobot.
+
+    Parameters
+    ----------
+    model_id : str
+        DataRobot model ID
+    datarobot_conn_id : str, optional
+        Connection ID, defaults to `datarobot_default`
+
+    Returns
+    -------
+    str
+        SHAP impact job id
+    """
+
+    # Specify the arguments that are allowed to parse with jinja templating
+    template_fields: Sequence[str] = [
+        "model_id",
+    ]
+
+    def __init__(
+        self,
+        *,
+        model_id: str,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.model_id = str(model_id)
+
+    def validate(self) -> None:
+        if not self.model_id:
+            raise AirflowFailException("The `model_id` parameter is required.")
+
+    def execute(self, context: Context) -> str:
+        job: StatusCheckJob = ShapImpact.compute(entity_id=self.model_id)
+        return job.job_id
+
+
 class GetRocCurveInsightOperator(BaseDatarobotOperator):
     """
     Creates ROC curve insight data.
@@ -210,46 +250,6 @@ class GetRocCurveInsightOperator(BaseDatarobotOperator):
             "positive_class_predictions": roc_data.positive_class_predictions,
             "negative_class_predictions": roc_data.negative_class_predictions,
         }
-
-
-class ComputeShapImpactOperator(BaseDatarobotOperator):
-    """
-    Creates SHAP impact job in DataRobot.
-
-    Parameters
-    ----------
-    model_id : str
-        DataRobot model ID
-    datarobot_conn_id : str, optional
-        Connection ID, defaults to `datarobot_default`
-
-    Returns
-    -------
-    str
-        SHAP impact job id
-    """
-
-    # Specify the arguments that are allowed to parse with jinja templating
-    template_fields: Sequence[str] = [
-        "model_id",
-    ]
-
-    def __init__(
-        self,
-        *,
-        model_id: str,
-        **kwargs: Any,
-    ) -> None:
-        super().__init__(**kwargs)
-        self.model_id = str(model_id)
-
-    def validate(self) -> None:
-        if not self.model_id:
-            raise AirflowFailException("The `model_id` parameter is required.")
-
-    def execute(self, context: Context) -> str:
-        job: StatusCheckJob = ShapImpact.compute(entity_id=self.model_id)
-        return job.job_id
 
 
 class GetLiftChartInsightOperator(BaseDatarobotOperator):

--- a/docs/autodoc_operators/operators_insights.md
+++ b/docs/autodoc_operators/operators_insights.md
@@ -26,3 +26,8 @@
 .. autoclass:: datarobot_provider.operators.model_insights.GetRocCurveInsightOperator
    :members:
 ```
+
+```{eval-rst}
+.. autoclass:: datarobot_provider.operators.model_insights.GetLiftChartInsightOperator
+   :members:
+```

--- a/tests/unit/operators/test_model_insights_job.py
+++ b/tests/unit/operators/test_model_insights_job.py
@@ -145,6 +145,50 @@ def test_operator_compute_feature_effects_no_model_id(mocker):
         operator.validate()
 
 
+def test_operator_compute_shap(mocker):
+    model_id = "test-model-id"
+    job_id = 123
+
+    job_mock = mocker.Mock()
+    job_mock.job_id = job_id
+
+    request_shap_mock = mocker.patch.object(ShapPreview, "compute", return_value=job_mock)
+
+    operator = ComputeShapPreviewOperator(task_id="compute_shap", model_id=model_id)
+
+    result = operator.execute(context={"params": {}})
+
+    request_shap_mock.assert_called_with(entity_id=model_id)
+    assert result == 123
+
+
+def test_operator_compute_shap_no_model_id():
+    with pytest.raises(AirflowException):
+        ComputeShapPreviewOperator(task_id="compute_shap")
+
+
+def test_operator_compute_shap_impact(mocker):
+    model_id = "test-model-id"
+    job_id = 123
+
+    job_mock = mocker.Mock()
+    job_mock.job_id = job_id
+
+    request_shap_mock = mocker.patch.object(ShapImpact, "compute", return_value=job_mock)
+
+    operator = ComputeShapImpactOperator(task_id="compute_shap", model_id=model_id)
+
+    result = operator.execute(context={"params": {}})
+
+    request_shap_mock.assert_called_with(entity_id=model_id)
+    assert result == 123
+
+
+def test_operator_compute_shap_impact_no_model_id():
+    with pytest.raises(AirflowException):
+        ComputeShapImpactOperator(task_id="compute_shap")
+
+
 def test_operator_get_roc_curve_insight(mocker):
     project_id = "test-project-id"
     model_id = "test-model-id"
@@ -196,50 +240,6 @@ def test_operator_get_roc_curve_insight_no_model_id(mocker):
 
     with pytest.raises(AirflowFailException):
         operator.validate()
-
-
-def test_operator_compute_shap(mocker):
-    model_id = "test-model-id"
-    job_id = 123
-
-    job_mock = mocker.Mock()
-    job_mock.job_id = job_id
-
-    request_shap_mock = mocker.patch.object(ShapPreview, "compute", return_value=job_mock)
-
-    operator = ComputeShapPreviewOperator(task_id="compute_shap", model_id=model_id)
-
-    result = operator.execute(context={"params": {}})
-
-    request_shap_mock.assert_called_with(entity_id=model_id)
-    assert result == 123
-
-
-def test_operator_compute_shap_no_model_id():
-    with pytest.raises(AirflowException):
-        ComputeShapPreviewOperator(task_id="compute_shap")
-
-
-def test_operator_compute_shap_impact(mocker):
-    model_id = "test-model-id"
-    job_id = 123
-
-    job_mock = mocker.Mock()
-    job_mock.job_id = job_id
-
-    request_shap_mock = mocker.patch.object(ShapImpact, "compute", return_value=job_mock)
-
-    operator = ComputeShapImpactOperator(task_id="compute_shap", model_id=model_id)
-
-    result = operator.execute(context={"params": {}})
-
-    request_shap_mock.assert_called_with(entity_id=model_id)
-    assert result == 123
-
-
-def test_operator_compute_shap_impact_no_model_id():
-    with pytest.raises(AirflowException):
-        ComputeShapImpactOperator(task_id="compute_shap")
 
 
 def test_operator_get_lift_chart_insight(mocker):

--- a/tests/unit/operators/test_model_insights_job.py
+++ b/tests/unit/operators/test_model_insights_job.py
@@ -5,6 +5,7 @@
 # This is proprietary source code of DataRobot, Inc. and its affiliates.
 #
 # Released under the terms of DataRobot Tool and Utility Agreement.
+from collections import namedtuple
 from unittest.mock import Mock
 
 import datarobot as dr
@@ -192,7 +193,10 @@ def test_operator_compute_shap_impact_no_model_id():
 def test_operator_get_roc_curve_insight(mocker):
     project_id = "test-project-id"
     model_id = "test-model-id"
-    roc_data = Mock(
+    RocResults = namedtuple(
+        "RocResults", ["roc_points", "positive_class_predictions", "negative_class_predictions"]
+    )
+    roc_data = RocResults(
         roc_points=[{"fpr": 0.1, "tpr": 0.9}],
         positive_class_predictions=[0.9],
         negative_class_predictions=[0.1],
@@ -214,7 +218,7 @@ def test_operator_get_roc_curve_insight(mocker):
     get_model_mock.assert_called_with(project_id, model_id)
     model_mock.get_roc_curve.assert_called_with(source="validation")
     assert result == {
-        "rocPoints": roc_data.roc_points,
+        "roc_points": roc_data.roc_points,
         "positive_class_predictions": roc_data.positive_class_predictions,
         "negative_class_predictions": roc_data.negative_class_predictions,
     }

--- a/tests/unit/operators/test_model_insights_job.py
+++ b/tests/unit/operators/test_model_insights_job.py
@@ -20,6 +20,7 @@ from datarobot_provider.operators.model_insights import ComputeFeatureImpactOper
 from datarobot_provider.operators.model_insights import ComputeShapImpactOperator
 from datarobot_provider.operators.model_insights import ComputeShapPreviewOperator
 from datarobot_provider.operators.model_insights import GetLiftChartInsightOperator
+from datarobot_provider.operators.model_insights import GetRocCurveInsightOperator
 
 
 def test_operator_compute_feature_impact(mocker):
@@ -141,6 +142,59 @@ def test_operator_compute_feature_effects_no_model_id(mocker):
     )
 
     with pytest.raises(ValueError):
+        operator.validate()
+
+
+def test_operator_get_roc_curve_insight(mocker):
+    project_id = "test-project-id"
+    model_id = "test-model-id"
+    roc_data = Mock(
+        roc_points=[{"fpr": 0.1, "tpr": 0.9}],
+        positive_class_predictions=[0.9],
+        negative_class_predictions=[0.1],
+    )
+
+    model_mock = mocker.Mock()
+    model_mock.id = model_id
+    model_mock.project_id = project_id
+    model_mock.get_roc_curve.return_value = roc_data
+
+    get_model_mock = mocker.patch.object(Model, "get", return_value=model_mock)
+
+    operator = GetRocCurveInsightOperator(
+        task_id="get_roc_curve_insight", project_id=project_id, model_id=model_id
+    )
+
+    result = operator.execute(context={"params": {}})
+
+    get_model_mock.assert_called_with(project_id, model_id)
+    model_mock.get_roc_curve.assert_called_with(source="validation")
+    assert result == {
+        "rocPoints": roc_data.roc_points,
+        "positive_class_predictions": roc_data.positive_class_predictions,
+        "negative_class_predictions": roc_data.negative_class_predictions,
+    }
+
+
+def test_operator_get_roc_curve_insight_no_project_id(mocker):
+    model_id = "test-model-id"
+
+    operator = GetRocCurveInsightOperator(
+        task_id="get_roc_curve_insight", project_id="", model_id=model_id
+    )
+
+    with pytest.raises(AirflowFailException):
+        operator.validate()
+
+
+def test_operator_get_roc_curve_insight_no_model_id(mocker):
+    project_id = "test-project-id"
+
+    operator = GetRocCurveInsightOperator(
+        task_id="get_roc_curve_insight", project_id=project_id, model_id=""
+    )
+
+    with pytest.raises(AirflowFailException):
         operator.validate()
 
 


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
PR adds support for retrieving the roc curve information as a dictionary that can be used by other operators, along with the associated tests.
