### PR TITLE
[CFX-2801] Update NBX imports in anticipation of GA availability

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased Changes
 
+- As DR Notebooks APIs become GA the DR Python Client will have the Notebooks related classes moved out of the respective '\_experimental' directory. The Notebooks operator and sensor have been updated to work with both import locations for now.
+
 ## v1.0.1
 
 

--- a/datarobot_provider/_experimental/operators/notebook.py
+++ b/datarobot_provider/_experimental/operators/notebook.py
@@ -14,9 +14,15 @@ from typing import Union
 
 from airflow.exceptions import AirflowException
 from airflow.utils.context import Context
-from datarobot._experimental.models.notebooks import Notebook
-from datarobot._experimental.models.notebooks.enums import ManualRunType
-from datarobot._experimental.models.notebooks.session import StartSessionParameters
+
+try:
+    from datarobot.models.notebooks import Notebook
+    from datarobot.models.notebooks.enums import ManualRunType
+    from datarobot.models.notebooks.session import StartSessionParameters
+except ImportError:
+    from datarobot._experimental.models.notebooks import Notebook
+    from datarobot._experimental.models.notebooks.enums import ManualRunType
+    from datarobot._experimental.models.notebooks.session import StartSessionParameters
 
 from datarobot_provider.operators.base_datarobot_operator import BaseDatarobotOperator
 

--- a/datarobot_provider/_experimental/sensors/notebook.py
+++ b/datarobot_provider/_experimental/sensors/notebook.py
@@ -10,9 +10,15 @@ from typing import Any
 from airflow.exceptions import AirflowException
 from airflow.sensors.base import BaseSensorOperator
 from airflow.utils.context import Context
-from datarobot._experimental.models.notebooks.enums import ScheduledRunStatus
-from datarobot._experimental.models.notebooks.notebook import Notebook
-from datarobot._experimental.models.notebooks.scheduled_job import NotebookScheduledJob
+
+try:
+    from datarobot.models.notebooks.enums import ScheduledRunStatus
+    from datarobot.models.notebooks.notebook import Notebook
+    from datarobot.models.notebooks.scheduled_job import NotebookScheduledJob
+except ImportError:
+    from datarobot._experimental.models.notebooks.enums import ScheduledRunStatus
+    from datarobot._experimental.models.notebooks.notebook import Notebook
+    from datarobot._experimental.models.notebooks.scheduled_job import NotebookScheduledJob
 
 from datarobot_provider.constants import DATAROBOT_CONN_ID
 from datarobot_provider.hooks.datarobot import DataRobotHook

--- a/datarobot_provider/operators/data_prep.py
+++ b/datarobot_provider/operators/data_prep.py
@@ -131,7 +131,7 @@ class CreateWranglingRecipeOperator(BaseUseCaseEntityOperator):
 
             self.log.info("Working with data_store_id=%s", self.data_store_id)
             data_store = DataStore.get(self.data_store_id)
-            if not (data_store.type and data_store.type in iter(DataWranglingDataSourceTypes)):
+            if not (data_store.type and data_store.type in list(DataWranglingDataSourceTypes)):
                 raise AirflowException(f"Unexpected data store type: {data_store.type}")
 
             data_source_canonical_name = self._generate_data_source_canonical_name()


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer code or data.

## Summary

Notebooks APIs are getting promoted to GA and as they do the next release of the python client (non early-access) will include these classes in a new location.

## Changes

- Update imports to check new, GA location first
- Update Makefile to make nicer to work with
- Make update to data-prep file to get newest (`1.16.0`) mypy happy

## Screenshots

With latest mypy of `1.16.0` there was an error ([seen here](https://app.harness.io/ng/account/oP3BKzKwSDe_4hCFYw_UWA/module/ci/orgs/AGENTS/projects/airflowproviderdatarobot/pipelines/cichecks/executions/N4jmJqfzSHCWVSbLEbznIg/pipeline?stage=TpTaAcVvTIiExFh5Eu0h3Q)):

<img width="613" alt="Screenshot 2025-06-02 at 11 10 16 AM" src="https://github.com/user-attachments/assets/7efeb091-78dd-442d-abc6-226bd2eb85d5" />


<hr>

Now `make help` renders this:

<img width="695" alt="Screenshot 2025-06-02 at 10 00 03 AM" src="https://github.com/user-attachments/assets/170db898-826a-48c9-ae53-2f2e9b85d57a" />


## PR Checklist
- [ ] Changelog entry updated (`CHANGES.md`).
- [ ] Documentation added or updated (if relevant).
- [ ] Tests added or updated (if relevant).
