### PR TITLE
[MODEL-17047] Add cross validation operators

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased Changes
+- Add the `CrossValidationMetricsOperator` to compute scoring for all partitions for a model.
+- Add the `ScoreBacktestsModelOperator` to score all backtests for a datetime partitioned model.
 
 
 ## 0.3.0

--- a/docs/autodoc_operators/operators_model_training.md
+++ b/docs/autodoc_operators/operators_model_training.md
@@ -22,12 +22,10 @@
    :members:
 ```
 
-
 ```{eval-rst}
 .. autoclass:: datarobot_provider.operators.model_training.CrossValidateModelOperator
    :members:
 ```
-
 
 ```{eval-rst}
 .. autoclass:: datarobot_provider.operators.model_training.ScoreBacktestsModelOperator

--- a/docs/autodoc_operators/operators_model_training.md
+++ b/docs/autodoc_operators/operators_model_training.md
@@ -21,3 +21,15 @@
 .. autoclass:: datarobot_provider.operators.model_training.GetTrainedModelParametersOperator
    :members:
 ```
+
+
+```{eval-rst}
+.. autoclass:: datarobot_provider.operators.model_training.CrossValidateModelOperator
+   :members:
+```
+
+
+```{eval-rst}
+.. autoclass:: datarobot_provider.operators.model_training.ScoreBacktestsModelOperator
+   :members:
+```


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer code or data.

## Summary
This PR adds a pair of cross validation operators (one for AutoML cross validation and the other for AutoTS backtests). This allows the user to trigger these jobs from the orchestration flows.


## Changes
- Add `CrossValidateModelOperator`
- Add datetime version that inherits `CrossValidateModelOperator` as `ScoreBacktestsModelOperator`
- Add unit tests
- Add documentation


## PR Checklist
- [x] Changelog entry updated (`CHANGES.md`).
- [x] Documentation added or updated (if relevant).
- [x] Tests added or updated (if relevant).
