### PR TITLE
[MODEL-17053] Add CancelJobOperator

### DIFF
--- a/datarobot_provider/operators/queue.py
+++ b/datarobot_provider/operators/queue.py
@@ -1,0 +1,60 @@
+# Copyright 2025 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+from collections.abc import Sequence
+from typing import Any
+
+import datarobot as dr
+from airflow.utils.context import Context
+from datarobot import QUEUE_STATUS
+
+from datarobot_provider.operators.base_datarobot_operator import BaseDatarobotOperator
+
+
+class CancelJobOperator(BaseDatarobotOperator):
+    """
+    Cancel a job that is in the queue or currently running.
+
+    Args:
+        project_id (str): DataRobot project ID.
+        job_id (str): Job ID in the project.
+        datarobot_conn_id (str, optional): Connection ID, defaults to `datarobot_default`.
+    """
+
+    # Specify the arguments that are allowed to parse with jinja templating
+    template_fields: Sequence[str] = ["project_id", "job_id"]
+
+    def __init__(
+        self,
+        *,
+        project_id: str,
+        job_id: str,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.project_id = project_id
+        self.job_id = job_id
+
+    def validate(self):
+        if not self.project_id:
+            raise ValueError("project_id is required.")
+        if not self.job_id:
+            raise ValueError("job_id is required.")
+
+    def execute(self, context: Context) -> None:
+        project = dr.Project.get(self.project_id)
+        job = dr.Job.get(self.project_id, self.job_id)
+        if job.status in [
+            QUEUE_STATUS.INPROGRESS,
+            QUEUE_STATUS.QUEUE,
+        ]:
+            project.pause_autopilot()
+            job.cancel()
+            project.unpause_autopilot()
+
+        else:
+            self.log.info("Job already completed or aborted.")

--- a/docs/autodoc_operators/operators_queue.md
+++ b/docs/autodoc_operators/operators_queue.md
@@ -1,6 +1,6 @@
-(predictions-modules)=
+(queue-modules)=
 
-# Predictions Modules
+# Queue Modules
 
 ```{eval-rst}
 .. autoclass:: datarobot_provider.operators.queue.CancelJobOperator

--- a/docs/autodoc_operators/operators_queue.md
+++ b/docs/autodoc_operators/operators_queue.md
@@ -1,0 +1,8 @@
+(predictions-modules)=
+
+# Predictions Modules
+
+```{eval-rst}
+.. autoclass:: datarobot_provider.operators.queue.CancelJobOperator
+   :members:
+```

--- a/tests/unit/operators/test_queue.py
+++ b/tests/unit/operators/test_queue.py
@@ -1,0 +1,62 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from datarobot import QUEUE_STATUS
+
+from datarobot_provider.operators.queue import CancelJobOperator
+
+
+@pytest.mark.parametrize(
+    "project_id, job_id, expected_exception, match",
+    [
+        ("project-id", "job-id", None, None),
+        (None, "job-id", ValueError, "project_id is required."),
+        ("project-id", None, ValueError, "job_id is required."),
+    ],
+)
+def test_cancel_job_operator_validate(project_id, job_id, expected_exception, match):
+    operator = CancelJobOperator(task_id="cancel_job", project_id=project_id, job_id=job_id)
+    if expected_exception:
+        with pytest.raises(expected_exception, match=match):
+            operator.validate()
+    else:
+        operator.validate()
+
+
+@patch("datarobot_provider.operators.queue.dr.Project.get")
+@patch("datarobot_provider.operators.queue.dr.Job.get")
+def test_cancel_job_operator_execute(mock_get_job, mock_get_project):
+    mock_project = MagicMock()
+    mock_job = MagicMock()
+    mock_job.status = QUEUE_STATUS.INPROGRESS
+    mock_get_project.return_value = mock_project
+    mock_get_job.return_value = mock_job
+
+    operator = CancelJobOperator(task_id="cancel_job", project_id="project-id", job_id="job-id")
+    operator.execute(context={})
+
+    mock_get_project.assert_called_once_with("project-id")
+    mock_get_job.assert_called_once_with("project-id", "job-id")
+    mock_project.pause_autopilot.assert_called_once()
+    mock_job.cancel.assert_called_once()
+    mock_project.unpause_autopilot.assert_called_once()
+
+
+@patch("datarobot_provider.operators.queue.dr.Project.get")
+@patch("datarobot_provider.operators.queue.dr.Job.get")
+def test_cancel_job_operator_execute_job_completed(mock_get_job, mock_get_project):
+    mock_project = MagicMock()
+    mock_job = MagicMock()
+    mock_job.status = "COMPLETED"
+    mock_get_project.return_value = mock_project
+    mock_get_job.return_value = mock_job
+
+    operator = CancelJobOperator(task_id="cancel_job", project_id="project-id", job_id="job-id")
+    operator.execute(context={})
+
+    mock_get_project.assert_called_once_with("project-id")
+    mock_get_job.assert_called_once_with("project-id", "job-id")
+    mock_project.pause_autopilot.assert_not_called()
+    mock_job.cancel.assert_not_called()
+    mock_project.unpause_autopilot.assert_not_called()

--- a/tests/unit/operators/test_queue.py
+++ b/tests/unit/operators/test_queue.py
@@ -1,3 +1,10 @@
+# Copyright 2025 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
 from unittest.mock import MagicMock
 from unittest.mock import patch
 


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
This PR adds an operator which cancels a job is the `project_id` and `job_id` are provided. If the job has already completed, errored, or aborted, it will simply log that the job cannot be cancelled.

Tests and documentation added also.
