### PR TITLE
[MODEL-17048] Retrieve the features used to train a model

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased Changes
-
+- Add the `GetFeaturesUsedOperator` to get the features used to train the model.
 
 ## 0.3.0
 - Rename example DAGs to product/GTM desired names

--- a/datarobot_provider/operators/model_insights.py
+++ b/datarobot_provider/operators/model_insights.py
@@ -32,7 +32,7 @@ class GetFeaturesUsedOperator(BaseDatarobotOperator):
         datarobot_conn_id (str, optional): Connection ID, defaults to `datarobot_default`.
 
     Returns:
-        str: Feature Impact job ID.
+        List[str]: The names of the features used in the model.
     """
 
     # Specify the arguments that are allowed to parse with jinja templating
@@ -54,19 +54,16 @@ class GetFeaturesUsedOperator(BaseDatarobotOperator):
 
     def validate(self) -> None:
         if not self.project_id:
-            raise ValueError("project_id is required to retrieve the used features.")
+            raise ValueError("project_id is required.")
 
         if not self.model_id:
-            raise ValueError("model_id is required to retrieve the used features.")
+            raise ValueError("model_id is required.")
 
-    def execute(self, context: Context) -> str:
+    def execute(self, context: Context) -> List[str]:
         model = dr.models.Model.get(self.project_id, self.model_id)
+        features = model.get_features_used()
 
-        job = model.request_feature_impact()
-
-        self.log.info(f"Feature Impact Job submitted, job_id={job.id}")
-
-        return job.id
+        return features
 
 
 class ComputeFeatureImpactOperator(BaseDatarobotOperator):

--- a/datarobot_provider/operators/model_insights.py
+++ b/datarobot_provider/operators/model_insights.py
@@ -24,7 +24,7 @@ from datarobot_provider.operators.base_datarobot_operator import BaseDatarobotOp
 
 class GetFeaturesUsedOperator(BaseDatarobotOperator):
     """
-    Get the features used for the model.
+    Get the features used for training the model.
 
     Args:
         project_id (str): DataRobot project ID.

--- a/datarobot_provider/operators/model_insights.py
+++ b/datarobot_provider/operators/model_insights.py
@@ -22,6 +22,53 @@ from datarobot.models import StatusCheckJob
 from datarobot_provider.operators.base_datarobot_operator import BaseDatarobotOperator
 
 
+class GetFeaturesUsedOperator(BaseDatarobotOperator):
+    """
+    Get the features used for the model.
+
+    Args:
+        project_id (str): DataRobot project ID.
+        model_id (str): DataRobot model ID.
+        datarobot_conn_id (str, optional): Connection ID, defaults to `datarobot_default`.
+
+    Returns:
+        str: Feature Impact job ID.
+    """
+
+    # Specify the arguments that are allowed to parse with jinja templating
+    template_fields: Sequence[str] = [
+        "project_id",
+        "model_id",
+    ]
+
+    def __init__(
+        self,
+        *,
+        project_id: str,
+        model_id: str,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.project_id = project_id
+        self.model_id = model_id
+
+    def validate(self) -> None:
+        if not self.project_id:
+            raise ValueError("project_id is required to retrieve the used features.")
+
+        if not self.model_id:
+            raise ValueError("model_id is required to retrieve the used features.")
+
+    def execute(self, context: Context) -> str:
+        model = dr.models.Model.get(self.project_id, self.model_id)
+
+        job = model.request_feature_impact()
+
+        self.log.info(f"Feature Impact Job submitted, job_id={job.id}")
+
+        return job.id
+
+
 class ComputeFeatureImpactOperator(BaseDatarobotOperator):
     """
     Creates Feature Impact job in DataRobot.

--- a/docs/autodoc_operators/operators_insights.md
+++ b/docs/autodoc_operators/operators_insights.md
@@ -3,6 +3,11 @@
 # Insights Modules
 
 ```{eval-rst}
+.. autoclass:: datarobot_provider.operators.model_insights.GetFeaturesUsedOperator
+   :members:
+```
+
+```{eval-rst}
 .. autoclass:: datarobot_provider.operators.model_insights.ComputeFeatureImpactOperator
    :members:
 ```


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer code or data.

## Summary
Because each project can have many associated featurelists, it is important to know which features a model requires in order to run. This helps ensure that the necessary features are provided when generating predictions. This PR adds an operator to connect to this pySDK logic.

## Changes
- Add `GetFeaturesUsedOperator` class
- Add unit tests for the class
- Update docs and changelog


## PR Checklist
- [x] Changelog entry updated (`CHANGES.md`).
- [x] Documentation added or updated (if relevant).
- [x] Tests added or updated (if relevant).
