### PR TITLE
[MODEL-17042] Add get model parameters operator and tests

### DIFF
--- a/datarobot_provider/operators/model_training.py
+++ b/datarobot_provider/operators/model_training.py
@@ -193,7 +193,7 @@ class AdvancedTuneModelOperator(BaseDatarobotOperator):
         return job.id
 
 
-class GetModelParametersOperator(BaseDatarobotOperator):
+class GetTrainedModelParametersOperator(BaseDatarobotOperator):
     """
     Retrieve the parameters used to train a given model ID.
 

--- a/docs/autodoc_operators/operators_model_training.md
+++ b/docs/autodoc_operators/operators_model_training.md
@@ -16,3 +16,8 @@
 .. autoclass:: datarobot_provider.operators.model_training.AdvancedTuneModelOperator
    :members:
 ```
+
+```{eval-rst}
+.. autoclass:: datarobot_provider.operators.model_training.GetTrainedModelParametersOperator
+   :members:
+```

--- a/tests/unit/operators/test_model_training.py
+++ b/tests/unit/operators/test_model_training.py
@@ -12,7 +12,7 @@ import datarobot as dr
 import pytest
 
 from datarobot_provider.operators.model_training import AdvancedTuneModelOperator
-from datarobot_provider.operators.model_training import GetModelParametersOperator
+from datarobot_provider.operators.model_training import GetTrainedModelParametersOperator
 from datarobot_provider.operators.model_training import TrainModelOperator
 
 
@@ -132,7 +132,7 @@ def test_advanced_tune_model_operator_execute(mock_get_model, parameters, set_pa
     ],
 )
 def test_get_model_parameters_operator_validate(project_id, model_id, expected_exception, match):
-    operator = GetModelParametersOperator(
+    operator = GetTrainedModelParametersOperator(
         task_id="get_model_parameters", project_id=project_id, model_id=model_id
     )
     if expected_exception:
@@ -150,7 +150,7 @@ def test_get_model_parameters_operator_execute(mock_get_model):
     mock_model.get_parameters.return_value = mock_parameters
     mock_get_model.return_value = mock_model
 
-    operator = GetModelParametersOperator(
+    operator = GetTrainedModelParametersOperator(
         task_id="get_model_parameters", project_id="project-id", model_id="model-id"
     )
     result = operator.execute(context={})


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Add a simple operator to retrieve the basic dictionary of parameters for a `project_id` and `model_id`. This can be used for advanced tuning, to retrain a model with similar parameters, or just to log these parameters.

PR adds class, tests and documentation.
