### PR TITLE
[CFX-2798] Account for renaming of method in experimental DR Python Client

### DIFF
--- a/datarobot_provider/_experimental/operators/notebook.py
+++ b/datarobot_provider/_experimental/operators/notebook.py
@@ -110,11 +110,19 @@ class NotebookRunOperator(BaseDatarobotOperator):
             raise AirflowException("Notebook should have use_case_id")
 
         # Run the notebook as a manual run of type "pipeline"
-        manual_run = notebook.run(
-            notebook_path=self.notebook_path,
-            parameters=self.parameters,
-            manual_run_type=ManualRunType.PIPELINE,
-        )
+        if hasattr(notebook, "run_as_job"):
+            manual_run = notebook.run_as_job(
+                notebook_path=self.notebook_path,
+                parameters=self.parameters,
+                manual_run_type=ManualRunType.PIPELINE,
+            )
+        else:
+            # TODO: [CFX-2798] Remove this once both versions of early-access packages are in sync
+            manual_run = notebook.run(
+                notebook_path=self.notebook_path,
+                parameters=self.parameters,
+                manual_run_type=ManualRunType.PIPELINE,
+            )
         self.log.info(f"Notebook triggered. Manual run ID: {manual_run.id}")
 
         return manual_run.id


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer code or data.

## Summary

We're changing the name of the `run()` method to be more verbose in the experimental client (before we move Notebooks APIs to GA)

PR here:
https://github.com/datarobot/public_api_client/pull/3658

## Changes

- Account for rename of method

## PR Checklist
- [ ] Changelog entry updated (`CHANGES.md`).
- [ ] Documentation added or updated (if relevant).
- [ ] Tests added or updated (if relevant).
