### PR TITLE
[MODEL-18335] Add GitHub release creation to mainline release pipeline

### DIFF
--- a/.harness/release_early_access_pypi.yaml
+++ b/.harness/release_early_access_pypi.yaml
@@ -52,11 +52,14 @@ pipeline:
 
                       # Create a standard release
                       gh release create $RELEASE_VERSION --latest=true --title "$RELEASE_VERSION" --generate-notes --verify-tag
+                    envVariables:
+                      GH_TOKEN: <+secrets.getValue("account.githubpatsvcharnessgit2")>
+                      RELEASE_VERSION: <+stage.variables.RELEASE_VERSION>
         variables:
           - name: RELEASE_VERSION
             type: String
             description: |-
-              Please provide the version to use for the release. This version should include the `v` prefix.
+              Please provide the tag to use for the release. This version should include the `v` prefix. This tag should be created from a commit prior to a release. It should be the same tag used to execute this pipeline.
 
               Example:
               v1.0.0

--- a/.harness/release_early_access_pypi.yaml
+++ b/.harness/release_early_access_pypi.yaml
@@ -56,7 +56,7 @@ pipeline:
                       GH_TOKEN: <+secrets.getValue("account.githubpatsvcharnessgit2")>
                       RELEASE_VERSION: <+stage.variables.RELEASE_VERSION>
         variables:
-          - name: RELEASE_VERSION
+          - name: RELEASE_VERSION_TAG
             type: String
             description: |-
               Please provide the tag to use for the release. This version should include the `v` prefix. This tag should be created from a commit prior to a release. It should be the same tag used to execute this pipeline.

--- a/.harness/release_early_access_pypi.yaml
+++ b/.harness/release_early_access_pypi.yaml
@@ -51,10 +51,10 @@ pipeline:
                       cd airflow-provider-datarobot
 
                       # Create a standard release
-                      gh release create $RELEASE_VERSION --latest=true --title "$RELEASE_VERSION" --generate-notes --verify-tag
+                      gh release create $RELEASE_VERSION_TAG --latest=true --title "$RELEASE_VERSION_TAG" --generate-notes --verify-tag
                     envVariables:
                       GH_TOKEN: <+secrets.getValue("account.githubpatsvcharnessgit2")>
-                      RELEASE_VERSION: <+stage.variables.RELEASE_VERSION>
+                      RELEASE_VERSION_TAG: <+stage.variables.RELEASE_VERSION_TAG>
         variables:
           - name: RELEASE_VERSION_TAG
             type: String

--- a/.harness/release_early_access_pypi.yaml
+++ b/.harness/release_early_access_pypi.yaml
@@ -17,6 +17,49 @@ pipeline:
               templateRef: unit_tests
               versionLabel: "1"
     - stage:
+        name: Release to Github
+        identifier: Release_to_Github
+        description: ""
+        type: CI
+        spec:
+          cloneCodebase: true
+          caching:
+            enabled: true
+          buildIntelligence:
+            enabled: true
+          platform:
+            os: Linux
+            arch: Amd64
+          runtime:
+            type: Cloud
+            spec: {}
+          execution:
+            steps:
+              - step:
+                  type: Run
+                  name: Release to Github
+                  identifier: Release_to_Github
+                  spec:
+                    shell: Sh
+                    command: |-
+                      set -ex pipefail
+                      curl -sS https://webi.sh/gh | sh
+
+                      git clone https://github.com/datarobot/airflow-provider-datarobot.git
+                      cd airflow-provider-datarobot
+
+                      gh release create $RELEASE_VERSION --latest=true --title "$RELEASE_VERSION" --generate-notes
+        variables:
+          - name: RELEASE_VERSION
+            type: String
+            description: |-
+              Please provide the version to use for the release. This version should include the `v` prefix.
+
+              Example:
+              v1.0.0
+            required: true
+            value: <+input>
+    - stage:
         name: Publish to Test Pypi
         identifier: Publish_to_Test_Pypi
         template:

--- a/.harness/release_early_access_pypi.yaml
+++ b/.harness/release_early_access_pypi.yaml
@@ -43,11 +43,14 @@ pipeline:
                     shell: Sh
                     command: |-
                       set -ex pipefail
+                      # Install github-cli
                       curl -sS https://webi.sh/gh | sh
 
+                      # Clone the repo
                       git clone https://github.com/datarobot/airflow-provider-datarobot.git
                       cd airflow-provider-datarobot
 
+                      # Create a standard release
                       gh release create $RELEASE_VERSION --latest=true --title "$RELEASE_VERSION" --generate-notes
         variables:
           - name: RELEASE_VERSION

--- a/.harness/release_early_access_pypi.yaml
+++ b/.harness/release_early_access_pypi.yaml
@@ -51,7 +51,7 @@ pipeline:
                       cd airflow-provider-datarobot
 
                       # Create a standard release
-                      gh release create $RELEASE_VERSION --latest=true --title "$RELEASE_VERSION" --generate-notes
+                      gh release create $RELEASE_VERSION --latest=true --title "$RELEASE_VERSION" --generate-notes --verify-tag
         variables:
           - name: RELEASE_VERSION
             type: String


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer code or data.

## Summary
Execute a custom release script using environment variables and service accounts to publish the mainline release formally to github before doing an official mainline release.

## Changes
- Add `Release to Github` step
- Add environment variables to mainline release pipeline


## PR Checklist
- <s>[ ] Changelog entry updated (`CHANGES.md`).</s>
- <s>[ ] Documentation added or updated (if relevant).</s>
- <s>[ ] Tests added or updated (if relevant).</s>
