### PR TITLE
[MODEL-17056] Add operator to get jobs from queue

### DIFF
--- a/datarobot_provider/operators/queue.py
+++ b/datarobot_provider/operators/queue.py
@@ -7,12 +7,52 @@
 # Released under the terms of DataRobot Tool and Utility Agreement.
 from collections.abc import Sequence
 from typing import Any
+from typing import List
+from typing import Optional
 
 import datarobot as dr
 from airflow.utils.context import Context
 from datarobot import QUEUE_STATUS
 
 from datarobot_provider.operators.base_datarobot_operator import BaseDatarobotOperator
+
+
+class GetJobsOperator(BaseDatarobotOperator):
+    """
+    Get a list of jobs that match the requested status.
+
+    Args:
+        project_id (str): DataRobot project ID.
+        job_id (str): Job ID in the project.
+        datarobot_conn_id (str, optional): Connection ID, defaults to `datarobot_default`.
+    """
+
+    # Specify the arguments that are allowed to parse with jinja templating
+    template_fields: Sequence[str] = ["project_id", "job_id"]
+
+    def __init__(
+        self,
+        *,
+        project_id: str,
+        status: Optional[str] = QUEUE_STATUS.INPROGRESS,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.project_id = project_id
+        self.status = status
+
+    def validate(self):
+        if not self.project_id:
+            raise ValueError("project_id is required.")
+        if self.status not in list(QUEUE_STATUS.__dict__.values()):
+            raise ValueError(f"Invalid status: {self.status}, must be a QUEUE_STATUS.")
+
+    def execute(self, context: Context) -> List[str]:
+        project = dr.Project.get(self.project_id)
+        # Actual filtering logic is handled by the DataRobot API
+        project_jobs = project.get_all_jobs(status=self.status)
+
+        return [str(job.id) for job in project_jobs]
 
 
 class CancelJobOperator(BaseDatarobotOperator):

--- a/datarobot_provider/operators/queue.py
+++ b/datarobot_provider/operators/queue.py
@@ -23,7 +23,7 @@ class GetJobsOperator(BaseDatarobotOperator):
 
     Args:
         project_id (str): DataRobot project ID.
-        job_id (str): Job ID in the project.
+        status (str): Status of the job. Default is QUEUE_STATUS.INPROGRESS.
         datarobot_conn_id (str, optional): Connection ID, defaults to `datarobot_default`.
     """
 

--- a/docs/autodoc_operators/operators_queue.md
+++ b/docs/autodoc_operators/operators_queue.md
@@ -3,6 +3,11 @@
 # Queue Modules
 
 ```{eval-rst}
+.. autoclass:: datarobot_provider.operators.queue.GetJobsOperator
+   :members:
+```
+
+```{eval-rst}
 .. autoclass:: datarobot_provider.operators.queue.CancelJobOperator
    :members:
 ```


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Add a new operator to retrieve the jobs of the specified status by their ids. The user determines the status when it is sent to the operator.

This PR also adds:
- Tests
- Docs
