### PR TITLE
[CFX-3228] Notebooks classes were not added to the docs when recently promoted to GA

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased Changes
 
+- Add DR Notebooks operator and sensor to the documentation.
+
 ## v1.0.2
 
 - DR Notebooks APIs have become GA in the DR Python Client. The Notebooks related classes have been moved out of the '\_experimental' directory.

--- a/docs/autodoc_operators/operators_notebook.md
+++ b/docs/autodoc_operators/operators_notebook.md
@@ -1,0 +1,8 @@
+(notebook-modules)=
+
+# Notebook Modules
+
+```{eval-rst}
+.. autoclass:: datarobot_provider.operators.notebook.NotebookRunOperator
+   :members:
+```

--- a/docs/autodoc_sensors/sensors_notebook.md
+++ b/docs/autodoc_sensors/sensors_notebook.md
@@ -1,0 +1,8 @@
+(notebook-sensors)=
+
+# Notebook Sensors
+
+```{eval-rst}
+.. autoclass:: datarobot_provider.sensors.notebook.NotebookRunCompleteSensor
+   :members:
+```


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer code or data.

## Summary

Notebooks classes were not added to the docs when recently promoted to GA

This handles that.

## Changes

<img width="1128" height="1041" alt="Screenshot 2025-07-16 at 3 04 13 PM" src="https://github.com/user-attachments/assets/aee12333-1629-4273-aba0-de15680e672d" />

<hr>

<img width="1152" height="870" alt="Screenshot 2025-07-16 at 3 04 29 PM" src="https://github.com/user-attachments/assets/3cdf8b7d-7397-4c77-aab4-a1611cbe37c9" />


## PR Checklist
- [ ] Changelog entry updated (`CHANGES.md`).
- [ ] Documentation added or updated (if relevant).
- [ ] Tests added or updated (if relevant).
