### PR TITLE
[DM-17544] Support dynamic secondary dataset in feature discovery DAG

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,13 @@
 
 ## Unreleased Changes
 
+
+## v1.0.1
+- Don't allow `apache-airflow>=3.0` until the package is compatible.
+- Update `feature_discovery_retraining_and_scoring` example DAG to work with a dynamic dataset.
+- Update `CreateDatasetFromDataStoreOperator` to add a new dataset into use case.
+
+
 ## v1.0.0
 - Add `SubmitActualsOperator` operator for users to upload actuals
 - Documentation improvements and corrections

--- a/datarobot_provider/__init__.py
+++ b/datarobot_provider/__init__.py
@@ -34,7 +34,7 @@ def get_provider_info() -> ProviderInfoType:
         "package-name": "airflow-provider-datarobot",
         "name": "DataRobot Airflow Provider",
         "description": "DataRobot Airflow provider.",
-        "versions": ["1.0.0"],
+        "versions": ["1.0.1"],
         "connection-types": [
             {
                 "hook-class-name": "datarobot_provider.hooks.datarobot.DataRobotHook",

--- a/datarobot_provider/_version.py
+++ b/datarobot_provider/_version.py
@@ -9,4 +9,4 @@
 # affiliates.
 #
 # Released under the terms of DataRobot Tool and Utility Agreement.
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/datarobot_provider/example_dags/feature_discovery_retraining_and_scoring.py
+++ b/datarobot_provider/example_dags/feature_discovery_retraining_and_scoring.py
@@ -11,6 +11,8 @@ from datarobot import AUTOPILOT_MODE
 
 from datarobot_provider.operators.autopilot import StartAutopilotOperator
 from datarobot_provider.operators.data_prep import CreateFeatureDiscoveryRecipeOperator
+from datarobot_provider.operators.data_registry import CreateDatasetFromDataStoreOperator
+from datarobot_provider.operators.data_registry import GetDataStoreOperator
 from datarobot_provider.operators.data_registry import UploadDatasetOperator
 from datarobot_provider.operators.datarobot import CreateProjectOperator
 from datarobot_provider.operators.datarobot import GetOrCreateUseCaseOperator
@@ -30,6 +32,11 @@ from datarobot_provider.sensors.datarobot import AutopilotCompleteSensor
         },
         "advanced_options": {"feature_discovery_supervised_feature_reduction": True},
         "deployment_id": "",
+        "do_snapshot": False,
+        "persist_data_after_ingestion": False,
+        "data_connection": "Demo Connection",
+        "table_schema": "TRIAL_READONLY",
+        "table_name": "LENDING_CLUB_TRANSACTIONS",
     },
 )
 def datarobot_feature_discovery_retraining_and_scoring(
@@ -39,28 +46,22 @@ def datarobot_feature_discovery_retraining_and_scoring(
     profile_dataset_path=(
         "https://s3.us-east-1.amazonaws.com/datarobot_public_datasets/LendingClub/profile.csv"
     ),
-    transactions_dataset_path=(
-        "https://s3.us-east-1.amazonaws.com/datarobot_public_datasets/LendingClub/transactions.csv"
-    ),
 ):
     # Create a Use Case to keep all subsequent assets. Default name is "Airflow"
-    create_use_case = GetOrCreateUseCaseOperator(task_id="create_use_case")
+    create_use_case = GetOrCreateUseCaseOperator(task_id="create_use_case", set_default=True)
 
-    # Upload all the datasets into Data Registry.
+    # Upload primary dataset and one of secondary datasets into Data Registry.
     upload_primary_dataset = UploadDatasetOperator(
-        task_id="upload_primary_dataset",
-        file_path=primary_dataset_path,
-        use_case_id=create_use_case.output,
+        task_id="upload_primary_dataset", file_path=primary_dataset_path
     )
     upload_profile_dataset = UploadDatasetOperator(
-        task_id="upload_profile_dataset",
-        file_path=profile_dataset_path,
-        use_case_id=create_use_case.output,
+        task_id="upload_profile_dataset", file_path=profile_dataset_path
     )
-    upload_transactions_dataset = UploadDatasetOperator(
-        task_id="upload_transactions_dataset",
-        file_path=transactions_dataset_path,
-        use_case_id=create_use_case.output,
+
+    # Create dynamic secondary dataset.
+    get_data_store = GetDataStoreOperator(task_id="get_data_store")
+    create_transactions_dataset = CreateDatasetFromDataStoreOperator(
+        task_id="create_transactions_dataset", data_store_id=get_data_store.output
     )
 
     # Define the secondary datasets for Feature Discovery
@@ -71,7 +72,7 @@ def datarobot_feature_discovery_retraining_and_scoring(
 
     transaction_dataset_definition = {
         "identifier": "transactions",
-        "catalogId": upload_transactions_dataset.output,
+        "catalogId": create_transactions_dataset.output,
     }
 
     # Define the relationships between the datasets.
@@ -102,7 +103,6 @@ def datarobot_feature_discovery_retraining_and_scoring(
     # Create a Feature Discovery recipe with all the above information.
     create_feature_discovery_recipe = CreateFeatureDiscoveryRecipeOperator(
         dataset_id=upload_primary_dataset.output,
-        use_case_id=create_use_case.output,
         dataset_definitions=dataset_definitions,
         relationships=relationships,
         feature_discovery_settings=feature_discovery_settings,
@@ -111,9 +111,7 @@ def datarobot_feature_discovery_retraining_and_scoring(
 
     # Create and launch a project from the recipe.
     create_project = CreateProjectOperator(
-        recipe_id=create_feature_discovery_recipe.output,
-        use_case_id=create_use_case.output,
-        task_id="create_project",
+        recipe_id=create_feature_discovery_recipe.output, task_id="create_project"
     )
 
     train_models = StartAutopilotOperator(task_id="train_models", project_id=create_project.output)
@@ -142,12 +140,12 @@ def datarobot_feature_discovery_retraining_and_scoring(
     replace_model = ReplaceModelOperator(
         task_id="replace_model",
         new_registered_model_version_id=register_model.output,
-        deployment_id=str("{{ params.deployment_id }}"),
+        deployment_id="{{ params.deployment_id }}",
     )
 
     (
         create_use_case
-        >> [upload_primary_dataset, upload_profile_dataset, upload_transactions_dataset]
+        >> [upload_primary_dataset, upload_profile_dataset, create_transactions_dataset]
         >> create_feature_discovery_recipe
         >> create_project
         >> train_models

--- a/datarobot_provider/example_dags/feature_discovery_retraining_and_scoring.py
+++ b/datarobot_provider/example_dags/feature_discovery_retraining_and_scoring.py
@@ -37,6 +37,7 @@ from datarobot_provider.sensors.datarobot import AutopilotCompleteSensor
         "data_connection": "Demo Connection",
         "table_schema": "TRIAL_READONLY",
         "table_name": "LENDING_CLUB_TRANSACTIONS",
+        "dataset_name": "transactions",
     },
 )
 def datarobot_feature_discovery_retraining_and_scoring(
@@ -73,6 +74,7 @@ def datarobot_feature_discovery_retraining_and_scoring(
     transaction_dataset_definition = {
         "identifier": "transactions",
         "catalogId": create_transactions_dataset.output,
+        "snapshotPolicy": "dynamic",
     }
 
     # Define the relationships between the datasets.
@@ -145,7 +147,11 @@ def datarobot_feature_discovery_retraining_and_scoring(
 
     (
         create_use_case
-        >> [upload_primary_dataset, upload_profile_dataset, create_transactions_dataset]
+        >> [
+            upload_primary_dataset,
+            upload_profile_dataset,
+            get_data_store >> create_transactions_dataset,
+        ]
         >> create_feature_discovery_recipe
         >> create_project
         >> train_models

--- a/datarobot_provider/example_dags/feature_discovery_retraining_and_scoring.py
+++ b/datarobot_provider/example_dags/feature_discovery_retraining_and_scoring.py
@@ -51,7 +51,7 @@ def datarobot_feature_discovery_retraining_and_scoring(
     # Create a Use Case to keep all subsequent assets. Default name is "Airflow"
     create_use_case = GetOrCreateUseCaseOperator(task_id="create_use_case", set_default=True)
 
-    # Upload primary dataset and one of secondary datasets into Data Registry.
+    # Upload primary dataset and a static secondary datasets into Data Registry.
     upload_primary_dataset = UploadDatasetOperator(
         task_id="upload_primary_dataset", file_path=primary_dataset_path
     )
@@ -59,7 +59,7 @@ def datarobot_feature_discovery_retraining_and_scoring(
         task_id="upload_profile_dataset", file_path=profile_dataset_path
     )
 
-    # Create dynamic secondary dataset.
+    # Create a dynamic secondary dataset.
     get_data_store = GetDataStoreOperator(task_id="get_data_store")
     create_transactions_dataset = CreateDatasetFromDataStoreOperator(
         task_id="create_transactions_dataset", data_store_id=get_data_store.output

--- a/datarobot_provider/operators/base_datarobot_operator.py
+++ b/datarobot_provider/operators/base_datarobot_operator.py
@@ -6,6 +6,7 @@
 #
 # Released under the terms of DataRobot Tool and Utility Agreement.
 
+import logging
 from typing import Any
 from typing import Optional
 from typing import Union
@@ -18,6 +19,8 @@ from airflow.utils.context import Context
 from datarobot_provider.constants import DATAROBOT_CONN_ID
 from datarobot_provider.constants import XCOM_DEFAULT_USE_CASE_ID
 from datarobot_provider.hooks.datarobot import DataRobotHook
+
+logger = logging.getLogger(__name__)
 
 
 class BaseDatarobotOperator(BaseOperator):
@@ -58,7 +61,7 @@ class BaseUseCaseEntityOperator(BaseDatarobotOperator):
         super().__init_subclass__(**kwargs)
         if "use_case_id" not in cls.template_fields:
             cls.template_fields = (*cls.template_fields, "use_case_id")
-            cls.logger().info(
+            logger.info(
                 "use_case_id is implicitly added into %s template_fields list.", cls.__name__
             )
 

--- a/datarobot_provider/operators/data_registry.py
+++ b/datarobot_provider/operators/data_registry.py
@@ -194,7 +194,7 @@ class UpdateDatasetFromFileOperator(BaseDatarobotOperator):
         return ai_catalog_dataset.version_id
 
 
-class CreateDatasetFromDataStoreOperator(BaseDatarobotOperator):
+class CreateDatasetFromDataStoreOperator(BaseUseCaseEntityOperator):
     """
     Loading dataset from JDBC Connection to DataRobot AI Catalog and return Dataset ID.
 
@@ -259,6 +259,7 @@ class CreateDatasetFromDataStoreOperator(BaseDatarobotOperator):
             max_wait=DATAROBOT_MAX_WAIT_SEC,
         )
         self.log.info(f"Dataset created: dataset_id={ai_catalog_dataset.id}")
+        self.add_into_use_case(ai_catalog_dataset, context=context)
         return ai_catalog_dataset.id
 
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ common_setup_kwargs = dict(
     long_description=None,
     long_description_content_type="text/markdown",
     classifiers=None,
-    install_requires=["apache-airflow>=2.6.0", "datarobot>=3.7.0"],
+    install_requires=["apache-airflow>=2.6.0,<3.0", "datarobot>=3.7.0"],
     entry_points={
         "apache_airflow_provider": [
             "provider_info = datarobot_provider.__init__:get_provider_info",


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer code or data.

## Changes

- Don't allow `apache-airflow>=3.0` until the package is compatible.
- Update `feature_discovery_retraining_and_scoring` example DAG to work with a dynamic dataset.
- Update `CreateDatasetFromDataStoreOperator` to add a new dataset into use case.



## PR Checklist
- [ ] Changelog entry updated (`CHANGES.md`).
- [ ] Documentation added or updated (if relevant).
- [ ] Tests added or updated (if relevant).
