### PR TITLE
[-] Set ceiling for apache-airflow to avoid breaking changes

### DIFF
--- a/setup_early_access.py
+++ b/setup_early_access.py
@@ -74,7 +74,7 @@ common_setup_kwargs.update(
     packages=packages,
     long_description=description,
     classifiers=classifiers,
-    install_requires=["apache-airflow>=2.6.0", "datarobot-early-access"],
+    install_requires=["apache-airflow>=2.6.0,<3.0", "datarobot-early-access"],
 )
 
 setup(**common_setup_kwargs)


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer code or data.

## Summary

Follow up to: https://github.com/datarobot/airflow-provider-datarobot/pull/234

Ensure we have the same ceiling set for early-access version.

## Notes

- early-access version auto-release on Tuesdays
- early-access version is what is currently being used by the MLPipelines feature in MTS

## Changes

Don't allow apache-airflow>=3.0 until the package is compatible.

## PR Checklist
- [ ] Changelog entry updated (`CHANGES.md`).
- [ ] Documentation added or updated (if relevant).
- [ ] Tests added or updated (if relevant).
